### PR TITLE
chore(workflows): sync main->next cleanup + manual dispatch, auto-merge, conflict issues

### DIFF
--- a/.github/workflows/sync-main-to-next.yml
+++ b/.github/workflows/sync-main-to-next.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    # Manual trigger to run the same sync logic (main -> next)
+    {}
 
 permissions:
   contents: write

--- a/.github/workflows/sync-main-to-next.yml
+++ b/.github/workflows/sync-main-to-next.yml
@@ -120,13 +120,17 @@ jobs:
 
                 console.log(`✅ Created PR #${pr.data.number}: ${pr.data.html_url}`);
 
-                // Request review from team
-                await github.rest.pulls.requestReviewers({
-                  owner,
-                  repo,
-                  pull_number: pr.data.number,
-                  team_reviewers: ["bugsnag-dev"]
-                });
+                // Request review from team (tolerate errors)
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner,
+                    repo,
+                    pull_number: pr.data.number,
+                    team_reviewers: ["bugsnag-dev"]
+                  });
+                } catch (e) {
+                  console.log('Reviewer request skipped or failed:', e.message);
+                }
 
                 // Enable auto-merge (requires GraphQL)
                 const enableAutoMergeQuery = `


### PR DESCRIPTION
## Goal

Ensure the next branch stays up to date with main after releases by automatically creating a PR from main to next on each push to main, with manual dispatch support. Keep auto-merge enabled by default and conflict issue creation enabled.

## Design

- Workflow triggers on push to main and via workflow_dispatch.
- Uses actions/github-script to create a branch from next, merges main into it, opens a PR to next, requests reviewers (wrapped in try/catch to avoid failing the workflow), and enables auto-merge via GraphQL.
- Posts a summary and creates an issue if conflicts occur.

## Changeset

- .github/workflows/sync-main-to-next.yml
  - Added manual dispatch trigger.
  - Ensured auto-merge enablement remains by default.
  - Kept conflict issue creation enabled.
  - Wrapped reviewer request in try/catch.

## Testing

- Verified behavior on test branches, including PR creation and auto-merge path.
- Cleaned up test-only logic for production usage (main -> next).
