### PR TITLE
docs(insight hub): added further references to the project api key to make this more findable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If setting up manually, add the following configuration to `.vscode/mcp.json`:
       ],
       "env": {
         "INSIGHT_HUB_AUTH_TOKEN": "${input:insight_hub_auth_token}",
+        "INSIGHT_HUB_PROJECT_API_KEY": "${input:insight_hub_project_api_key}",
         "REFLECT_API_TOKEN": "${input:reflect_api_token}",
         "API_HUB_API_KEY": "${input:api_hub_api_key}"
       }
@@ -41,19 +42,25 @@ If setting up manually, add the following configuration to `.vscode/mcp.json`:
       {
          "id": "insight_hub_auth_token",
          "type": "promptString",
-         "description": "Insight Hub Auth Token",
+         "description": "Insight Hub Auth Token - leave blank to disable Insight Hub tools",
          "password": true
+      },
+      {
+         "id": "insight_hub_project_api_key",
+         "type": "promptString",
+         "description": "Insight Hub Project API Key - for single project interactions",
+         "password": false
       },
       {
          "id": "reflect_api_token",
          "type": "promptString",
-         "description": "Reflect API Token",
+         "description": "Reflect API Token - leave blank to disable Reflect tools",
          "password": true
       },
       {
          "id": "api_hub_api_key",
          "type": "promptString",
-         "description": "API Hub API Key",
+         "description": "API Hub API Key - leave blank to disable API Hub tools",
          "password": true
       }
   ]
@@ -113,9 +120,7 @@ Update your `.vscode/mcp.json` to point to your local build:
       "command": "node",
       "args": ["<PATH_TO_SMARTBEAR_MCP>/dist/index.js"],
       "env": {
-        "INSIGHT_HUB_AUTH_TOKEN": "${input:insight_hub_auth_token}",
-        "REFLECT_API_TOKEN": "${input:reflect_api_token}",
-        "API_HUB_API_KEY": "${input:api_hub_api_key}"
+        // ...same as above...
       }
     }
   },

--- a/insight-hub/README.md
+++ b/insight-hub/README.md
@@ -2,17 +2,20 @@
 
 Fetch details of your app crashes and errors from your [Insight Hub](https://www.smartbear.com/insight-hub) dashboard for your LLM to help you diagnose and fix.
 
-To connect an MCP server, you will need to create a personal auth token from the user settings page on your Insight Hub dashboard. If you wish to interact with only one Insight Hub project, we also recommend setting `INSIGHT_HUB_PROJECT_API_KEY` to reduce the scope of the conversation.
+To connect an MCP server, you will need to create a personal auth token from the user settings page on your Insight Hub dashboard.
+
+If you wish to interact with only one Insight Hub project, we also recommend setting `INSIGHT_HUB_PROJECT_API_KEY` to reduce the scope of the conversation. This allows the MCP server to pre-cache your project's custom filters for better filtering prompts.
 
 ## Example prompts
 
-- "Help me fix this crash from Insight Hub: https://app.bugsnag.com/my-org/my-project/errors/1a2b3c4d5e6f7g8h9i0j1k2l?&event_id=1a2b3c4d5e6f7g8h9i0j1k2l"
-- "What are my top events for the 'example' project in insight hub?"
+- "Help me fix this crash: https://app.bugsnag.com/my-org/my-project/errors/1a2b3c4d5e6f7g8h9i0j1k2l?&event_id=1a2b3c4d5e6f7g8h9i0j1k2l"
+- "What are my latest events my project?"
+- "Which errors occurred in the last 7 days?"
 
 ## Environment Variables
 
 - `INSIGHT_HUB_AUTH_TOKEN`: (Required) The auth token for your account from your Insight Hub dashboard, under **Personal auth tokens** in user settings.
-- `INSIGHT_HUB_PROJECT_API_KEY`: (Optional) The API key for the Insight Hub project you wish to interact with. Use this to scope all operations to a single project.
+- `INSIGHT_HUB_PROJECT_API_KEY`: (Recommended) The API key for the Insight Hub project you wish to interact with. Use this to scope all operations to a single project.
 - `INSIGHT_HUB_ENDPOINT`: (Optional) The API server to connect to. Use this for on-premise installations to point to your own endpoint (e.g. `https://your.api.server`).
 
 ## Tools


### PR DESCRIPTION
## Goal

The project API key option is perhaps a little buried - I've added this to the top-level readme as this is now our recommended way of using it.