### PR TITLE
fix portal products path

### DIFF
--- a/swaggerhub-portal/client.ts
+++ b/swaggerhub-portal/client.ts
@@ -132,7 +132,7 @@ export class SwaggerHubClient implements Client {
   }
 
   async getSwaggerHubProduct(productId: string): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${productId}`, {
+    const response = await fetch(`https://api.portal.swaggerhub.com/v1/products/${productId}`, {
       method: "GET",
       headers: this.headers,
     });
@@ -141,14 +141,14 @@ export class SwaggerHubClient implements Client {
   }
 
   async deleteSwaggerHubProduct(productId: string): Promise<any> {
-    await fetch(`https://api.portal.swaggerhub.com/v1/portals/${productId}`, {
+    await fetch(`https://api.portal.swaggerhub.com/v1/products/${productId}`, {
       method: "DELETE",
       headers: this.headers,
     });
   }
 
   async updateSwaggerHubProduct(productId: string, body: updateProductArgs): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${productId}`, {
+    const response = await fetch(`https://api.portal.swaggerhub.com/v1/products/${productId}`, {
       method: "PATCH",
       headers: this.headers,
       body: JSON.stringify(body),


### PR DESCRIPTION
This pull request updates the `SwaggerHubClient` class in `swaggerhub-portal/client.ts` to align API endpoint URLs with the correct resource path. The changes ensure consistency and correctness in how the client interacts with the SwaggerHub API.

Endpoint corrections:

* Updated the `getSwaggerHubProduct` method to use the `/products/` endpoint instead of `/portals/`.
* Updated the `deleteSwaggerHubProduct` method to use the `/products/` endpoint instead of `/portals/`.
* Updated the `updateSwaggerHubProduct` method to use the `/products/` endpoint instead of `/portals/`.## Goal

