### PR TITLE
docs: remove temporary branch rule

### DIFF
--- a/.github/workflows/docs-as-code.yaml
+++ b/.github/workflows/docs-as-code.yaml
@@ -5,9 +5,8 @@ on:
     branches:
       - main
       - next
-      - 'tom/docs-as-code'
-    # paths:
-      # - 'docs/**'
+    paths:
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       log_level:


### PR DESCRIPTION
## Goal

Removes the branch name and reinstates the path check for the docs-as-code job, that was in place to allow it to be tested and reviewed on a separate branch.

The merge to `next` worked [successfully](https://github.com/SmartBear/smartbear-mcp/actions/runs/16779502450), so these can be removed.