### PR TITLE
feat(insight-hub): add latest error and URL to error details

### DIFF
--- a/common/templates.ts
+++ b/common/templates.ts
@@ -30,7 +30,8 @@ export function toolDescriptionTemplate(params: ToolDescriptionParams): string {
     useCases,
     examples,
     parameters,
-    hints
+    hints,
+    outputFormat
   } = params;
 
   let description = summary;
@@ -40,6 +41,10 @@ export function toolDescriptionTemplate(params: ToolDescriptionParams): string {
     description += `\n\n**Parameters:** ${parameters.map(p =>
       `${p.name} (${p.type})${p.required ? ' *required*' : ''}`
     ).join(', ')}`;
+  }
+
+  if (outputFormat) {
+    description += `\n\n**Output Format:** ${outputFormat}`;
   }
 
   // Use Cases

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -7,7 +7,6 @@ import Bugsnag from "../common/bugsnag.js";
 import NodeCache from "node-cache";
 import { Organization, Project } from "./client/api/CurrentUser.js";
 import { EventField, ProjectAPI } from "./client/api/Project.js";
-import { ErrorOperations } from "./client/api/Error.js";
 import { FilterObject, FilterObjectSchema } from "./client/api/filters.js";
 import { toolDescriptionTemplate, createParameter, createExample } from "../common/templates.js";
 
