### PR TITLE
[Insight Hub] Add API key configuration and filtering tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+- [Insight Hub] Add project API key configuration and initial caching
+  [#27](https://github.com/SmartBear/smartbear-mcp/pull/27)
+- [Insight Hub] Add error filtering by both standard fields and custom filters
+  [#27](https://github.com/SmartBear/smartbear-mcp/pull/27)
+
 ## [0.1.1] - 2025-07-01
 - Updated README to reflect the correct package name and usage instructions.
 - Added more fields to package.json for better npm integration.

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ async function main() {
 
   const reflectToken = process.env.REFLECT_API_TOKEN;
   const insightHubToken = process.env.INSIGHT_HUB_AUTH_TOKEN;
+  const insightHubProjectApiKey = process.env.INSIGHT_HUB_PROJECT_API_KEY;
   const apiHubToken = process.env.API_HUB_API_KEY;
 
   if (!reflectToken && !insightHubToken && !apiHubToken) {
@@ -47,7 +48,7 @@ async function main() {
   }
 
   if (insightHubToken) {
-    const insightHubClient = new InsightHubClient(insightHubToken);
+    const insightHubClient = new InsightHubClient(insightHubToken, insightHubProjectApiKey);
     await insightHubClient.initialize();
     insightHubClient.registerTools(server);
     insightHubClient.registerResources(server);

--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,7 @@ async function main() {
 
   if (insightHubToken) {
     const insightHubClient = new InsightHubClient(insightHubToken);
+    await insightHubClient.initialize();
     insightHubClient.registerTools(server);
     insightHubClient.registerResources(server);
   }

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -223,25 +223,6 @@ export class InsightHubClient implements Client {
 
   registerResources(server: McpServer): void {
     server.resource(
-      "insight_hub_orgs",
-      "insighthub://orgs",
-      { description: "List all organizations in Insight Hub", mimeType: "application/json" },
-      async (uri) => {
-        try {
-          return {
-            contents: [{
-              uri: uri.href,
-              text: JSON.stringify(await this.listOrgs())
-            }]
-          }
-        } catch (e) {
-          Bugsnag.notify(e as unknown as Error);
-          throw e;
-        }
-      }
-    );
-
-    server.resource(
       "insight_hub_event",
       new ResourceTemplate("insighthub://event/{id}", { list: undefined }),
       async (uri, { id }) => {

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -4,6 +4,13 @@ import { Client } from "../common/types.js";
 import { CurrentUserAPI, ErrorAPI, Configuration } from "./client/index.js";
 import { z } from "zod";
 import Bugsnag from "../common/bugsnag.js";
+import NodeCache from "node-cache";
+import { Organization, Project } from "./client/api/CurrentUser.js";
+
+const cacheKeys = {
+  ORG: "insight_hub_org",
+  PROJECTS: "insight_hub_projects",
+}
 
 // Type definitions for tool arguments
 export interface ProjectArgs {
@@ -21,6 +28,7 @@ export interface ErrorArgs extends ProjectArgs {
 export class InsightHubClient implements Client {
   private currentUserApi: CurrentUserAPI;
   private errorsApi: ErrorAPI;
+  private cache: NodeCache;
 
   constructor(token: string) {
     const config = new Configuration({
@@ -33,18 +41,50 @@ export class InsightHubClient implements Client {
     });
     this.currentUserApi = new CurrentUserAPI(config);
     this.errorsApi = new ErrorAPI(config);
+    this.cache = new NodeCache();
+  }
+
+  async initialize(): Promise<void> {
+    const orgs = await this.listOrgs();
+    if (!orgs || orgs.length === 0) {
+      throw new Error("No organizations found for the current user.");
+    }
+    // We should only have one org
+    this.cache.set(cacheKeys.ORG, orgs[0]);
+    const projects = await this.listProjects(orgs[0].id);
+    this.cache.set(cacheKeys.PROJECTS, projects);
   }
 
   async listOrgs(): Promise<any> {
     return this.currentUserApi.listUserOrganizations();
   }
 
-  async listProjects(orgId: string, options?: any ): Promise<any> {
+  async listProjects(orgId: string, options?: any): Promise<any> {
     options = {
       ...options,
       paginate: true
     };
     return this.currentUserApi.getOrganizationProjects(orgId, options);
+  }
+
+  // This method retrieves all orojects for the organization stored in the cache.
+  // If no projects are found in the cache, it fetches them from the API and
+  // stores them in the cache for future use.
+  // It throws an error if no organizations are found in the cache.
+  async getProjects(): Promise<Project[]> {
+    let projects = this.cache.get<Project[]>(cacheKeys.PROJECTS);
+    if (!projects) {
+      const org = this.cache.get<Organization>(cacheKeys.ORG);
+      if (!org) {
+        throw new Error("No organization found in cache.");
+      }
+      projects = await this.listProjects(org.id);
+      this.cache.set(cacheKeys.PROJECTS, projects);
+    }
+    if (!projects) {
+      throw new Error("No projects found.");
+    }
+    return projects;
   }
 
   async getErrorDetails(projectId: string, errorId: string): Promise<any> {
@@ -65,130 +105,147 @@ export class InsightHubClient implements Client {
     return eventDetails.find(event => !!event);
   }
 
-registerTools(server: McpServer): void {
-  server.tool(
-    "list_insight_hub_projects",
-    "List all projects in an organization",
-    { orgId: z.string().describe("ID of the organization to list projects for") },
-    async (args, _extra) => {
-      try {
-        if (!args.orgId) throw new Error("orgId argument is required");
-        const response = await this.listProjects(args.orgId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_error",
-    "Get error details from a project",
-    {
-      projectId: z.string().describe("ID of the project"),
-      errorId: z.string().describe("ID of the error to fetch"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.projectId || !args.errorId) throw new Error("Both projectId and errorId arguments are required");
-        const response = await this.getErrorDetails(args.projectId, args.errorId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_error_latest_event",
-    "Get the latest event for an error",
-    {
-      errorId: z.string().describe("ID of the error to get the latest event for"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.errorId) throw new Error("errorId argument is required");
-        const response = await this.getLatestErrorEvent(args.errorId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  );
-  server.tool(
-    "get_insight_hub_event_details",
-    "Get details of a specific event on Insight Hub",
-    {
-      link: z.string().describe("Link to the event details"),
-    },
-    async (args, _extra) => {
-      try {
-        if (!args.link) throw new Error("link argument is required");
-        const url = new URL(args.link);
-        const eventId = url.searchParams.get("event_id");
-        const projectSlug = url.pathname.split('/')[2];
-        if (!projectSlug || !eventId) throw new Error("Both projectSlug and eventId must be present in the link");
-
-        // get the project id from list of projects
-        // limitation: this assumes a single page of results, so will not work for orgs with >100 projects
-        const orgId = await this.currentUserApi.listUserOrganizations().then(orgs => orgs[0].id);
-        const projectId = await this.listProjects(orgId).then(projects => projects.find((p: any) => p.slug === projectSlug)?.id);
-
-        const response = await this.getProjectEvent(projectId, eventId);
-        return {
-          content: [{ type: "text", text: JSON.stringify(response) }],
-        };
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
-      }
-    }
-  )
-}
-
-registerResources(server: McpServer): void {
-  server.resource(
-    "insight_hub_orgs",
-    "insighthub://orgs",
-    { description: "List all organizations in Insight Hub", mimeType: "application/json" },
-    async (uri) => {
-      try {
-        return {
-          contents: [{
-            uri: uri.href,
-            text: JSON.stringify(await this.listOrgs())
-          }]
+  registerTools(server: McpServer): void {
+    server.tool(
+      "list_insight_hub_projects",
+      "List all projects in an organization",
+      {
+        page_size: z.number().optional().describe("Number of projects to return per page"),
+        page: z.number().optional().describe("Page number to return"),
+      },
+      async (args, _extra) => {
+        try {
+          let projects = await this.getProjects();
+          if (!projects || projects.length === 0) {
+            return {
+              content: [{ type: "text", text: "No projects found." }],
+            };
+          }
+          if (args.page_size || args.page) {
+            const pageSize = args.page_size || 10;
+            const page = args.page || 1;
+            projects = projects.slice((page - 1) * pageSize, page * pageSize);
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify(projects) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
         }
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
       }
-    }
-  );
-
-  server.resource(
-    "insight_hub_event",
-    new ResourceTemplate("insighthub://event/{id}", { list: undefined }),
-    async (uri, { id }) => {
-      try {
-        return {
-          contents: [{
-            uri: uri.href,
-            text: JSON.stringify(await this.findEventById(id as string))
-          }]
+    );
+    server.tool(
+      "get_insight_hub_error",
+      "Get error details from a project",
+      {
+        projectId: z.string().describe("ID of the project"),
+        errorId: z.string().describe("ID of the error to fetch"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.projectId || !args.errorId) throw new Error("Both projectId and errorId arguments are required");
+          const response = await this.getErrorDetails(args.projectId, args.errorId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
         }
-      } catch (e) {
-        Bugsnag.notify(e as unknown as Error);
-        throw e;
       }
-    }
-  )
-}
+    );
+    server.tool(
+      "get_insight_hub_error_latest_event",
+      "Get the latest event for an error",
+      {
+        errorId: z.string().describe("ID of the error to get the latest event for"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.errorId) throw new Error("errorId argument is required");
+          const response = await this.getLatestErrorEvent(args.errorId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    );
+    server.tool(
+      "get_insight_hub_event_details",
+      "Get details of a specific event on Insight Hub",
+      {
+        link: z.string().describe("Link to the event details"),
+      },
+      async (args, _extra) => {
+        try {
+          if (!args.link) throw new Error("link argument is required");
+          const url = new URL(args.link);
+          const eventId = url.searchParams.get("event_id");
+          const projectSlug = url.pathname.split('/')[2];
+          if (!projectSlug || !eventId) throw new Error("Both projectSlug and eventId must be present in the link");
+
+          // get the project id from list of projects
+          const projects = this.cache.get<Project[]>("insight_hub_projects");
+          if (!projects) {
+            throw new Error("No projects found in cache.");
+          }
+          const projectId = projects.find((p: any) => p.slug === projectSlug)?.id;
+          if (!projectId) {
+            throw new Error("Project with the specified slug not found.");
+          }
+
+          const response = await this.getProjectEvent(projectId, eventId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    )
+  }
+
+  registerResources(server: McpServer): void {
+    server.resource(
+      "insight_hub_orgs",
+      "insighthub://orgs",
+      { description: "List all organizations in Insight Hub", mimeType: "application/json" },
+      async (uri) => {
+        try {
+          return {
+            contents: [{
+              uri: uri.href,
+              text: JSON.stringify(await this.listOrgs())
+            }]
+          }
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    );
+
+    server.resource(
+      "insight_hub_event",
+      new ResourceTemplate("insighthub://event/{id}", { list: undefined }),
+      async (uri, { id }) => {
+        try {
+          return {
+            contents: [{
+              uri: uri.href,
+              text: JSON.stringify(await this.findEventById(id as string))
+            }]
+          }
+        } catch (e) {
+          Bugsnag.notify(e as unknown as Error);
+          throw e;
+        }
+      }
+    )
+  }
 }

--- a/insight-hub/client/api/CurrentUser.ts
+++ b/insight-hub/client/api/CurrentUser.ts
@@ -14,6 +14,7 @@ export interface Project {
   id: string;
   name: string;
   slug: string;
+  api_key: string;
 }
 
 export type GetOrganizationProjectsResponse = Project[];
@@ -22,7 +23,7 @@ export type GetOrganizationProjectsResponse = Project[];
 
 export class CurrentUserAPI extends BaseAPI {
   static organizationFields: (keyof Organization)[] = ['id', 'name'];
-  static projectFields: (keyof Project)[] = ['id', 'name', 'slug'];
+  static projectFields: (keyof Project)[] = ['id', 'name', 'slug', 'api_key'];
 
   constructor(configuration: Configuration) {
     super(configuration);

--- a/insight-hub/client/api/Error.ts
+++ b/insight-hub/client/api/Error.ts
@@ -1,5 +1,6 @@
 import { BaseAPI } from './base.js';
 import { Configuration } from '../configuration.js';
+import { FilterObject, toQueryString } from './filters.js';
 
 // --- Response Types ---
 
@@ -47,7 +48,7 @@ export interface ListProjectErrorsOptions {
   sort?: 'last_seen' | 'first_seen' | 'users' | 'events' | 'unsorted';
   direction?: 'asc' | 'desc';
   per_page?: number;
-  filters?: any; // Filters object as defined in the API spec
+  filters?: FilterObject; // Filters object as defined in the API spec
   [key: string]: any;
 }
 
@@ -117,20 +118,9 @@ export class ErrorAPI extends BaseAPI {
    * GET /projects/{project_id}/errors
    */
   async listProjectErrors(projectId: string, options: ListProjectErrorsOptions = {}): Promise<ListProjectErrorsResponse> {
-    const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(options)) {
-      if (value !== undefined) {
-        if (key === 'filters' && typeof value === 'object') {
-          // Handle filters as JSON string if it's an object
-          params.append(key, JSON.stringify(value));
-        } else {
-          params.append(key, String(value));
-        }
-      }
-    }
-    const url = params.toString()
-      ? `/projects/${projectId}/errors?${params}`
-      : `/projects/${projectId}/errors`;
+    const url = options.filters
+      ? `/projects/${projectId}/errors?${toQueryString(options.filters)}`
+      : `/projects/${projectId}/errors`; 
     return (await this.request<ListProjectErrorsResponse>({
       method: 'GET',
       url,

--- a/insight-hub/client/api/Project.ts
+++ b/insight-hub/client/api/Project.ts
@@ -1,0 +1,63 @@
+import { Configuration } from "../configuration.js";
+import { BaseAPI, pickFieldsFromArray } from "./base.js";
+
+// --- Response Types ---
+
+export interface EventFieldFilterOptions {
+  name: string;
+  type?: string[];
+}
+
+export interface EventFieldPivotOptions {
+  name: string;
+  summary?: boolean;
+  values?: boolean;
+  cardinality?: boolean;
+  average?: boolean;
+}
+
+export interface EventField {
+  custom: boolean;
+  display_id: string;
+  filter_options: EventFieldFilterOptions;
+  pivot_options: EventFieldPivotOptions;
+}
+
+export type ListProjectEventFieldsResponse = EventField[];
+
+export interface ListProjectEventFieldsOptions {
+  [key: string]: any;
+}
+
+// --- API Class ---
+
+export class ProjectAPI extends BaseAPI {
+  static eventFieldFields: (keyof EventField)[] = [
+    'custom',
+    'display_id', 
+    'filter_options',
+    'pivot_options'
+  ];
+
+  constructor(configuration: Configuration) {
+    super(configuration);
+  }
+
+  /**
+   * List the Event Fields for a Project
+   * GET /projects/{project_id}/event_fields
+   * @param projectId The project ID
+   * @returns A promise that resolves to the list of event fields
+   */
+  async listProjectEventFields(projectId: string): Promise<ListProjectEventFieldsResponse> {
+    const url = `/projects/${projectId}/event_fields`;
+    
+    const data = await this.request<ListProjectEventFieldsResponse>({
+      method: 'GET',
+      url,
+    });
+    
+    // Only return allowed fields
+    return pickFieldsFromArray<EventField>(data as ListProjectEventFieldsResponse[], ProjectAPI.eventFieldFields);
+  }
+}

--- a/insight-hub/client/api/filters.ts
+++ b/insight-hub/client/api/filters.ts
@@ -1,0 +1,215 @@
+/**
+ * Filters utility for Insight Hub API
+ * 
+ * This file provides utility functions for creating filter URL parameters
+ * based on the Insight Hub filtering specification described in the Filtering.md document.
+ */
+
+/**
+ * Types of filter comparison operations
+ */
+export type FilterType = 'eq' | 'ne' | 'empty';
+
+/**
+ * Single filter value with its comparison type
+ */
+export interface FilterValue {
+  /** The type of comparison to perform */
+  type: FilterType;
+  /** The value to compare against */
+  value: string | boolean | number;
+}
+
+/**
+ * Filter object structure as specified in the Insight Hub API
+ * 
+ * Example:
+ * {
+ *   "event.field": [{ "type": "eq", "value": "filter value 1" }],
+ *   "error.status": [{ "type": "empty", "value": "true" }]
+ * }
+ */
+export interface FilterObject {
+  [fieldName: string]: FilterValue[];
+}
+
+/**
+ * Creates a filter value object for equality comparison
+ * 
+ * @param value The value to compare against
+ * @returns FilterValue with type 'eq'
+ */
+export function equals(value: string | number): FilterValue {
+  return {
+    type: 'eq',
+    value,
+  };
+}
+
+/**
+ * Creates a filter value object for inequality comparison
+ * 
+ * @param value The value to compare against
+ * @returns FilterValue with type 'ne'
+ */
+export function notEquals(value: string | number): FilterValue {
+  return {
+    type: 'ne',
+    value,
+  };
+}
+
+/**
+ * Creates a filter value object for checking if a field is empty or not
+ * 
+ * @param isEmpty Whether the field should be empty (true) or not (false)
+ * @returns FilterValue with type 'empty'
+ */
+export function empty(isEmpty: boolean): FilterValue {
+  return {
+    type: 'empty',
+    value: isEmpty.toString(),
+  };
+}
+
+/**
+ * Creates a relative time filter for event.since or event.before
+ * 
+ * @param value The amount of time
+ * @param unit The time unit ('h' for hours, 'd' for days)
+ * @returns FilterValue for the relative time
+ */
+export function relativeTime(value: number, unit: 'h' | 'd'): FilterValue {
+  return {
+    type: 'eq',
+    value: `${value}${unit}`,
+  };
+}
+
+/**
+ * Creates an ISO 8601 time filter (must be in UTC format like 2018-05-20T00:00:00Z)
+ * 
+ * @param date The date object to convert to ISO string
+ * @returns FilterValue for the ISO time
+ */
+export function isoTime(date: Date): FilterValue {
+  return {
+    type: 'eq',
+    value: date.toISOString(),
+  };
+}
+
+/**
+ * Converts a FilterObject to URL search parameters
+ * 
+ * @param filters The filter object to convert
+ * @returns URLSearchParams object with the encoded filters
+ */
+export function toUrlSearchParams(filters: FilterObject): URLSearchParams {
+  const params = new URLSearchParams();
+  
+  Object.entries(filters).forEach(([field, filterValues]) => {
+    filterValues.forEach((filterValue, index) => {
+      params.append(`filters[${field}][${index}][type]`, filterValue.type);
+      params.append(`filters[${field}][${index}][value]`, filterValue.value.toString());
+    });
+  });
+  
+  return params;
+}
+
+/**
+ * Converts a FilterObject to a query string
+ * 
+ * @param filters The filter object to convert
+ * @returns Query string representation of the filters
+ */
+export function toQueryString(filters: FilterObject): string {
+  return toUrlSearchParams(filters).toString();
+}
+
+/**
+ * Helper to build a FilterObject with type safety
+ * 
+ * @returns An empty FilterObject that can be built upon
+ */
+export function createFilter(): FilterObject {
+  return {};
+}
+
+/**
+ * Adds a field filter to an existing FilterObject
+ * 
+ * @param filters The FilterObject to add to
+ * @param field The field name (e.g., 'error.status', 'event.since')
+ * @param filterValue The FilterValue to add
+ * @returns The updated FilterObject for chaining
+ */
+export function addFilter(
+  filters: FilterObject,
+  field: string,
+  filterValue: FilterValue
+): FilterObject {
+  if (!filters[field]) {
+    filters[field] = [];
+  }
+  filters[field].push(filterValue);
+  return filters;
+}
+
+/**
+ * Utility to create a time range filter between two dates
+ * 
+ * @param filters The FilterObject to add to
+ * @param since Start date
+ * @param before End date
+ * @returns The updated FilterObject for chaining
+ */
+export function addTimeRange(
+  filters: FilterObject,
+  since: Date,
+  before: Date
+): FilterObject {
+  addFilter(filters, 'event.since', isoTime(since));
+  addFilter(filters, 'event.before', isoTime(before));
+  return filters;
+}
+
+/**
+ * Utility to create a relative time range filter
+ * 
+ * @param filters The FilterObject to add to
+ * @param amount The amount of time (e.g., 7 for 7 days)
+ * @param unit The time unit ('h' for hours, 'd' for days)
+ * @returns The updated FilterObject for chaining
+ */
+export function addRelativeTimeRange(
+  filters: FilterObject,
+  amount: number,
+  unit: 'h' | 'd'
+): FilterObject {
+  addFilter(filters, 'event.since', relativeTime(amount, unit));
+  return filters;
+}
+
+/**
+ * Usage examples:
+ * 
+ * // Example 1: Open errors with events in the last day
+ * const filters = createFilter();
+ * addRelativeTimeRange(filters, 1, 'd');
+ * addFilter(filters, 'error.status', equals('open'));
+ * const queryString = toQueryString(filters);
+ * 
+ * // Example 2: Events affecting specific users on a specific day
+ * const filters = createFilter();
+ * addTimeRange(filters, new Date('2017-01-01'), new Date('2017-01-02'));
+ * addFilter(filters, 'user.email', equals('user1@example.com'));
+ * addFilter(filters, 'user.email', equals('user2@example.com'));
+ * const queryString = toQueryString(filters);
+ * 
+ * // Example 3: Events that have user data
+ * const filters = createFilter();
+ * addFilter(filters, 'user.id', empty(false));
+ * const queryString = toQueryString(filters);
+ */

--- a/insight-hub/client/api/filters.ts
+++ b/insight-hub/client/api/filters.ts
@@ -4,6 +4,7 @@
  * This file provides utility functions for creating filter URL parameters
  * based on the Insight Hub filtering specification described in the Filtering.md document.
  */
+import { z } from "zod";
 
 /**
  * Types of filter comparison operations
@@ -32,6 +33,13 @@ export interface FilterValue {
 export interface FilterObject {
   [fieldName: string]: FilterValue[];
 }
+
+export const FilterValueSchema = z.object({
+  type: z.enum(['eq', 'ne', 'empty']),
+  value: z.union([z.string(), z.boolean(), z.number()]),
+});
+
+export const FilterObjectSchema = z.record(z.array(FilterValueSchema));
 
 /**
  * Creates a filter value object for equality comparison
@@ -109,9 +117,9 @@ export function toUrlSearchParams(filters: FilterObject): URLSearchParams {
   const params = new URLSearchParams();
   
   Object.entries(filters).forEach(([field, filterValues]) => {
-    filterValues.forEach((filterValue, index) => {
-      params.append(`filters[${field}][${index}][type]`, filterValue.type);
-      params.append(`filters[${field}][${index}][value]`, filterValue.value.toString());
+    filterValues.forEach((filterValue) => {
+      params.append(`filters[${field}][][type]`, filterValue.type);
+      params.append(`filters[${field}][][value]`, filterValue.value.toString());
     });
   });
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.2.0",
-        "@modelcontextprotocol/sdk": "1.12.1"
+        "@modelcontextprotocol/sdk": "1.12.1",
+        "node-cache": "^5.1.2"
       },
       "bin": {
         "mcp": "dist/index.js"
@@ -855,6 +856,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2009,6 +2019,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@bugsnag/js": "^8.2.0",
-    "@modelcontextprotocol/sdk": "1.12.1"
+    "@modelcontextprotocol/sdk": "1.12.1",
+    "node-cache": "^5.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Goal

Optionally reduce the scope of queries to a single project and expand the filtering capabilities

## Design

### API key configuration

Added the `API_HUB_API_KEY` environment variable as startup config. This allows initial queries to the endpoints for org and project data, which is then cached at the Node layer. Tools that were taking a project slug/ID now have this as an optional parameter allowing more simple prompts assuming a single project.

### Improved filtering

Integrated with the project event fields endpoint to provide the filtering fields available for the configured project. This can then be used by the LLM to send to the list errors endpoint to provide queries on both standard fields and custom filters.