### PR TITLE
Fix bin name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@modelcontextprotocol/sdk": "1.12.1"
       },
       "bin": {
-        "mcp-server-smartbear": "dist/index.js"
+        "mcp": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "mcp-server-smartbear": "dist/index.js"
+    "mcp": "dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Goal

Fixes the bin name, to ensure that `npx @smartbear/mcp` works correctly

## Design
## Changeset

Change bin name to `mcp`

## Testing

No functional to code, but tested locally using:
```
npm link
npx @smartbear/mcp
```