### PR TITLE
Pact 4423 mcp tool generate pacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY common /app/common
 COPY reflect /app/reflect
 COPY insight-hub /app/insight-hub
 COPY api-hub /app/api-hub
+COPY pactflow /app/pactflow
 COPY index.ts /app/
 COPY package.json package-lock.json tsconfig.json /app/
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </div>
 <br />
 
-A Model Context Protocol (MCP) server which provides AI assistants with seamless access to SmartBear's suite of testing and monitoring tools, including [Insight Hub](https://www.smartbear.com/insight-hub), [Reflect](https://reflect.run), and [API Hub](https://www.smartbear.com/api-hub).
+A Model Context Protocol (MCP) server which provides AI assistants with seamless access to SmartBear's suite of testing and monitoring tools, including [Insight Hub](https://www.smartbear.com/insight-hub), [Reflect](https://reflect.run), [API Hub](https://www.smartbear.com/api-hub) and [PactFlow](https://pactflow.io/)
 
 ## What is MCP?
 
@@ -68,7 +68,9 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
         "INSIGHT_HUB_AUTH_TOKEN": "${input:insight_hub_auth_token}",
         "INSIGHT_HUB_PROJECT_API_KEY": "${input:insight_hub_project_api_key}",
         "REFLECT_API_TOKEN": "${input:reflect_api_token}",
-        "API_HUB_API_KEY": "${input:api_hub_api_key}"
+        "API_HUB_API_KEY": "${input:api_hub_api_key}",
+        "PACT_BROKER_BASE_URL": "${input:pact_broker_base_url}",
+        "PACT_BROKER_TOKEN": "${input.pact_broker_token}",
       }
     }
   },
@@ -96,7 +98,19 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
          "type": "promptString",
          "description": "API Hub API Key - leave blank to disable API Hub tools",
          "password": true
-      }
+      },
+      {
+         "id": "pact_broker_base_url",
+         "type": "promptString",
+         "description": "Pactflow base url - leave blank to disable Pactflow tools",
+         "password": true
+      },
+      {
+         "id": "pact_broker_token",
+         "type": "promptString",
+         "description": "Pactflow token - leave blank to disable Pactflow tools",
+         "password": true
+      },
   ]
 }
 ```
@@ -119,7 +133,9 @@ Add the following configuration to your `claude_desktop_config.json` to launch t
         "INSIGHT_HUB_AUTH_TOKEN": "your_personal_auth_token",
         "INSIGHT_HUB_PROJECT_API_KEY": "your_project_api_key",
         "REFLECT_API_TOKEN": "your_reflect_token",
-        "API_HUB_API_KEY": "your_api_hub_key"
+        "API_HUB_API_KEY": "your_api_hub_key",
+        "PACT_BROKER_BASE_URL": "your_pactflow_base_url",
+        "PACT_BROKER_TOKEN": "your_pactflow_token"
       }
     }
   }
@@ -172,7 +188,9 @@ For developers who want to contribute to the SmartBear MCP server, customize its
             "INSIGHT_HUB_AUTH_TOKEN": "${input:insight_hub_auth_token}",
             "INSIGHT_HUB_PROJECT_API_KEY": "${input:insight_hub_project_api_key}",
             "REFLECT_API_TOKEN": "${input:reflect_api_token}",
-            "API_HUB_API_KEY": "${input:api_hub_api_key}"
+            "API_HUB_API_KEY": "${input:api_hub_api_key}",
+            "PACT_BROKER_BASE_URL": "${input:pact_broker_base_url}",
+            "PACT_BROKER_TOKEN": "${input.pact_broker_token}",
           }
         }
       },
@@ -200,7 +218,19 @@ For developers who want to contribute to the SmartBear MCP server, customize its
           "type": "promptString",
           "description": "API Hub API Key - leave blank to disable API Hub tools",
           "password": true
-        }
+        },
+        {
+         "id": "pact_broker_base_url",
+         "type": "promptString",
+         "description": "Pactflow base url - leave blank to disable Pactflow tools",
+         "password": true
+        },
+        {
+          "id": "pact_broker_token",
+          "type": "promptString",
+          "description": "Pactflow token - leave blank to disable Pactflow tools",
+          "password": true
+        },
       ]
     }
     ```