@@ -185,14 +184,6 @@ export class InsightHubClient implements Client {
 
   getErrorUrl(projectId: string, errorId: string): string {
     return `${this.getDashboardUrl(projectId)}/errors/${errorId}`;
-  }
-
-  async updateError(projectId: string, errorId: string, operation: string, options?: any): Promise<any> {
-    const errorUpdateRequest = {
-      operation: operation,
-      ...options
-    };
-    return this.errorsApi.updateErrorOnProject(projectId, errorId, errorUpdateRequest)
   }
 
   registerTools(server: McpServer): void {

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -7,6 +7,7 @@ import Bugsnag from "../common/bugsnag.js";
 import NodeCache from "node-cache";
 import { Organization, Project } from "./client/api/CurrentUser.js";
 import { EventField, ProjectAPI } from "./client/api/Project.js";
+import { ErrorOperations } from "./client/api/Error.js";
 import { FilterObject, FilterObjectSchema } from "./client/api/filters.js";
 import { toolDescriptionTemplate, createParameter, createExample } from "../common/templates.js";
 
@@ -184,6 +185,14 @@ export class InsightHubClient implements Client {
 
   getErrorUrl(projectId: string, errorId: string): string {
     return `${this.getDashboardUrl(projectId)}/errors/${errorId}`;
+  }
+
+  async updateError(projectId: string, errorId: string, operation: string, options?: any): Promise<any> {
+    const errorUpdateRequest = {
+      operation: operation,
+      ...options
+    };
+    return this.errorsApi.updateErrorOnProject(projectId, errorId, errorUpdateRequest)
   }
 
   registerTools(server: McpServer): void {

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -63,7 +63,7 @@ export class InsightHubClient implements Client {
         "X-Bugsnag-API": "true",
         "X-Version": "2",
       },
-      basePath: endpoint || this.getHost(this.projectApiKey, "api"),
+      basePath: endpoint || this.getHost(projectApiKey, "api"),
     });
     this.currentUserApi = new CurrentUserAPI(config);
     this.errorsApi = new ErrorAPI(config);

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -7,7 +7,7 @@ import Bugsnag from "../common/bugsnag.js";
 import NodeCache from "node-cache";
 import { Organization, Project } from "./client/api/CurrentUser.js";
 import { EventField, ProjectAPI } from "./client/api/Project.js";
-import { FilterObject, FilterObjectSchema } from "./client/api/filters.js";
+import { FilterObjectSchema } from "./client/api/filters.js";
 import { toolDescriptionTemplate, createParameter, createExample } from "../common/templates.js";
 
 const HUB_PREFIX = "00000";
@@ -600,7 +600,7 @@ export class InsightHubClient implements Client {
       },
       async (_args, _extra) => {
         try {
-          let projectFields = this.cache.get<EventField[]>(cacheKeys.CURRENT_PROJECT_EVENT_FILTERS);
+          const projectFields = this.cache.get<EventField[]>(cacheKeys.CURRENT_PROJECT_EVENT_FILTERS);
           if (!projectFields) throw new Error("No event filters found in cache.");
 
           return {

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -648,7 +648,7 @@ export class InsightHubClient implements Client {
                 "projectId",
                 "string",
                 true,
-                "ID of the project to query for errors"
+                "ID of the project that contains the error to be updated"
               )
             ]),
             createParameter(

--- a/insight-hub/client/api/CurrentUser.ts
+++ b/insight-hub/client/api/CurrentUser.ts
@@ -6,6 +6,7 @@ import { Configuration } from '../configuration.js';
 export interface Organization {
   id: string;
   name: string;
+  slug: string;
 }
 
 export type ListUserOrganizationsResponse = Organization[];
@@ -20,7 +21,7 @@ export interface Project {
 // --- API Class ---
 
 export class CurrentUserAPI extends BaseAPI {
-  static organizationFields: (keyof Organization)[] = ['id', 'name'];
+  static organizationFields: (keyof Organization)[] = ['id', 'name', 'slug'];
   static projectFields: (keyof Project)[] = ['id', 'name', 'slug', 'api_key'];
 
   constructor(configuration: Configuration) {

--- a/tests/unit/insight-hub/client.test.ts
+++ b/tests/unit/insight-hub/client.test.ts
@@ -435,7 +435,7 @@ describe('InsightHubClient', () => {
       });
     });
 
-    describe('findEventById', () => {
+    describe('getEventById', () => {
       it('should find event across multiple projects', async () => {
         const mockOrgs = [{ id: 'org-1', name: 'Test Org' }];
         const mockProjects = [
@@ -450,7 +450,7 @@ describe('InsightHubClient', () => {
           .mockRejectedValueOnce(new Error('Not found')) // proj-1
           .mockResolvedValueOnce({ body: mockEvent }); // proj-2
 
-        const result = await client.findEventById('event-1');
+        const result = await client.getEventById('event-1');
 
         expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith('proj-1', 'event-1');
         expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith('proj-2', 'event-1');
@@ -465,7 +465,7 @@ describe('InsightHubClient', () => {
         mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
         mockErrorAPI.viewEventById.mockRejectedValue(new Error('Not found'));
 
-        const result = await client.findEventById('event-1');
+        const result = await client.getEventById('event-1');
 
         expect(result).toBeUndefined();
       });

--- a/tests/unit/insight-hub/client.test.ts
+++ b/tests/unit/insight-hub/client.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InsightHubClient } from '../../../insight-hub/client.js';
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '../../../common/info.js';
-import { mock } from 'node:test';
 
 // Mock the dependencies
 const mockCurrentUserAPI = {
@@ -256,7 +255,6 @@ describe('InsightHubClient', () => {
 
     it('should initialize with project API key and set up event filters', async () => {
       const clientWithApiKey = new InsightHubClient('test-token', 'project-api-key');
-      const mockOrg = { id: 'org-1', name: 'Test Org' };
       const mockProjects = [
         { id: 'proj-1', name: 'Project 1', api_key: 'project-api-key' },
         { id: 'proj-2', name: 'Project 2', api_key: 'other-key' }
@@ -291,12 +289,10 @@ describe('InsightHubClient', () => {
     it('should throw error when project with API key not found', async () => {
       const clientWithApiKey = new InsightHubClient('test-token', 'non-existent-key');
       const mockOrg = { id: 'org-1', name: 'Test Org' };
-      const mockProjects = [
-        { id: 'proj-1', name: 'Project 1', api_key: 'other-key' }
-      ];
+      const mockProject = { id: 'proj-1', name: 'Project 1', api_key: 'other-key' };
 
       mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [mockOrg] });
-      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
+      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: [mockProject] });
 
       await expect(clientWithApiKey.initialize()).rejects.toThrow(
         'Unable to find project with API key non-existent-key in organization.'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,11 +14,7 @@ export default defineConfig({
         '*.config.*',
         '**/*.d.ts',
         // Auto-generated API client files
-        'insight-hub/client/api/CurrentUser.ts',
-        'insight-hub/client/api/Error.ts',
-        'insight-hub/client/api/Project.ts',
-        'insight-hub/client/api/base.ts',
-        'insight-hub/client/api/index.ts',
+        'insight-hub/client/api/*.ts',
         'insight-hub/client/index.ts',
         'insight-hub/client/configuration.ts',
         // Main entry point (tested via integration)


### PR DESCRIPTION
## Goal

Improve the prompting around getting error details.

## Design

[Structured Content](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) and [Output Schema](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema)s are not yet supported in VSCode, but probably soon will. However it seems we may as well add what we can to the text response for now.

## Changeset

* Added Output Format section to our hints on the tool;
* Added the error details and a dashboard URL to the error response, with appropriate descriptions;
* Bit of a reorg of the functions to be more consistent on how we access the cache;
* Added a project ID param to the update error function for consistency, so that the current project isn't assumed.

## Testing

Manual testing.

The URL isn't consistently used, but ChatGPT often shows it and they all will do so on explicit request.

Similarly, it often calls `get_insight_hub_error_latest_event` even though we're returning it, but we've sign posted this about as much as we can.