### PR TITLE
[InsightHub] Fix tests following change of API responses

### DIFF
--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -128,9 +128,6 @@ export class InsightHubClient implements Client {
       projects = await this.listProjects(org.id);
       this.cache.set(cacheKeys.PROJECTS, projects);
     }
-    if (!projects) {
-      throw new Error("No projects found.");
-    }
     return projects;
   }
 


### PR DESCRIPTION
## Goal

Fixes tests after changing the response of the Insight Hub API client

## Design

The response type changed so a lot of the tests failed

## Changeset

Updates tests to account for `body`

## Testing

Ran tests locally