@@ -209,7 +239,7 @@ For developers who want to contribute to the SmartBear MCP server, customize its
 5. **Local testing** using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) web interface:
 
     ```bash
-    INSIGHT_HUB_AUTH_TOKEN="your_token" REFLECT_API_TOKEN="your_reflect_token" API_HUB_API_KEY="your_api_hub_key" npx @modelcontextprotocol/inspector npx @smartbear/mcp@latest
+    INSIGHT_HUB_AUTH_TOKEN="your_token" REFLECT_API_TOKEN="your_reflect_token" API_HUB_API_KEY="your_api_hub_key" PACT_BROKER_BASE_URL="your-pactflow-url" PACT_BROKER_TOKEN="your-pactflow-token" npx @modelcontextprotocol/inspector npx @smartbear/mcp@latest
     ```
 
 ## License

--- a/pactflow/client.ts
+++ b/pactflow/client.ts
@@ -1,0 +1,144 @@
+import { GenerationInput, GenerationResponse, StatusResponse } from "./client/ai.js";
+import { ClientType, TOOLS } from "./client/tools.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
+import { Client } from "../common/types.js";
+
+
+// Tool definitions for PactFlow AI API client
+export class PactflowClient implements Client {
+    private headers: {
+      Authorization: string;
+      "Content-Type": string;
+      "User-Agent": string;
+    };
+    private aiBaseUrl: string;
+    private baseUrl: string;
+    private clientType: ClientType;
+
+    constructor(auth: string | { username: string; password: string }, baseUrl: string, clientType: ClientType) {
+      // Set headers based on the type of auth provided
+      if (typeof auth === "string") { 
+        this.headers = {
+          Authorization: `Bearer ${auth}`,
+          "Content-Type": "application/json",
+          "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        };
+      } else {
+        this.headers = {
+          Authorization: `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString("base64")}`,
+          "Content-Type": "application/json",
+          "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        };
+      }
+      this.baseUrl = baseUrl;
+      this.aiBaseUrl = `${this.baseUrl}/api/ai`;
+      this.clientType = clientType;
+    }
+  
+    async generate(body: GenerationInput): Promise<GenerationResponse> {
+      // Submit the generation request
+      const response = await fetch(`${this.aiBaseUrl}/generate`, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(body),
+        });
+  
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+  
+      const status_response: StatusResponse = await response.json();
+      return await this.pollForCompletion<GenerationResponse>(
+        status_response,
+        "Generation"
+      );
+    }
+  
+    async getStatus(
+      statusUrl: string
+    ): Promise<{ status: number; isComplete: boolean }> {
+      const response = await fetch(statusUrl, {
+        method: "HEAD",
+        headers: this.headers,
+      });
+  
+      return {
+        status: response.status,
+        isComplete: response.status === 200,
+      };
+    }
+  
+    async getResult<T>(resultUrl: string): Promise<T> {
+      const response = await fetch(resultUrl, {
+        method: "GET",
+        headers: this.headers,
+      });
+      // Check if the response is OK (status 200)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+  
+      return response.json();
+    }
+  
+    private async pollForCompletion<T>(
+      status_response: StatusResponse,
+      operationName: string
+    ): Promise<T> {
+      // Polling for completion
+      const startTime = Date.now();
+      const timeout = 120000; // 120 seconds
+      const pollInterval = 1000; // 1 second
+  
+      while (Date.now() - startTime < timeout) {
+        const statusCheck = await this.getStatus(status_response.status_url);
+
+        if (statusCheck.isComplete) {
+          // Operation is complete, get the result
+          return await this.getResult<T>(status_response.result_url);
+        }
+  
+        if (statusCheck.status !== 202) {
+          throw new Error(
+            `${operationName} failed with status: ${statusCheck.status}`
+          );
+        }
+  
+        // Wait before next poll
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      }
+  
+      throw new Error(
+        `${operationName} timed out after ${timeout / 1000} seconds`
+      );
+    }
+    
+    registerTools(server: McpServer): void {
+      for (const tool of TOOLS.filter(t => t.clients.includes(this.clientType))) {
+        server.tool(
+          tool.name,
+          tool.description,
+          tool.inputSchema,
+          async (args: any, _extra: any) => {
+            const handler = (this as any)[tool.handler];
+            if (typeof handler !== "function") {
+              throw new Error(`Handler '${tool.handler}' not found on PactClient`);
+            }
+            
+            const result = await handler.call(this, args);
+            
+            // Use custom response formatter if provided
+            if (tool.formatResponse) {
+              return tool.formatResponse(result);
+            }
+
+            // Default fallback
+            return {
+              content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            };
+          }
+        );
+      }
+    }
+}

--- a/pactflow/client/ai.ts
+++ b/pactflow/client/ai.ts
@@ -1,0 +1,95 @@
+// Type definitions for PactFlow AI API
+export type GenerationLanguage =
+  | "javascript"
+  | "typescript"
+  | "java"
+  | "golang"
+  | "dotnet"
+  | "kotlin"
+  | "swift"
+  | "php";
+
+export type HttpMethod =
+  | "GET"
+  | "PUT"
+  | "POST"
+  | "DELETE"
+  | "OPTIONS"
+  | "HEAD"
+  | "PATCH"
+  | "TRACE";
+
+export interface FileInput {
+  filename?: string;
+  body: string;
+  language?: string;
+}
+
+export interface EndpointMatcher {
+  path?: string;
+  methods?: HttpMethod[];
+  statusCodes?: (number | string)[];
+  operationId?: string;
+}
+
+export interface OpenApi {
+  openapi: string;
+  paths: Record<string, Record<string, any>>;
+  components?: Record<string, Record<string, any>>;
+  [key: string]: any;
+}
+
+export interface OpenApiWithMatcher {
+  document: OpenApi;
+  matcher: EndpointMatcher;
+}
+
+export interface RequestResponsePair {
+  request: FileInput;
+  response: FileInput;
+}
+
+export interface GenerationInput {
+  language?: GenerationLanguage;
+  requestResponse?: RequestResponsePair;
+  code?: FileInput[];
+  openapi?: OpenApiWithMatcher;
+  additionalInstructions?: string;
+  testTemplate?: FileInput;
+}
+
+export interface StatusResponse {
+  status: "accepted"; 
+  session_id: string;
+  submitted_at: string;
+  status_url: string;
+  result_url: string;
+}
+
+export interface SessionStatusResponse {
+  status: "completed" | "accepted" | "invalid";
+}
+
+export interface GenerationResponse {
+  id?: string;
+  code: string;
+  language: string;
+}
+
+export interface RefineInput {
+  pactTests: FileInput;
+  code?: FileInput[];
+  userInstructions?: string;
+  errorMessages?: string[];
+  openapi?: OpenApiWithMatcher;
+}
+
+export interface RefineRecommendation {
+  recommendation: string;
+  diff?: string;
+  confidence?: number;
+}
+
+export interface RefineResponse {
+  recommendations: RefineRecommendation[];
+}

--- a/pactflow/client/tools.ts
+++ b/pactflow/client/tools.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+
+export type ClientType = "pactflow" | "pactbroker";
+
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema:  z.ZodRawShape;
+  handler: string;
+  clients: ClientType[];
+  formatResponse?: (result: any) => any; // optional custom response format
+};
+
+export const TOOLS: ToolDefinition[] = [
+  {
+    name: "generate_pact",
+    description:
+      "Generate Pact tests using PactFlow AI. You can provide one or more of the following input types: (1) request/response pairs for specific interactions, (2) code files to analyze and extract interactions from, and/or (3) OpenAPI document to generate tests for specific endpoints. When providing an OpenAPI document, a matcher is required to specify which endpoints to generate tests for.",
+    inputSchema: {
+      language: z
+        .enum([
+          "typescript",
+          "java",
+          "golang",
+          "dotnet",
+          "kotlin",
+          "swift",
+          "php",
+        ])
+        .optional()
+        .describe(
+          "Target language for the generated Pact tests. If not provided, will be inferred from other inputs."
+        ),
+      requestResponse: z
+        .object({
+          request: z.object({
+            filename: z
+              .string()
+              .optional()
+              .describe(
+                "Optional filename for the request (helps with context)"
+              ),
+            body: z
+              .string()
+              .describe(
+                "Request content/payload - can be HTTP request, JSON, or any format describing the request"
+              ),
+            language: z
+              .string()
+              .optional()
+              .describe(
+                "Language hint for better parsing (e.g., 'json', 'http', 'yaml')"
+              ),
+          }),
+          response: z.object({
+            filename: z
+              .string()
+              .optional()
+              .describe(
+                "Optional filename for the response (helps with context)"
+              ),
+            body: z
+              .string()
+              .describe(
+                "Response content/payload - can be HTTP response, JSON, or any format describing the response"
+              ),
+            language: z
+              .string()
+              .optional()
+              .describe(
+                "Language hint for better parsing (e.g., 'json', 'http', 'yaml')"
+              ),
+          }),
+        })
+        .optional()
+        .describe(
+          "Direct request/response pair for a specific interaction. Use this when you have concrete examples of API requests and responses"
+        ),
+      code: z
+        .array(
+          z.object({
+            filename: z
+              .string()
+              .optional()
+              .describe("Filename (helps identify file type and context)"),
+            body: z
+              .string()
+              .describe(
+                "Complete file contents - client code, models, test files, etc."
+              ),
+            language: z
+              .string()
+              .optional()
+              .describe(
+                "Programming language (e.g., 'javascript', 'java', 'python') for better analysis"
+              ),
+          })
+        )
+        .optional()
+        .describe(
+          "Collection of source code files to analyze and extract API interactions from. Include client code, data models, existing tests, or any code that makes API calls"
+        ),
+      openapi: z
+        .object({
+          document: z
+            .object({
+              openapi: z.string().describe("OpenAPI version (e.g., '3.0.0')"),
+              paths: z
+                .record(z.record(z.any()))
+                .describe(
+                  "OpenAPI paths object containing all API endpoints"
+                ),
+              components: z
+                .record(z.record(z.any()))
+                .optional()
+                .describe(
+                  "OpenAPI components section (schemas, responses, etc.)"
+                ),
+            })
+            .passthrough()
+            .describe("The complete OpenAPI document describing the API"),
+          matcher: z
+            .object({
+              path: z
+                .string()
+                .optional()
+                .describe(
+                  "Path pattern to match specific endpoints (e.g., '/users/{id}', '/users/*', '/users/**'). Supports glob patterns: ? (single char), * (excluding /), ** (including /)"
+                ),
+              methods: z
+                .array(
+                  z.enum([
+                    "GET",
+                    "PUT",
+                    "POST",
+                    "DELETE",
+                    "OPTIONS",
+                    "HEAD",
+                    "PATCH",
+                    "TRACE",
+                  ])
+                )
+                .optional()
+                .describe(
+                  "HTTP methods to include (e.g., ['GET', 'POST']). If not specified, all methods are matched"
+                ),
+              statusCodes: z
+                .array(z.union([z.number(), z.string()]))
+                .optional()
+                .describe(
+                  "Response status codes to include (e.g., [200, '2XX', 404]). Use 'X' as wildcard (e.g., '2XX' for 200-299). Defaults to successful codes (2XX)"
+                ),
+              operationId: z
+                .string()
+                .optional()
+                .describe(
+                  "OpenAPI operation ID to match (e.g., 'getUserById', 'get*'). Supports glob patterns"
+                ),
+            })
+            .required()
+            .describe(
+              "REQUIRED: Matcher to specify which endpoints from the OpenAPI document to generate tests for. At least one matcher field must be provided"
+            ),
+        })
+        .optional()
+        .describe(
+          "OpenAPI document for generating tests from API specifications. IMPORTANT: When providing an OpenAPI document, the matcher field is REQUIRED to specify which endpoints to generate tests for. This filters the relevant interactions from potentially large OpenAPI documents"
+        ),
+      additionalInstructions: z
+        .string()
+        .optional()
+        .describe(
+          "Optional free-form instructions to guide the generation process (e.g., 'Focus on error scenarios', 'Include authentication headers', 'Use specific test framework patterns')"
+        ),
+      testTemplate: z
+        .object({
+          filename: z
+            .string()
+            .optional()
+            .describe("Template filename for context"),
+          body: z
+            .string()
+            .describe(
+              "Existing test template or example to use as a basis for the generated tests"
+            ),
+          language: z
+            .string()
+            .optional()
+            .describe(
+              "Template language/framework (e.g., 'javascript', 'junit', 'jest')"
+            ),
+        })
+        .optional()
+        .describe(
+          "Optional test template to use as a basis for generation. Helps ensure generated tests follow your specific patterns, frameworks, and coding standards"
+        ),
+    },
+    handler: "generate",
+    clients: ["pactflow"], // ONLY pactflow
+  },
+  // Add more tools here
+];

