### PR TITLE
[Insight Hub] Add endpoint config and status code response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#27](https://github.com/SmartBear/smartbear-mcp/pull/27)
 - [Insight Hub] Add error filtering by both standard fields and custom filters
   [#27](https://github.com/SmartBear/smartbear-mcp/pull/27)
+- [Insight Hub] Add endpoint configuration for non-bugsnag.com endpoints and improve handling for unsuccessful status codes
+  [#27](https://github.com/SmartBear/smartbear-mcp/pull/26)
 
 ## [0.1.1] - 2025-07-01
 - Updated README to reflect the correct package name and usage instructions.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,6 @@ REFLECT_API_TOKEN=your_reflect_token INSIGHT_HUB_AUTH_TOKEN=your_insight_hub_tok
 
 This will open an inspector window in your browser, where you can test the tools.
 
-## Environment Variables
-
-- `INSIGHT_HUB_AUTH_TOKEN`: Required for Insight Hub tools. The Auth Token for Insight Hub.
-- `REFLECT_API_TOKEN`: Required for Reflect tools. The Reflect Account API Key for Reflect-based tools.
-- `API_HUB_API_KEY`: Required for API Hub tools. The API Key for API Hub tools.
-- `MCP_SERVER_INSIGHT_HUB_API_KEY`: Optional. If set, enables error reporting of the _MCP_server_ code via the BugSnag SDK. This is useful for debugging and monitoring of the MCP server itself and shouldn't be set to the same API key as your app.
-
 ## Supported Tools
 
 See individual guides for suggested prompts and supported tools and resources:
@@ -85,6 +78,15 @@ See individual guides for suggested prompts and supported tools and resources:
   Get your top events and invite your LLM to help you fix them.
 - [Reflect](./reflect/README.md)
 - [API Hub](./api-hub/README.md)
+
+## Environment Variables
+
+- `INSIGHT_HUB_AUTH_TOKEN`: Required for Insight Hub tools. The Auth Token for Insight Hub.
+- `REFLECT_API_TOKEN`: Required for Reflect tools. The Reflect Account API Key for Reflect-based tools.
+- `API_HUB_API_KEY`: Required for API Hub tools. The API Key for API Hub tools.
+- `MCP_SERVER_INSIGHT_HUB_API_KEY`: Optional. If set, enables error reporting of the _MCP_server_ code via the BugSnag SDK. This is useful for debugging and monitoring of the MCP server itself and shouldn't be set to the same API key as your app.
+
+See individual guides for product-specific configuration via environment variables.
 
 ## Local Development
 

--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,6 @@ async function main() {
 
   const reflectToken = process.env.REFLECT_API_TOKEN;
   const insightHubToken = process.env.INSIGHT_HUB_AUTH_TOKEN;
-  const insightHubProjectApiKey = process.env.INSIGHT_HUB_PROJECT_API_KEY;
   const apiHubToken = process.env.API_HUB_API_KEY;
 
   if (!reflectToken && !insightHubToken && !apiHubToken) {
@@ -48,7 +47,11 @@ async function main() {
   }
 
   if (insightHubToken) {
-    const insightHubClient = new InsightHubClient(insightHubToken, insightHubProjectApiKey);
+    const insightHubClient = new InsightHubClient(
+      insightHubToken,
+      process.env.INSIGHT_HUB_PROJECT_API_KEY,
+      process.env.INSIGHT_HUB_ENDPOINT
+    );
     await insightHubClient.initialize();
     insightHubClient.registerTools(server);
     insightHubClient.registerResources(server);

--- a/insight-hub/README.md
+++ b/insight-hub/README.md
@@ -26,9 +26,9 @@ To connect an MCP server, you will need to create a personal auth token from the
    - Get the latest event for an error.
 4. `get_insight_hub_event_details`
    - Get details of a specific event.
-6. `get_project_event_filters`
+5. `get_project_event_filters`
    - List the filters available for a project.
-5. `list_insight_hub_project_errors`
+6. `list_insight_hub_project_errors`
    - List and filter the errors from a project.
 
 ## Resources

--- a/insight-hub/README.md
+++ b/insight-hub/README.md
@@ -2,6 +2,8 @@
 
 Fetch details of your app crashes and errors from your [Insight Hub](https://www.smartbear.com/insight-hub) dashboard for your LLM to help you diagnose and fix.
 
+To connect an MCP server, you will need to create a personal auth token from the user settings page on your Insight Hub dashboard. If you wish to interact with only one Insight Hub project, we also recommend setting `INSIGHT_HUB_PROJECT_API_KEY` to reduce the scope of the conversation.
+
 ## Example prompts
 
 - "Help me fix this crash from Insight Hub: https://app.bugsnag.com/my-org/my-project/errors/1a2b3c4d5e6f7g8h9i0j1k2l?&event_id=1a2b3c4d5e6f7g8h9i0j1k2l"
@@ -9,26 +11,27 @@ Fetch details of your app crashes and errors from your [Insight Hub](https://www
 
 ## Environment Variables
 
-- `INSIGHT_HUB_AUTH_TOKEN`: Required for this client. The auth token for your account from your Insight Hub dashboard, under **Personal auth tokens** in user settings.
-- `MCP_SERVER_INSIGHT_HUB_API_KEY`: Optional. If set, enables error reporting of the _MCP_server_ code via the BugSnag SDK. This is useful for debugging and monitoring of the MCP server itself and shouldn't be set to the same API key as your app.
+- `INSIGHT_HUB_AUTH_TOKEN`: (Required) The auth token for your account from your Insight Hub dashboard, under **Personal auth tokens** in user settings.
+- `INSIGHT_HUB_PROJECT_API_KEY`: (Optional) The API key for the Insight Hub project you wish to interact with. Use this to scope all operations to a single project.
+- `INSIGHT_HUB_ENDPOINT`: (Optional) The API server to connect to. Use this for on-premise installations to point to your own endpoint (e.g. `https://your.api.server`).
 
 ## Tools
 
 1. `list_insight_hub_projects`
    - List all projects in an organization.
+   - Multi-project mode only.
 2. `get_insight_hub_error`
    - Get error details from a project.
 3. `get_insight_hub_error_latest_event`
    - Get the latest event for an error.
 4. `get_insight_hub_event_details`
-   - Get details of a specific event on Insight Hub.
+   - Get details of a specific event.
+6. `get_project_event_filters`
+   - List the filters available for a project.
+5. `list_insight_hub_project_errors`
+   - List and filter the errors from a project.
 
 ## Resources
-
-- **insight_hub_orgs**
-  - URI: `insighthub://orgs`
-  - Description: Lists all organizations available to your Insight Hub account in JSON format.
-  - Example usage: Retrieve a list of all organizations to get their IDs for use with other tools.
 
 - **insight_hub_event**
   - URI Template: `insighthub://event/{id}`

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -9,6 +9,10 @@ import { Organization, Project } from "./client/api/CurrentUser.js";
 import { EventField, ProjectAPI } from "./client/api/Project.js";
 import { FilterObject, FilterObjectSchema } from "./client/api/filters.js";
 
+const HUB_PREFIX = "00000";
+const HUB_API_ENDPOINT = "https://api.insighthub.smartbear.com";
+const DEFAULT_API_ENDPOINT = "https://api.bugsnag.com";
+
 const cacheKeys = {
   ORG: "insight_hub_org",
   PROJECTS: "insight_hub_projects",
@@ -28,7 +32,6 @@ export interface OrgArgs {
 export interface ErrorArgs extends ProjectArgs {
   errorId: string;
 }
-
 export class InsightHubClient implements Client {
   private currentUserApi: CurrentUserAPI;
   private errorsApi: ErrorAPI;
@@ -36,14 +39,21 @@ export class InsightHubClient implements Client {
   private projectApi: ProjectAPI;
   private projectApiKey?: string;
 
-  constructor(token: string, projectApiKey?: string) {
+  constructor(token: string, projectApiKey?: string, endpoint?: string) {
+    if (!endpoint) {
+      if (projectApiKey && projectApiKey.startsWith(HUB_PREFIX)) {
+        endpoint = HUB_API_ENDPOINT;
+      } else {
+        endpoint = DEFAULT_API_ENDPOINT;
+      }
+    }
     const config = new Configuration({
       authToken: token,
       headers: {
         "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
         "Content-Type": "application/json",
       },
-      basePath: "https://api.bugsnag.com",
+      basePath: endpoint,
     });
     this.currentUserApi = new CurrentUserAPI(config);
     this.errorsApi = new ErrorAPI(config);

--- a/insight-hub/client/api/base.ts
+++ b/insight-hub/client/api/base.ts
@@ -53,6 +53,11 @@ export class BaseAPI {
     let nextUrl: string | undefined = url;
     do {
       const response: Response = await fetch(nextUrl!, fetchOptions);
+      if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+      }
+
       const data: T = await response.json();
       if (paginate) {
         results = results.concat(data);


### PR DESCRIPTION
Added logic to handle the new Hub API key.

It also now throws an error if the status code is not successful, rather than going ahead to try and parse the response, so now it gives a more understandable error.