### PR TITLE
Add caching for org and projects

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,7 @@ async function main() {
 
   if (insightHubToken) {
     const insightHubClient = new InsightHubClient(insightHubToken);
+    await insightHubClient.initialize();
     insightHubClient.registerTools(server);
     insightHubClient.registerResources(server);
   }

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -4,6 +4,13 @@ import { Client } from "../common/types.js";
 import { CurrentUserAPI, ErrorAPI, Configuration } from "./client/index.js";
 import { z } from "zod";
 import Bugsnag from "../common/bugsnag.js";
+import NodeCache from "node-cache";
+import { Organization, Project } from "./client/api/CurrentUser.js";
+
+const cacheKeys = {
+  ORG: "insight_hub_org",
+  PROJECTS: "insight_hub_projects",
+}
 
 // Type definitions for tool arguments
 export interface ProjectArgs {
@@ -21,6 +28,7 @@ export interface ErrorArgs extends ProjectArgs {
 export class InsightHubClient implements Client {
   private currentUserApi: CurrentUserAPI;
   private errorsApi: ErrorAPI;
+  private cache: NodeCache;
 
   constructor(token: string) {
     const config = new Configuration({
@@ -33,18 +41,50 @@ export class InsightHubClient implements Client {
     });
     this.currentUserApi = new CurrentUserAPI(config);
     this.errorsApi = new ErrorAPI(config);
+    this.cache = new NodeCache();
+  }
+
+  async initialize(): Promise<void> {
+    const orgs = await this.listOrgs();
+    if (!orgs || orgs.length === 0) {
+      throw new Error("No organizations found for the current user.");
+    }
+    // We should only have one org
+    this.cache.set(cacheKeys.ORG, orgs[0]);
+    const projects = await this.listProjects(orgs[0].id);
+    this.cache.set(cacheKeys.PROJECTS, projects);
   }
 
   async listOrgs(): Promise<any> {
     return this.currentUserApi.listUserOrganizations();
   }
 
-  async listProjects(orgId: string, options?: any ): Promise<any> {
+  async listProjects(orgId: string, options?: any): Promise<any> {
     options = {
       ...options,
       paginate: true
     };
     return this.currentUserApi.getOrganizationProjects(orgId, options);
+  }
+
+  // This method retrieves all orojects for the organization stored in the cache.
+  // If no projects are found in the cache, it fetches them from the API and
+  // stores them in the cache for future use.
+  // It throws an error if no organizations are found in the cache.
+  async getProjects(): Promise<Project[]> {
+    let projects = this.cache.get<Project[]>(cacheKeys.PROJECTS);
+    if (!projects) {
+      const org = this.cache.get<Organization>(cacheKeys.ORG);
+      if (!org) {
+        throw new Error("No organization found in cache.");
+      }
+      projects = await this.listProjects(org.id);
+      this.cache.set(cacheKeys.PROJECTS, projects);
+    }
+    if (!projects) {
+      throw new Error("No projects found.");
+    }
+    return projects;
   }
 
   async getErrorDetails(projectId: string, errorId: string): Promise<any> {
@@ -65,130 +105,147 @@ export class InsightHubClient implements Client {
     return eventDetails.find(event => !!event);
   }
 
-registerTools(server: McpServer): void {
-  server.tool(
-    "list_insight_hub_projects",
-    "List all projects in an organization",
-    { orgId: z.string().describe("ID of the organization to list projects for") },
-    async (args, _extra) => {
-      try {
-        if (!args.orgId) throw new Error("orgId argument is required");
-        const response = await this.listProjects(args.orgId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_error",
-    "Get error details from a project",
-    {
-      projectId: z.string().describe("ID of the project"),
-      errorId: z.string().describe("ID of the error to fetch"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.projectId || !args.errorId) throw new Error("Both projectId and errorId arguments are required");
-        const response = await this.getErrorDetails(args.projectId, args.errorId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_error_latest_event",
-    "Get the latest event for an error",
-    {
-      errorId: z.string().describe("ID of the error to get the latest event for"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.errorId) throw new Error("errorId argument is required");
-        const response = await this.getLatestErrorEvent(args.errorId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_event_details",
-    "Get details of a specific event on Insight Hub",
-    {
-      link: z.string().describe("Link to the event details"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.link) throw new Error("link argument is required");
-        const url = new URL(args.link);
-        const eventId = url.searchParams.get("event_id");
-        const projectSlug = url.pathname.split('/')[2];
-        if (!projectSlug || !eventId) throw new Error("Both projectSlug and eventId must be present in the link");
-
-        // get the project id from list of projects
-        // limitation: this assumes a single page of results, so will not work for orgs with >100 projects
-        const orgId = await this.currentUserApi.listUserOrganizations().then(orgs => orgs[0].id);
-        const projectId = await this.listProjects(orgId).then(projects => projects.find((p: any) => p.slug === projectSlug)?.id);
-
-        const response = await this.getProjectEvent(projectId, eventId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  )
-}
-
-registerResources(server: McpServer): void {
-  server.resource(
-    "insight_hub_orgs",
-    "insighthub://orgs",
-    { description: "List all organizations in Insight Hub", mimeType: "application/json" },
-    async (uri) => {
-      try {
-        return {
-          contents: [{
-            uri: uri.href,
-            text: JSON.stringify(await this.listOrgs())
-          }]
+  registerTools(server: McpServer): void {
+    server.tool(
+      "list_insight_hub_projects",
+      "List all projects in an organization",
+      {
+        page_size: z.number().optional().describe("Number of projects to return per page"),
+        page: z.number().optional().describe("Page number to return"),
+      },
+      async (args, _extra) => {
+        try {
+          let projects = await this.getProjects();
+          if (!projects || projects.length === 0) {
+            return {
+              content: [{ type: "text", text: "No projects found." }],
+            };
+          }
+          if (args.page_size || args.page) {
+            const pageSize = args.page_size || 10;
+            const page = args.page || 1;
+            projects = projects.slice((page - 1) * pageSize, page * pageSize);
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify(projects) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
         }
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
       }
-    }
-  );
-
-  server.resource(
-    "insight_hub_event",
-    new ResourceTemplate("insighthub://event/{id}", { list: undefined }),
-    async (uri, { id }) => {
-      try {
-        return {
-          contents: [{
-            uri: uri.href,
-            text: JSON.stringify(await this.findEventById(id as string))
-          }]
+    );
+    server.tool(
+      "get_insight_hub_error",
+      "Get error details from a project",
+      {
+        projectId: z.string().describe("ID of the project"),
+        errorId: z.string().describe("ID of the error to fetch"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.projectId || !args.errorId) throw new Error("Both projectId and errorId arguments are required");
+          const response = await this.getErrorDetails(args.projectId, args.errorId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
         }
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
       }
-    }
-  )
-}
+    );
+    server.tool(
+      "get_insight_hub_error_latest_event",
+      "Get the latest event for an error",
+      {
+        errorId: z.string().describe("ID of the error to get the latest event for"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.errorId) throw new Error("errorId argument is required");
+          const response = await this.getLatestErrorEvent(args.errorId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    );
+    server.tool(
+      "get_insight_hub_event_details",
+      "Get details of a specific event on Insight Hub",
+      {
+        link: z.string().describe("Link to the event details"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.link) throw new Error("link argument is required");
+          const url = new URL(args.link);
+          const eventId = url.searchParams.get("event_id");
+          const projectSlug = url.pathname.split('/')[2];
+          if (!projectSlug || !eventId) throw new Error("Both projectSlug and eventId must be present in the link");
+
+          // get the project id from list of projects
+          const projects = this.cache.get<Project[]>("insight_hub_projects");
+          if (!projects) {
+            throw new Error("No projects found in cache.");
+          }
+          const projectId = projects.find((p: any) => p.slug === projectSlug)?.id;
+          if (!projectId) {
+            throw new Error("Project with the specified slug not found.");
+          }
+
+          const response = await this.getProjectEvent(projectId, eventId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    )
+  }
+
+  registerResources(server: McpServer): void {
+    server.resource(
+      "insight_hub_orgs",
+      "insighthub://orgs",
+      { description: "List all organizations in Insight Hub", mimeType: "application/json" },
+      async (uri) => {
+        try {
+          return {
+            contents: [{
+              uri: uri.href,
+              text: JSON.stringify(await this.listOrgs())
+            }]
+          }
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    );
+
+    server.resource(
+      "insight_hub_event",
+      new ResourceTemplate("insighthub://event/{id}", { list: undefined }),
+      async (uri, { id }) => {
+        try {
+          return {
+            contents: [{
+              uri: uri.href,
+              text: JSON.stringify(await this.findEventById(id as string))
+            }]
+          }
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    )
+  }
 }

--- a/insight-hub/client/api/CurrentUser.ts
+++ b/insight-hub/client/api/CurrentUser.ts
@@ -14,6 +14,7 @@ export interface Project {
   id: string;
   name: string;
   slug: string;
+  api_key: string;
 }
 
 export type GetOrganizationProjectsResponse = Project[];
@@ -22,7 +23,7 @@ export type GetOrganizationProjectsResponse = Project[];
 
 export class CurrentUserAPI extends BaseAPI {
   static organizationFields: (keyof Organization)[] = ['id', 'name'];
-  static projectFields: (keyof Project)[] = ['id', 'name', 'slug'];
+  static projectFields: (keyof Project)[] = ['id', 'name', 'slug', 'api_key'];
 
   constructor(configuration: Configuration) {
     super(configuration);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.2.0",
-        "@modelcontextprotocol/sdk": "1.12.1"
+        "@modelcontextprotocol/sdk": "1.12.1",
+        "node-cache": "^5.1.2"
       },
       "bin": {
         "mcp": "dist/index.js"
@@ -855,6 +856,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2009,6 +2019,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@bugsnag/js": "^8.2.0",
-    "@modelcontextprotocol/sdk": "1.12.1"
+    "@modelcontextprotocol/sdk": "1.12.1",
+    "node-cache": "^5.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Goal

Improve the Insight Hub client by adding caching for organizations and projects, and ensure proper initialization and resource registration in the MCP server.

## Design

- Introduced in-memory caching using `node-cache` to reduce redundant API calls for organizations and projects.
- Updated the Insight Hub client to initialize and cache organization and project data on startup.

## Changeset

- Added `node-cache` as a dependency.
- Refactored `InsightHubClient` to cache organizations and projects.
- No changes to the public API or breaking changes.

## Testing

- Manual testing by running the MCP server with different combinations of API tokens.
- Verified that organizations and projects are cached and not redundantly fetched.
