### PR TITLE
Add User-Agent headers to API Hub and Reflect clients

### DIFF
--- a/api-hub/client.ts
+++ b/api-hub/client.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
 import { Client } from "../common/types.js";
 
 // Type definitions for tool arguments
@@ -54,12 +55,13 @@ export interface updateProductArgs extends productArgs {
 
 // Tool definitions for API Hub API client
 export class ApiHubClient implements Client {
-  private headers: { "Authorization": string; "Content-Type": string };
+  private headers: { "Authorization": string; "Content-Type": string, "User-Agent": string };
 
   constructor(token: string) {
     this.headers = {
       "Authorization": `Bearer ${token}`,
       "Content-Type": "application/json",
+      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
     };
   }
 
@@ -172,9 +174,9 @@ export class ApiHubClient implements Client {
     server.tool(
       "create_portal",
       "Create a new portal within API Hub.",
-      { 
-        name: z.string().optional().describe("The portal name."), 
-        subdomain: z.string().describe("The portal subdomain."), 
+      {
+        name: z.string().optional().describe("The portal name."),
+        subdomain: z.string().describe("The portal subdomain."),
         offline: z.boolean().optional().describe("If set to true the portal will not be visible to customers."),
         routing: z.string().optional().describe("Determines the routing strategy ('browser' or 'proxy')."),
         credentialsEnabled: z.string().optional().describe("Indicates if credentials are enabled for the portal."),

--- a/reflect/client.ts
+++ b/reflect/client.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
 import { Client } from "../common/types.js";
 import { z } from "zod";
 
@@ -23,12 +24,13 @@ export interface testExecutionArgs {
 
 // ReflectClient class implementing the Client interface
 export class ReflectClient implements Client {
-  private headers: { "X-API-KEY": string; "Content-Type": string };
+  private headers: { "X-API-KEY": string; "Content-Type": string, "User-Agent": string };
 
   constructor(token: string) {
     this.headers = {
       "X-API-KEY": `${token}`,
       "Content-Type": "application/json",
+      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
     };
   }
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

This change adds consistent User-Agent headers across all SmartBear MCP client implementations to improve API request tracking, debugging, and analytics. User-Agent headers help API providers identify the source and version of requests, which is essential for troubleshooting, rate limiting, and usage analytics.

## Design

<!-- Why was this approach used? -->

The solution adds a standardized User-Agent header to both the API Hub and Reflect clients by:

1. Importing the common `MCP_SERVER_NAME` and `MCP_SERVER_VERSION` constants from `../common/info.js`
2. Adding a `User-Agent` field to the headers object in each client constructor
3. Using the format `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}` which follows standard User-Agent conventions

This approach ensures consistency across all SmartBear MCP clients and makes it easy to identify requests coming from this MCP server. The User-Agent format follows the pattern "SmartBear MCP Server/0.2.1".

## Changeset

<!-- What changed? -->

- **api-hub/client.ts**: 
  - Added import for `MCP_SERVER_NAME` and `MCP_SERVER_VERSION` from common info module
  - Updated headers type definition to include `User-Agent` field
  - Added `User-Agent` header to constructor with standardized format

- **reflect/client.ts**:
  - Added import for `MCP_SERVER_NAME` and `MCP_SERVER_VERSION` from common info module  
  - Updated headers type definition to include `User-Agent` field
  - Added `User-Agent` header to constructor with standardized format

Both changes maintain backward compatibility and don't affect existing functionality.

## Testing

<!-- How was it tested? -->

The changes should be tested to ensure:
1. All API Hub operations (portal management, product management) continue to work correctly
2. All Reflect operations (suite and test management) continue to work correctly  
3. User-Agent headers are properly included in outgoing requests to respective APIs
4. No breaking changes to existing client functionality
5. The User-Agent string format matches expected pattern: "SmartBear MCP Server/0.2.1"

Testing can be verified by monitoring network requests or checking API logs to confirm the User-Agent header is being sent with the correct value.