### PR TITLE
fix manifest for doc publishing

### DIFF
--- a/docs/products/SmartBear MCP Server/manifest.json
+++ b/docs/products/SmartBear MCP Server/manifest.json
@@ -1,6 +1,6 @@
 {
     "productMetadata": {
-        "description": "A Model Context Protocol (MCP) server which provides AI assistants with seamless access to SmartBear's suite of testing and monitoring tools, including [Insight Hub](https://www.smartbear.com/insight-hub), [Reflect](https://reflect.run), and [API Hub](https://www.smartbear.com/api-hub).",
+        "description": "Integrate capabilities from SmartBear's API Hub, Test Hub, and Insight Hub into your AI development workflow.",
         "slug": "smartbear-mcp",
         "public": true,
         "hidden": false,
@@ -27,31 +27,31 @@
             "contentUrl": "mcp-server-capabilities.md"
         },
         {
-            "order": 0,
+            "order": 2,
             "parent": "mcp-server-capabilities",
-            "name": "API Hub integration",
+            "name": "API Hub Integration",
             "slug": "api-hub-integration",
             "type": "markdown",
             "contentUrl": "api-hub-integration.md"
         },
         {
-            "order": 1,
+            "order": 3,
             "parent": "mcp-server-capabilities",
-            "name": "Test Hub integration",
+            "name": "Test Hub Integration",
             "slug": "test-hub-integration",
             "type": "markdown",
             "contentUrl": "test-hub-integration.md"
         },
         {
-            "order": 2,
+            "order": 4,
             "parent": "mcp-server-capabilities",
-            "name": "Insight Hub integration",
+            "name": "Insight Hub Integration",
             "slug": "insight-hub-integration",
             "type": "markdown",
             "contentUrl": "insight-hub-integration.md"
         },
         {
-            "order": 2,
+            "order": 5,
             "parent": "",
             "name": "Getting Started",
             "slug": "getting-started",
@@ -59,7 +59,7 @@
             "contentUrl": "getting-started.md"
         },
         {
-            "order": 3,
+            "order": 6,
             "parent": "",
             "name": "Best Practices",
             "slug": "best-practices",
@@ -67,7 +67,7 @@
             "contentUrl": "best-practices.md"
         },
         {
-            "order": 4,
+            "order": 7,
             "parent": "",
             "name": "Troubleshooting",
             "slug": "troubleshooting",


### PR DESCRIPTION
## Goal

To ensure that all docs changes get autopublished.


## Changeset

Adjusted the manifest order to ensure TOC entries are correct. Adjusted the description to match the developer portal product description
