### PR TITLE
Supply api and api version header to suport on-premise instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased] - 2025-07-09
+- [Insight Hub] Add API headers to support On-premise installations
+  [#30](https://github.com/SmartBear/smartbear-mcp/pull/30)
+
 ## [0.2.0] - 2025-07-08
 
 - [Insight Hub] Add project API key configuration and initial caching

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -52,6 +52,8 @@ export class InsightHubClient implements Client {
       headers: {
         "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
         "Content-Type": "application/json",
+        "X-Bugsnag-API": "true",
+        "X-Version": "2",
       },
       basePath: endpoint,
     });


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

This change adds support for on-premise Insight Hub instances by including the required API headers that are expected by on-premise deployments. On-premise Insight Hub instances require specific headers (`X-Bugsnag-API` and `X-Version`) to properly authenticate and route API requests, which were missing from the MCP server client configuration.

## Design

<!-- Why was this approach used? -->

The solution adds the required headers directly to the Configuration object in the InsightHubClient constructor. This approach ensures that all API requests made through the client will include these headers automatically. The headers are:

- `X-Bugsnag-API: "true"` - Identifies the request as coming from a Bugsnag API client
- `X-Version: "2"` - Specifies the API version being used

This is a minimal, non-breaking change that maintains compatibility with existing cloud deployments while enabling support for on-premise instances.

## Changeset

<!-- What changed? -->

- **insight-hub/client.ts**: Added two required headers to the Configuration object:
  - `X-Bugsnag-API: "true"`
  - `X-Version: "2"`

The change is isolated to the client initialization and affects all subsequent API calls made through the InsightHubClient.

## Testing

<!-- How was it tested? -->

The change should be tested against both cloud and on-premise Insight Hub instances to ensure:
1. Existing cloud functionality continues to work without issues
2. On-premise instances can now successfully authenticate and process API requests
3. All MCP tools that interact with Insight Hub (error listing, error details, event details, etc.) function correctly with the new headers