### PR TITLE
feat: add support for can-i-deploy in pactflow and pact_broker client

### DIFF
--- a/docs/custom-words.txt
+++ b/docs/custom-words.txt
@@ -7,3 +7,4 @@ SWAGGERHUB
 undiscarded
 undiscard
 pactflow
+pacticipant

--- a/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
+++ b/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
@@ -17,6 +17,10 @@ The PactFlow Contract testing client provides comprehensive tools which makes te
 
 - Review Pact tests and provide a list of recommendations that can be applied.
 
+### Can I Deploy
+
+- Determine whether a specific version of a pacticipant can be safely deployed into a given environment.
+
 ## Configuration Notes
 
 - **Required Environment Variables**: `PACT_BROKER_BASE_URL` is required for all operations.

--- a/pactflow/client.ts
+++ b/pactflow/client.ts
@@ -200,8 +200,7 @@ export class PactflowClient implements Client {
 
     registerTools(register: RegisterToolsFunction, _getInput: GetInputFunction): void {
       for (const tool of TOOLS.filter(t => t.clients.includes(this.clientType))) {
-        const {handler, clients, formatResponse, ...toolparams} = tool;
-        void clients;
+        const {handler, clients: _, formatResponse, ...toolparams} = tool; // eslint-disable-line @typescript-eslint/no-unused-vars
         register(toolparams, async (args, _extra) => {
             const handler_fn = (this as any)[handler];
             if (typeof handler_fn !== "function") {

--- a/pactflow/client.ts
+++ b/pactflow/client.ts
@@ -2,7 +2,7 @@ import { GenerationInput, GenerationResponse, RefineInput, RefineResponse, Statu
 import { ClientType, TOOLS } from "./client/tools.js";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
 import { Client, GetInputFunction, RegisterToolsFunction } from "../common/types.js";
-import { ProviderStatesResponse } from "./client/base.js";
+import { CanIDeployInput, CanIDeployResponse, ProviderStatesResponse } from "./client/base.js";
 
 
 // Tool definitions for PactFlow AI API client
@@ -156,10 +156,52 @@ export class PactflowClient implements Client {
       return response.json();
     }
 
+    /**
+     * Checks if a given pacticipant version is safe to deploy
+     * to a specified environment.
+     *
+     * @param body - Input containing:
+     *   - `pacticipant`: The name of the service (pacticipant).
+     *   - `version`: The version of the pacticipant being evaluated for deployment.
+     *   - `environment`: The target environment (e.g., staging, production).
+     * @returns CanIDeployResponse containing deployment decision and verification results.
+     * @throws Error if the request fails or returns a non-OK response.
+     */
+    async canIDeploy(body: CanIDeployInput): Promise<CanIDeployResponse> {
+      const { pacticipant, version, environment } = body;
+      const queryParams = new URLSearchParams({
+        pacticipant,
+        version,
+        environment,
+      });
+      const url = `${this.baseUrl}/can-i-deploy?${queryParams.toString()}`;
+      
+      try {
+        const response = await fetch(url, {
+          method: "GET",
+          headers: this.headers,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "");
+          throw new Error(
+            `Can-I-Deploy Request Failed - status: ${response.status} ${response.statusText}${
+              errorText ? ` - ${errorText}` : ""
+            }`
+          );
+        }
+
+        return (await response.json()) as CanIDeployResponse;
+      } catch (error) {
+        console.error("[CanIDeploy] Unexpected error:", error);
+        throw error;
+      }
+    }
+
     registerTools(register: RegisterToolsFunction, _getInput: GetInputFunction): void {
       for (const tool of TOOLS.filter(t => t.clients.includes(this.clientType))) {
         const {handler, clients, formatResponse, ...toolparams} = tool;
-        console.log(clients);
+        void clients;
         register(toolparams, async (args, _extra) => {
             const handler_fn = (this as any)[handler];
             if (typeof handler_fn !== "function") {

--- a/pactflow/client/base.ts
+++ b/pactflow/client/base.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface ProviderState {
   name: string;
   params?: Record<string, any> | null;
@@ -7,3 +9,32 @@ export interface ProviderState {
 export interface ProviderStatesResponse {
   providerStates: ProviderState[];
 }
+
+export const CanIDeploySchema = z.object({
+  pacticipant: z.string(),
+  version: z.string(),
+  environment: z.string(),
+});
+
+
+export interface CanIDeployResponse {
+  matrix: Array<{
+    consumer: Record<string, any>;
+    pact: Record<string, any>;
+    provider: Record<string, any>;
+    verificationResult: Record<string, any>;
+  }>;
+  notices: Array<{
+    text: string;
+    type: string;
+  }>;
+  summary: {
+    deployable: boolean; // The property that indicates whether or not the pacticipant version is safe to deploy.
+    failed: number;
+    reason: string;
+    success: number;
+    unknown: number;
+  };
+}
+
+export type CanIDeployInput = z.infer<typeof CanIDeploySchema>;

--- a/pactflow/client/tools.ts
+++ b/pactflow/client/tools.ts
@@ -13,6 +13,7 @@
 import { z } from "zod";
 import { ToolParams } from "../../common/types.js";
 import { GenerationInputSchema, RefineInputSchema } from "./ai.js";
+import { CanIDeploySchema } from "./base.js";
 
 export type ClientType = "pactflow" | "pact_broker";
 
@@ -53,6 +54,14 @@ export const TOOLS: PactflowToolParams[] = [
       }
     ],
     handler: "getProviderStates",       
+    clients: ["pactflow", "pact_broker"]
+  },
+  {
+    title: "Can I Deploy",
+    summary: "Performs a comprehensive compatibility check to determine whether a specific version of a service (pacticipant) can be safely deployed into a given environment. It analyzes the complete contract matrix of consumer-provider relationships to confirm that all required integrations are verified and compatible.",
+    purpose: "To serve as a deployment safety check within the PactBroker and PactFlow ecosystem, leveraging contract testing results to validate whether a specific service / pacticipant version is compatible with all integrated services. This feature prevents unsafe releases, reduces integration risks, and enables teams to confidently automate deployments across environments with a clear, auditable record of verification results.",
+    zodSchema: CanIDeploySchema,
+    handler: "canIDeploy",
     clients: ["pactflow", "pact_broker"]
   }
 ];

--- a/tests/unit/pactflow/client.test.ts
+++ b/tests/unit/pactflow/client.test.ts
@@ -2,86 +2,190 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PactflowClient } from "../../../pactflow/client.js";
 import * as toolsModule from "../../../pactflow/client/tools.js";
 
-describe("PactflowClient.registerTools", () => {
-  const mockRegister = vi.fn();
-  const mockGetInput = vi.fn();
+describe("PactFlowClient", () => {
+  let client: PactflowClient;
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
   });
 
-  it("registers only tools matching the given clientType", () => {
-    // Arrange — mock TOOLS with multiple client types
-    const fakeTools = [
-      {
-        title: "tool1",
-        summary: "summary1",
-        purpose: "purpose1",
-        parameters: [],
-        handler: "generate",
-        clients: ["pactflow"], // should be registered
-      },
-      {
-        title: "tool2",
-        summary: "summary2",
-        purpose: "purpose2",
-        parameters: [],
-        handler: "generate",
-        clients: ["pact_broker"], // should NOT be registered
-      },
-    ];
-    vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
+  describe("constructor", () => {
+    it("should initialize with correct parameters", () => {
+      client = new PactflowClient("test-token", "https://example.com", "pactflow");
+      expect(client).toBeInstanceOf(PactflowClient);
+      expect(client["baseUrl"]).toBe("https://example.com");
+      expect(client["clientType"]).toBe("pactflow");
+    });
 
-    const client = new PactflowClient("token", "https://example.com", "pactflow");
-    client.registerTools(mockRegister, mockGetInput);
+    it("sets correct headers when client is pactflow", () => {
+      client = new PactflowClient("my-token", "https://example.com", "pactflow");
 
-    expect(mockRegister).toHaveBeenCalledTimes(1);
-    expect(mockRegister.mock.calls[0][0].title).toBe("tool1");
-    expect(mockRegister.mock.calls[0][0].summary).toBe("summary1");
-  });
-
-  it("registers no tools if none match the clientType", () => {
-    const fakeTools = [
-      {
-        title: "tool2",
-        summary: "summary2",
-        purpose: "purpose2",
-        parameters: [],
-        handler: "generate",
-        clients: ["pact_broker"],
-      },
-    ];
-    vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
-
-    const client = new PactflowClient("token", "https://example.com", "pactflow");
-    client.registerTools(mockRegister, mockGetInput);
-
-    expect(mockRegister).not.toHaveBeenCalled();
-  });
-
-  it("sets correct headers for pactflow", () => {
-    const client = new PactflowClient("my-token", "https://example.com", "pactflow");
-
-    expect(client["headers"]).toEqual(
+      expect(client["headers"]).toEqual(
         expect.objectContaining({
-            Authorization: expect.stringContaining("Bearer my-token"),
-            "Content-Type": expect.stringContaining("application/json"),
+          Authorization: expect.stringContaining("Bearer my-token"),
+          "Content-Type": expect.stringContaining("application/json"),
         })
-    );
+      );
+    });
+
+    it("sets correct headers when client is pact_broker", () => {
+      client = new PactflowClient(
+        { username: "user", password: "pass" },
+        "https://example.com",
+        "pact_broker"
+      );
+
+      expect(client["headers"]).toEqual(
+        expect.objectContaining({
+          Authorization: expect.stringContaining(
+            `Basic ${Buffer.from("user:pass").toString("base64")}`
+          ),
+          "Content-Type": expect.stringContaining("application/json"),
+        })
+      );
+    });
   });
 
-  it("sets correct headers for pact_broker", () => {
-    const client = new PactflowClient(
-      { username: "user", password: "pass" },
-      "https://example.com",
-      "pact_broker"
-    );
+  describe("registerTools", () => {
+    const mockRegister = vi.fn();
+    const mockGetInput = vi.fn();
 
-    expect(client["headers"]).toEqual(
-        expect.objectContaining({
-            Authorization: expect.stringContaining(`Basic ${Buffer.from("user:pass").toString("base64")}`),
-            "Content-Type": expect.stringContaining("application/json"),
-        })
-    );
+    it("registers only tools matching the given clientType", () => {
+      // Arrange — mock TOOLS with multiple client types
+      const fakeTools = [
+        {
+          title: "tool1",
+          summary: "summary1",
+          purpose: "purpose1",
+          parameters: [],
+          handler: "generate",
+          clients: ["pactflow"], // should be registered
+        },
+        {
+          title: "tool2",
+          summary: "summary2",
+          purpose: "purpose2",
+          parameters: [],
+          handler: "generate",
+          clients: ["pact_broker"], // should NOT be registered
+        },
+      ];
+      vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
+
+      const client = new PactflowClient("token", "https://example.com", "pactflow");
+      client.registerTools(mockRegister, mockGetInput);
+
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+      expect(mockRegister.mock.calls[0][0].title).toBe("tool1");
+      expect(mockRegister.mock.calls[0][0].summary).toBe("summary1");
+    });
+
+    it("registers no tools if none match the clientType", () => {
+      const fakeTools = [
+        {
+          title: "tool2",
+          summary: "summary2",
+          purpose: "purpose2",
+          parameters: [],
+          handler: "generate",
+          clients: ["pact_broker"],
+        },
+      ];
+      vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
+
+      const client = new PactflowClient("token", "https://example.com", "pactflow");
+      client.registerTools(mockRegister, mockGetInput);
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("API Methods", () => {
+    beforeEach(() => {
+      client = new PactflowClient("test-token", "https://example.com", "pactflow");
+      global.fetch = vi.fn();
+    });
+
+    describe("canIDeploy", () => {
+      const mockInput = {
+        pacticipant: "my-service",
+        version: "1.0.0",
+        environment: "production",
+      };
+
+      it("should successfully check if deployment is allowed", async () => {
+        const mockResponse = {
+          summary: { deployable: true, failed: 0 },
+        };
+
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValueOnce(mockResponse),
+        });
+
+        const result = await client.canIDeploy(mockInput);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          "https://example.com/can-i-deploy?pacticipant=my-service&version=1.0.0&environment=production",
+          {
+            method: "GET",
+            headers: client["headers"],
+          }
+        );
+        expect(result.summary.deployable).toBe(true);
+      });
+
+      it("should handle deployment not allowed scenario", async () => {
+        const mockResponse = {
+          summary: { deployable: false },
+        };
+
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValueOnce(mockResponse),
+        });
+
+        const result = await client.canIDeploy(mockInput);
+
+        expect(result.summary.deployable).toBe(false);
+      });
+
+      it("should handle HTTP errors correctly", async () => {
+        const errorText = "Pacticipant not found";
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          text: vi.fn().mockResolvedValueOnce(errorText),
+        });
+
+        await expect(client.canIDeploy(mockInput)).rejects.toThrow(
+          "Can-I-Deploy Request Failed - status: 404 Not Found - Pacticipant not found"
+        );
+      });
+
+      it("should properly encode URL parameters", async () => {
+        const inputWithSpecialChars = {
+          pacticipant: "my-service@special",
+          version: "1.0.0-beta+build.123",
+          environment: "test/staging",
+        };
+
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValueOnce({ summary: { deployable: true } }),
+        });
+
+        await client.canIDeploy(inputWithSpecialChars);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          "https://example.com/can-i-deploy?pacticipant=my-service%40special&version=1.0.0-beta%2Bbuild.123&environment=test%2Fstaging",
+          {
+            method: "GET",
+            headers: client["headers"],
+          }
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Goal

This PR introduces support for `can-i-deploy` in PactFlow and Pact Broker client, enabling users to verify if a pacticipant version is safe to deploy.

## Testing

- Valid Input:

<img width="576" height="716" alt="Screenshot 2025-09-02 at 1 45 09 AM" src="https://github.com/user-attachments/assets/a64679d9-87c1-4e71-b877-950e8e88a0c7" />

<img width="566" height="799" alt="Screenshot 2025-09-02 at 1 32 55 AM" src="https://github.com/user-attachments/assets/481d612b-11f7-4b27-8a75-4084fe681a62" />

- Invalid Input ( When an Invalid Pacticipant is provided ) 
<img width="576" height="520" alt="Screenshot 2025-09-02 at 1 35 09 AM" src="https://github.com/user-attachments/assets/4b469261-a1fe-41fe-84ae-cc57b0b9d9aa" />