--- a/tests/pactflow/tools.test.ts
+++ b/tests/pactflow/tools.test.ts
@@ -1,0 +1,43 @@
+// tools.test.ts
+import { z } from "zod";
+import { TOOLS, ToolDefinition } from "../../pactflow/client/tools.js"; // adjust the import path
+import { describe, it, expect } from 'vitest';
+
+
+describe("TOOLS definition for 'generate_pact'", () => {
+  it("defines the generate_pact tool with correct metadata", () => {
+    const tool = TOOLS.find((t) => t.name === "generate_pact");
+    expect(tool).toBeDefined();
+    expect(tool?.description).toMatch(/Generate Pact tests using PactFlow AI/);
+    expect(tool?.clients).toEqual(["pactflow"]);
+    expect(tool?.handler).toBe("generate");
+    expect(typeof tool?.inputSchema).toBe("object");
+  });
+
+  it("enforces presence of matcher when openapi input is provided", () => {
+    const tool = TOOLS.find((t) => t.name === "generate_pact") as ToolDefinition;
+    const schema = z.object(tool.inputSchema);
+
+    const invalidOpenapi = {
+      openapi: {
+        document: {
+          openapi: "3.0.0",
+          paths: {},
+        },
+      },
+    };
+
+    expect(() => schema.parse(invalidOpenapi)).toThrow(/matcher/);
+  });
+
+  it("rejects unsupported language values in the language field", () => {
+    const tool = TOOLS.find((t) => t.name === "generate_pact") as ToolDefinition;
+    const schema = z.object(tool.inputSchema);
+
+    const invalidData = {
+      language: "ruby", // not allowed in enum
+    };
+
+    expect(() => schema.parse(invalidData)).toThrow(/Invalid enum value/);
+  });
+});


### PR DESCRIPTION
This PR introduces the PactFlow Client, enabling Pact test generation via `Pactflow AI` and laying the groundwork for future Pact Broker support.

**Integration of PactFlow Client:**

- `pactflow/client.ts` – Added the PactflowClient class, which provides methods for interacting with PactFlow's APIs. This includes authentication handling, dynamic tool registration with the McpServer, and request configuration.
- `pactflow/client/ai.ts` – Defines interfaces for PactFlow AI routes.
- `pactflow/client/base.ts` – Defines interfaces for shared PactFlow/Pact Broker routes.
- `pactflow/client/tools.ts` – Defines tools for registration, with clientType support for filtering.


**Note:**  Since We’re adding support for both Pactflow and Pact Broker, tools are registered dynamically based on the clientType. 