### PR TITLE
Update 'get error details'

### DIFF
--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -311,10 +311,11 @@ export class InsightHubClient implements Client {
       "get_insight_hub_error",
       {
         description: toolDescriptionTemplate({
-          summary: "Get aggregate information about an error from a project, including detailed information on latest event (occurrence), use filters to narrow down results",
-          purpose: "Retrieve error details including metadata, breadcrumb and context for debugging.",
+          summary: "Get full details on an error, including aggregated and summarised data across all events (occurrences) and details of the latest event (occurrence), such as breadcrumbs, metadata and the stacktrace. Use the filters parameter to narrow down the summaries further.",
+          purpose: "Retrieve all the information required on a specified error to understand who it is affecting and why.",
           useCases: [
             "Investigate a specific error found through list_insight_hub_project_errors",
+            "Understand which types of user are affected by the error using summarised event data",
             "Get error details for debugging and root cause analysis",
             "Retrieve error metadata for incident reports and documentation"
           ],
@@ -359,7 +360,7 @@ export class InsightHubClient implements Client {
           outputFormat: "JSON object containing: " +
             " - error_details: Aggregated data about the error, including first and last seen occurrence" +
             " - latest_event: Detailed information about the most recent occurrence of the error, including stacktrace, breadcrumbs, user and context" +
-            " - pivots: List of pivots for the error, which can be used to analyze patterns in occurrences" +
+            " - pivots: List of pivots (summaries) for the error, which can be used to analyze patterns in occurrences" +
             " - url: A link to the error in the Insight Hub dashboard - this should be shown to the user for them to perform further analysis",
           examples: [
             createExample(

--- a/insight-hub/client.ts
+++ b/insight-hub/client.ts
@@ -340,6 +340,7 @@ export class InsightHubClient implements Client {
           outputFormat: "JSON object containing: " +
             " - error_details: Aggregated data about the error, including first and last seen occurrence" +
             " - latest_event: Detailed information about the most recent occurrence of the error, including stacktrace, breadcrumbs, user and context" +
+            " - pivots: List of pivots for the error, which can be used to analyze patterns in occurrences" +
             " - url: A link to the error in the Insight Hub dashboard - this should be shown to the user for them to perform further analysis",
           examples: [
             createExample(
@@ -373,6 +374,7 @@ export class InsightHubClient implements Client {
           const content = {
             error_details: errorDetails,
             latest_event: (await this.errorsApi.viewLatestEventOnError(args.errorId)).body,
+            pivots: (await this.errorsApi.listErrorPivots(project.id, args.errorId)).body || [],
             url: await this.getErrorUrl(project, args.errorId),
           }
           return {

--- a/insight-hub/client/api/Error.ts
+++ b/insight-hub/client/api/Error.ts
@@ -175,18 +175,16 @@ export class ErrorAPI extends BaseAPI {
     params.append('sort', 'timestamp');
     params.append('direction', 'desc');
     params.append('per_page', '1');
+    params.append('full_reports', 'true');
 
     // Add filters as a JSON string if provided
     const filters = options.filters ? toQueryString(options.filters) : '';
+    const url = `/projects/${projectId}/events?${params}&${filters}`;
 
-    const url = params.toString()
-      ? `/projects/${projectId}/events?${params}&${filters}`
-      : `/projects/${projectId}/events`;
-      
-    return (await this.request<Event[]>({
+    return await this.request<Event[]>({
       method: 'GET',
       url,
-    })) as ApiResponse<Event[]>;
+    });
   }
 
   /**

--- a/insight-hub/client/api/Error.ts
+++ b/insight-hub/client/api/Error.ts
@@ -167,20 +167,9 @@ export class ErrorAPI extends BaseAPI {
    * List the Events on a Project
    * GET /projects/{project_id}/events
    */
-  async listEventsOnProject(projectId: string, options: ViewLatestEventOnErrorOptions = {}): Promise<ApiResponse<Event[]>> {
-    // Build query parameters
-    const params = new URLSearchParams();
-    
-    // Add sorting and pagination parameters to get the latest event
-    params.append('sort', 'timestamp');
-    params.append('direction', 'desc');
-    params.append('per_page', '1');
-    params.append('full_reports', 'true');
-
-    // Add filters as a JSON string if provided
-    const filters = options.filters ? toQueryString(options.filters) : '';
-    const url = `/projects/${projectId}/events?${params}&${filters}`;
-
+  async listEventsOnProject(projectId: string, queryString = ''): Promise<ApiResponse<Event[]>> {
+    const url = `/projects/${projectId}/events${queryString}`;
+      
     return await this.request<Event[]>({
       method: 'GET',
       url,

--- a/insight-hub/client/api/Error.ts
+++ b/insight-hub/client/api/Error.ts
@@ -51,6 +51,29 @@ export interface ListProjectErrorsOptions {
   [key: string]: any;
 }
 
+// Pivot-related interfaces based on the Data Access API
+export interface PivotApiView {
+  event_field_display_id: string;
+  name: string;
+  cardinality?: number;
+  values?: PivotValueApiView[];
+}
+
+export interface PivotValueApiView {
+  name: string;
+  events_count: number;
+  users_count?: number;
+  percentage?: number;
+}
+
+export interface ListPivotsOptions {
+  filters?: FilterObject;
+  summary_size?: number;
+  pivots?: string[]; // Array of field names to pivot by
+  per_page?: number;
+  [key: string]: any;
+}
+
 export const ErrorOperations = [
   'override_severity',
   'assign',
@@ -191,5 +214,43 @@ export class ErrorAPI extends BaseAPI {
       url,
       body: data,
     })) as ApiResponse<ErrorApiView>;
+  }
+
+  /**
+   * List Pivots on an Error
+   * GET /projects/{project_id}/errors/{error_id}/pivots
+   */
+  async listErrorPivots(projectId: string, errorId: string, options: ListPivotsOptions = {}): Promise<ApiResponse<PivotApiView[]>> {
+    const params = new URLSearchParams();
+    
+    if (options.filters) {
+      const filterParams = new URLSearchParams(toQueryString(options.filters));
+      filterParams.forEach((value, key) => {
+        params.append(key, value);
+      });
+    }
+    
+    if (options.summary_size !== undefined) {
+      params.append('summary_size', options.summary_size.toString());
+    }
+    
+    if (options.pivots && options.pivots.length > 0) {
+      options.pivots.forEach(pivot => {
+        params.append('pivots[]', pivot);
+      });
+    }
+    
+    if (options.per_page !== undefined) {
+      params.append('per_page', options.per_page.toString());
+    }
+
+    const url = params.toString()
+      ? `/projects/${projectId}/errors/${errorId}/pivots?${params}`
+      : `/projects/${projectId}/errors/${errorId}/pivots`;
+      
+    return await this.request<PivotApiView[]>({
+      method: 'GET',
+      url,
+    });
   }
 }

--- a/insight-hub/client/api/Error.ts
+++ b/insight-hub/client/api/Error.ts
@@ -35,6 +35,9 @@ export interface ViewErrorOnProjectOptions {
 }
 
 export interface ViewLatestEventOnErrorOptions {
+  base?: string; // date-time format
+  filters?: FilterObject; // Additional filters to apply along with the error.id filter
+  full_reports?: boolean;
   [key: string]: any;
 }
 
@@ -158,6 +161,32 @@ export class ErrorAPI extends BaseAPI {
       method: 'GET',
       url,
     })) as ApiResponse<ViewLatestEventOnErrorResponse>;
+  }
+
+  /**
+   * List the Events on a Project
+   * GET /projects/{project_id}/events
+   */
+  async listEventsOnProject(projectId: string, options: ViewLatestEventOnErrorOptions = {}): Promise<ApiResponse<Event[]>> {
+    // Build query parameters
+    const params = new URLSearchParams();
+    
+    // Add sorting and pagination parameters to get the latest event
+    params.append('sort', 'timestamp');
+    params.append('direction', 'desc');
+    params.append('per_page', '1');
+
+    // Add filters as a JSON string if provided
+    const filters = options.filters ? toQueryString(options.filters) : '';
+
+    const url = params.toString()
+      ? `/projects/${projectId}/events?${params}&${filters}`
+      : `/projects/${projectId}/events`;
+      
+    return (await this.request<Event[]>({
+      method: 'GET',
+      url,
+    })) as ApiResponse<Event[]>;
   }
 
   /**

--- a/tests/unit/insight-hub/client.test.ts
+++ b/tests/unit/insight-hub/client.test.ts
@@ -591,7 +591,6 @@ describe('InsightHubClient', () => {
 
       const registeredTools = mockServer.registerTool.mock.calls.map((call: any) => call[0]);
       expect(registeredTools).toContain('get_insight_hub_error');
-      expect(registeredTools).toContain('get_insight_hub_error_latest_event');
       expect(registeredTools).toContain('get_insight_hub_event_details');
       expect(registeredTools).toContain('list_insight_hub_project_errors');
       expect(registeredTools).toContain('get_project_event_filters');
@@ -729,13 +728,13 @@ describe('InsightHubClient', () => {
         const mockProject = { id: 'proj-1', name: 'Project 1', slug: 'my-project' };
         const mockError = { id: 'error-1', message: 'Test error' };
         const mockOrg = { id: 'org-1', name: 'Test Org', slug: 'test-org' };
-        const mockEvent = { id: 'event-1', timestamp: '2023-01-01' };
+        const mockEvents = [{ id: 'event-1', timestamp: '2023-01-01' }];
         const mockPivots = [{ id: 'pivot-1', name: 'test-pivot' }];
 
         mockCache.get.mockReturnValueOnce(mockProject)
           .mockReturnValueOnce(mockOrg);
         mockErrorAPI.viewErrorOnProject.mockResolvedValue({ body: mockError });
-        mockErrorAPI.viewLatestEventOnError.mockResolvedValue({ body: mockEvent });
+        mockErrorAPI.listEventsOnProject.mockResolvedValue({ body: mockEvents });
         mockErrorAPI.listErrorPivots.mockResolvedValue({ body: mockPivots });
 
         client.registerTools(mockServer);
@@ -747,7 +746,7 @@ describe('InsightHubClient', () => {
         expect(mockErrorAPI.viewErrorOnProject).toHaveBeenCalledWith('proj-1', 'error-1');
         expect(result.content[0].text).toBe(JSON.stringify({
           error_details: mockError,
-          latest_event: mockEvent,
+          latest_event: mockEvents[0],
           pivots: mockPivots,
           url: `https://app.bugsnag.com/${mockOrg.slug}/${mockProject.slug}/errors/error-1`
         }));
@@ -759,30 +758,6 @@ describe('InsightHubClient', () => {
           .find((call: any) => call[0] === 'get_insight_hub_error')[2];
 
         await expect(toolHandler({})).rejects.toThrow('Both projectId and errorId arguments are required');
-      });
-    });
-
-    describe('get_insight_hub_error_latest_event tool handler', () => {
-      it('should get latest error event', async () => {
-        const mockEvent = { id: 'event-1', timestamp: '2023-01-01' };
-        mockErrorAPI.viewLatestEventOnError.mockResolvedValue({ body: mockEvent });
-
-        client.registerTools(mockServer);
-        const toolHandler = mockServer.registerTool.mock.calls
-          .find((call: any) => call[0] === 'get_insight_hub_error_latest_event')[2];
-
-        const result = await toolHandler({ errorId: 'error-1' });
-
-        expect(mockErrorAPI.viewLatestEventOnError).toHaveBeenCalledWith('error-1');
-        expect(result.content[0].text).toBe(JSON.stringify(mockEvent));
-      });
-
-      it('should throw error when errorId missing', async () => {
-        client.registerTools(mockServer);
-        const toolHandler = mockServer.registerTool.mock.calls
-          .find((call: any) => call[0] === 'get_insight_hub_error_latest_event')[2];
-
-        await expect(toolHandler({})).rejects.toThrow('errorId argument is required');
       });
     });
 

--- a/tests/unit/insight-hub/client.test.ts
+++ b/tests/unit/insight-hub/client.test.ts
@@ -743,12 +743,14 @@ describe('InsightHubClient', () => {
 
         const result = await toolHandler({ errorId: 'error-1' });
 
+        const queryString = '?filters[error][][type]=eq&filters[error][][value]=error-1'
+        const encodedQueryString = encodeURI(queryString);
         expect(mockErrorAPI.viewErrorOnProject).toHaveBeenCalledWith('proj-1', 'error-1');
         expect(result.content[0].text).toBe(JSON.stringify({
           error_details: mockError,
           latest_event: mockEvents[0],
           pivots: mockPivots,
-          url: `https://app.bugsnag.com/${mockOrg.slug}/${mockProject.slug}/errors/error-1`
+          url: `https://app.bugsnag.com/${mockOrg.slug}/${mockProject.slug}/errors/error-1${encodedQueryString}`
         }));
       });
 

--- a/tests/unit/insight-hub/client.test.ts
+++ b/tests/unit/insight-hub/client.test.ts
@@ -18,6 +18,7 @@ const mockErrorAPI = {
   listProjectErrors: vi.fn(),
   updateErrorOnProject: vi.fn(),
   listErrorPivots: vi.fn(),
+  listEventsOnProject: vi.fn()
 } satisfies Omit<ErrorAPI, keyof BaseAPI>;
 
 const mockProjectAPI = {


### PR DESCRIPTION
## Goal

The PR enhances the MCP server's error analysis capabilities by:

- Consolidating error data retrieval into a single comprehensive tool
- Adding filtering support to narrow down error analysis
- Implementing pivot analysis to understand error patterns and distributions
- Improving API efficiency by reducing the number of separate requests needed
- Providing richer error context with latest events and analytical insights

## Design

- Single Response Object: Error details, latest event, and pivot data now returned together
- Graceful Degradation: Individual components (events, pivots) fail gracefully without breaking the entire response
- Optimized Queries: Latest events retrieved with timestamp-based sorting and pagination limits

## Changeset

- New method for project-scoped event listing `listEventsOnProject`
- New method for error pivot analysis: `listErrorPivots`
- Updated `get_insight_hub_error` tool to allow filtering, and include pivots
- Remove `get_insight_hub_error_latest_event`

## Testing

- Updated mocks to use satisfies for type safety with proper API interface coverage
- Added test coverage for error pivot data retrieval and response formatting
- Ensured filter parameters are properly validated and passed through API calls
- Verified graceful degradation when individual data components fail