### PR TITLE
added release fetching

### DIFF
--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -891,7 +891,7 @@ export class BugsnagClient implements Client {
           },
           {
             name: "nextUrl",
-            type: z.string().url(),
+            type: z.string(),
             description:
               "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. If provided, other parameters are ignored.",
             required: false,
@@ -1036,7 +1036,7 @@ export class BugsnagClient implements Client {
         },
         {
           name: "nextUrl",
-          type: z.string().url(),
+          type: z.string(),
           description:
             "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. If provided, other parameters are ignored.",
           required: false,

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -251,9 +251,10 @@ export class BugsnagClient implements Client {
     const fetchedBuilds = (await this.projectApi.listBuilds(projectId, options)).body || [];
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedBuilds = await Promise.all(
-      fetchedBuilds.map(async (b) => await this.addStabilityData(b, stabilityTargets))
+    const formattedBuilds = fetchedBuilds.map(
+      (b) => this.addStabilityData(b, stabilityTargets)
     );
+
     this.cache.set(cacheKey, formattedBuilds, 5 * 60);
     return formattedBuilds;
   }
@@ -267,7 +268,7 @@ export class BugsnagClient implements Client {
     if (!fetchedBuild) throw new Error(`No build for ${buildId} found.`);
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedBuild = await this.addStabilityData(fetchedBuild, stabilityTargets);
+    const formattedBuild = this.addStabilityData(fetchedBuild, stabilityTargets);
     this.cache.set(cacheKey, formattedBuild, 5 * 60);
     return formattedBuild;
   }
@@ -280,9 +281,10 @@ export class BugsnagClient implements Client {
     const fetchedReleases = (await this.projectApi.listReleases(projectId, opts)).body || [];
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedReleases = await Promise.all(
-      fetchedReleases.map(async (r) => await this.addStabilityData(r, stabilityTargets))
+    const formattedReleases = fetchedReleases.map(
+      (r) => this.addStabilityData(r, stabilityTargets)
     );
+
     this.cache.set(cacheKey, formattedReleases, 5 * 60);
     return formattedReleases;
   }
@@ -296,7 +298,7 @@ export class BugsnagClient implements Client {
     if (!fetchedRelease) throw new Error(`No release for ${releaseId} found.`);
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedRelease = await this.addStabilityData(fetchedRelease, stabilityTargets);
+    const formattedRelease = this.addStabilityData(fetchedRelease, stabilityTargets);
     this.cache.set(cacheKey, formattedRelease, 5 * 60);
     return formattedRelease;
   }

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1010,7 +1010,7 @@ export class BugsnagClient implements Client {
             ]),
         {
           name: "releaseStage",
-          type: z.string().default("production"),
+          type: z.string(),
           description: "Filter releases by this stage (e.g. production, staging)",
           required: false,
           examples: ["production", "staging"],
@@ -1048,7 +1048,7 @@ export class BugsnagClient implements Client {
             type: "text",
             text: JSON.stringify(
               await this.listReleases((await this.getInputProject(args.projectId)).id, {
-                release_stage_name: args.releaseStage,
+                release_stage_name: args.releaseStage ?? "production",
                 visible_only: args.visibleOnly,
               })
             ),

--- a/src/bugsnag/client/api/CurrentUser.ts
+++ b/src/bugsnag/client/api/CurrentUser.ts
@@ -60,7 +60,7 @@ export class CurrentUserAPI extends BaseAPI {
    * @returns A promise that resolves to the list of projects in the organization
    */
   async getOrganizationProjects(organizationId: string, options: GetOrganizationProjectsOptions = {}): Promise<ApiResponse<Project[]>> {
-    const { paginate = false, ...queryOptions } = options;
+    const { ...queryOptions } = options;
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(queryOptions)) {
       if (value !== undefined) params.append(key, String(value));
@@ -71,8 +71,7 @@ export class CurrentUserAPI extends BaseAPI {
     const data = await this.request<Project[]>({
       method: 'GET',
       url,
-    }, paginate);
-    // Only return allowed fields
+    }, true); // Always paginate for projects
     return {
       ...data,
       body: pickFieldsFromArray<Project>(data.body || [], CurrentUserAPI.projectFields)
@@ -87,6 +86,5 @@ export interface ListUserOrganizationsOptions {
 }
 
 export interface GetOrganizationProjectsOptions {
-  paginate?: boolean;
   [key: string]: any;
 }

--- a/src/bugsnag/client/api/Project.ts
+++ b/src/bugsnag/client/api/Project.ts
@@ -1,5 +1,5 @@
 import { Configuration } from "../configuration.js";
-import { BaseAPI, pickFieldsFromArray, ApiResponse } from "./base.js";
+import { BaseAPI, pickFieldsFromArray, ApiResponse, pickFields } from "./base.js";
 import { Project as ProjectApiView } from "./CurrentUser.js";
 
 // --- Response Types ---
@@ -102,15 +102,100 @@ export interface ProjectCreateRequest {
   ignore_old_browsers?: boolean;
 }
 
+export interface ListReleasesOptions {
+  release_stage?: string;
+}
+
+export interface ReleaseSummaryResponse {
+  id: string;
+  release_time: string;
+  app_version: string;
+  release_stage: { name: string };
+  errors_introduced_count: number;
+  errors_seen_count: number;
+  total_sessions_count: number;
+  unhandled_sessions_count: number;
+  accumulative_daily_users_seen: number;
+  accumulative_daily_users_with_unhandled: number;
+}
+
+export interface ReleaseResponse {
+  id: string;
+  project_id: string;
+  release_time: string;
+  release_source: string;
+  app_version: string;
+  app_version_code: string;
+  app_bundle_version: string;
+  build_label: string;
+  builder_name: string;
+  build_tool: string;
+  errors_introduced_count: number;
+  errors_seen_count: number;
+  sessions_count_in_last_24h: number;
+  total_sessions_count: number;
+  unhandled_sessions_count: number;
+  accumulative_daily_users_seen: number;
+  accumulative_daily_users_with_unhandled: number;
+  metadata: {
+    [key: string]: string;
+  };
+  release_stage: { name: string };
+  source_control: {
+    service: string;
+    commit_url: string;
+    revision: string;
+    diff_url_to_previous: string;
+  };
+  release_group_id: string;
+}
+
+export type ReleaseResponseAny = ReleaseResponse | ReleaseSummaryResponse;
+
+export type StabilityTargetType = "user" | "session";
+export interface ReleaseStabilityData {
+  user_stability: number;
+  session_stability: number;
+  stability_target_type: StabilityTargetType;
+  target_stability: number;
+  critical_stability: number;
+  meets_target_stability: boolean;
+  meets_critical_stability: boolean;
+}
+
+export interface ProjectStabilityTargets {
+  target_stability: StabilityData;
+  critical_stability: StabilityData;
+  stability_target_type: StabilityTargetType;
+}
+
+export interface StabilityData {
+  value: number;
+  updated_at: string;
+  updated_by_id: string;
+}
+
 // --- API Class ---
 
 export class ProjectAPI extends BaseAPI {
   static filterFields: string[] = ["errors_url", "events_url", "url", "html_url"]
-  static eventFieldFields: (keyof EventField)[] = [
-    'custom',
-    'display_id',
-    'filter_options',
-    'pivot_options'
+  static eventFieldFields: (keyof EventField)[] = ["custom", "display_id", "filter_options", "pivot_options"];
+  static releaseFields: (keyof ReleaseSummaryResponse)[] = [
+    "id",
+    "release_time",
+    "app_version",
+    "release_stage",
+    "errors_introduced_count",
+    "errors_seen_count",
+    "total_sessions_count",
+    "unhandled_sessions_count",
+    "accumulative_daily_users_seen",
+    "accumulative_daily_users_with_unhandled",
+  ];
+  static stabilityFields: (keyof ProjectStabilityTargets)[] = [
+    "critical_stability",
+    "target_stability",
+    "stability_target_type",
   ];
 
   constructor(configuration: Configuration) {
@@ -151,6 +236,63 @@ export class ProjectAPI extends BaseAPI {
       method: 'POST',
       url,
       body: data,
+    });
+  }
+
+  /**
+   * Retrieves the stability targets for a specific project.
+   * GET /projects/{project_id} (with internal header)
+   * @param projectId The ID of the project.
+   * @returns A promise that resolves to the project's stability targets.
+   */
+  async getProjectStabilityTargets(projectId: string) {
+    const url = `/projects/${projectId}`;
+    const response = await this.request<unknown>({
+      method: "GET",
+      url,
+      headers: {
+        "X-Bugsnag-Internal": "true", // needed to get the stability targets
+      },
+    });
+
+    return pickFields<ProjectStabilityTargets>(response.body || {}, ProjectAPI.stabilityFields);
+  }
+
+  /**
+   * Lists releases for a specific project.
+   * GET /projects/{project_id}/releases
+   * @param projectId The ID of the project.
+   * @param data Options for listing releases, including filtering by release stage.
+   * @returns A promise that resolves to an array of `ListReleasesResponse` objects.
+   */
+  async listReleases(projectId: string, data: ListReleasesOptions) {
+    const url = `/projects/${projectId}/releases${data.release_stage ? `?release_stage=${data.release_stage}` : ""}`;
+    const response = await this.request<ReleaseSummaryResponse[]>(
+      {
+        method: "GET",
+        url,
+      },
+      true
+    );
+
+    return {
+      ...response,
+      body: pickFieldsFromArray<ReleaseSummaryResponse>(response.body || [], ProjectAPI.releaseFields),
+    };
+  }
+
+  /**
+   * Retrieves a specific release from a project.
+   * GET /projects/{project_id}/releases/{release_id}
+   * @param projectId The ID of the project.
+   * @param releaseId The ID of the release to retrieve.
+   * @returns A promise that resolves to the release data.
+   */
+  async getRelease(projectId: string, releaseId: string) {
+    const url = `/projects/${projectId}/releases/${releaseId}`;
+    return await this.request<ReleaseResponse>({
+      method: "GET",
+      url,
     });
   }
 }

--- a/src/bugsnag/client/api/Project.ts
+++ b/src/bugsnag/client/api/Project.ts
@@ -106,6 +106,7 @@ export interface ProjectCreateRequest {
 // Builds
 export interface ListBuildsOptions {
   release_stage?: string;
+  next_url?: string;
 }
 
 export interface SourceControl {
@@ -161,6 +162,7 @@ export type BuildResponseAny = BuildResponse | BuildSummaryResponse;
 export interface ListReleasesOptions {
   release_stage_name: string;
   visible_only: boolean;
+  next_url?: string;
 }
 
 export interface ReleaseSummaryResponse {
@@ -327,7 +329,7 @@ export class ProjectAPI extends BaseAPI {
    * @returns A promise that resolves to an array of `ListReleasesResponse` objects.
    */
   async listBuilds(projectId: string, opts: ListBuildsOptions) {
-    const url = `/projects/${projectId}/releases${opts.release_stage ? `?release_stage=${opts.release_stage}` : ""}`;
+    const url = opts.next_url ?? `/projects/${projectId}/releases${opts.release_stage ? `?release_stage=${opts.release_stage}` : ""}`;
     const response = await this.request<BuildSummaryResponse[]>({
       method: "GET",
       url,
@@ -362,7 +364,7 @@ export class ProjectAPI extends BaseAPI {
    * @returns A promise that resolves to an array of `ReleaseSummaryResponse` objects.
    */
   async listReleases(projectId: string, opts: ListReleasesOptions) {
-    const url = `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}&top_only=true`
+    const url = opts.next_url ?? `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}&top_only=true`
     const response = await this.request<ReleaseSummaryResponse[]>({
       method: "GET",
       url
@@ -399,6 +401,6 @@ export class ProjectAPI extends BaseAPI {
     return await this.request<BuildResponse[]>({
       method: "GET",
       url,
-    });
+    }, true);
   }
 }

--- a/src/bugsnag/client/api/Project.ts
+++ b/src/bugsnag/client/api/Project.ts
@@ -331,8 +331,7 @@ export class ProjectAPI extends BaseAPI {
     const response = await this.request<BuildSummaryResponse[]>({
       method: "GET",
       url,
-    },
-    true);
+    });
 
     return {
       ...response,
@@ -363,12 +362,11 @@ export class ProjectAPI extends BaseAPI {
    * @returns A promise that resolves to an array of `ReleaseSummaryResponse` objects.
    */
   async listReleases(projectId: string, opts: ListReleasesOptions) {
-    const url = `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}`
+    const url = `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}&top_only=true`
     const response = await this.request<ReleaseSummaryResponse[]>({
       method: "GET",
       url
-    },
-    true);
+    });
 
     return {
       ...response,
@@ -401,7 +399,6 @@ export class ProjectAPI extends BaseAPI {
     return await this.request<BuildResponse[]>({
       method: "GET",
       url,
-    },
-    true);
+    });
   }
 }

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -73,9 +73,8 @@ export class BaseAPI {
       headers,
       body: options.body ? JSON.stringify(options.body) : undefined,
     };
-    const url = ensureFullUrl(options.url, this.configuration.basePath!);
     let results: T[] = [];
-    let nextUrl: string | null = url;
+    let nextUrl: string | null = options.url;
     let apiResponse: ApiResponse<T>
     do {
       nextUrl = ensureFullUrl(nextUrl!, this.configuration.basePath!);

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -79,7 +79,7 @@ export class BaseAPI {
     do {
       nextUrl = ensureFullUrl(nextUrl!, this.configuration.basePath!);
       const response: Response = await fetch(nextUrl!, fetchOptions);
-      if (!response.ok && response.status !== 429) { // 429 is handled separately
+      if (!response.ok) {
           const errorText = await response.text();
           throw new Error(`Request failed with status ${response.status}: ${errorText}`);
       }
@@ -87,14 +87,6 @@ export class BaseAPI {
       apiResponse = {
         status: response.status,
         headers: response.headers
-      }
-
-      // Just to make sure the server handles rate limiting properly
-      if (response.status === 429) {
-        const retryAfter = response.headers.get('Retry-After')!; // According to spec, this header is present
-        const waitTime = Number(retryAfter) * 1000;
-        await new Promise(r => setTimeout(r, waitTime));
-        continue; // Retry the request
       }
 
       const data: T = await response.json();

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -89,9 +89,9 @@ export class BaseAPI {
         status: response.status,
         headers: response.headers
       }
-      
+
       // Just to make sure the server handles rate limiting properly
-      if (response.status === 429) { 
+      if (response.status === 429) {
         const retryAfter = response.headers.get('Retry-After')!; // According to spec, this header is present
         const waitTime = Number(retryAfter) * 1000;
         await new Promise(r => setTimeout(r, waitTime));

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -71,6 +71,8 @@ export class BaseAPI {
     let nextUrl: string | null = url;
     let apiResponse: ApiResponse<T>
     do {
+      // TODO: Make this smarter
+      nextUrl = nextUrl.startsWith('http') ? nextUrl : `${this.configuration.basePath || ''}${nextUrl}`;
       const response: Response = await fetch(nextUrl!, fetchOptions);
       if (!response.ok && response.status !== 429) { // 429 is handled separately
           const errorText = await response.text();

--- a/src/tests/unit/bugsnag/api-utilities.test.ts
+++ b/src/tests/unit/bugsnag/api-utilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickFields, pickFieldsFromArray } from '../../../bugsnag/client/api/base.js';
+import { getNextUrlPathFromHeader, pickFields, pickFieldsFromArray } from '../../../bugsnag/client/api/base.js';
 
 describe('API Utilities', () => {
   describe('pickFields', () => {
@@ -32,6 +32,59 @@ describe('API Utilities', () => {
         { id: '1', name: 'Test1' },
         { id: '2', name: 'Test2' }
       ]);
+    });
+  });
+
+  describe("getNextUrlPathFromHeader", () => {
+    it("should extract next URL path from Link header", () => {
+      const headers = new Headers();
+        headers.append(
+          "Link",
+          '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
+        );
+
+      const result = getNextUrlPathFromHeader(
+        headers,
+        "https://api.bugsnag.com"
+      );
+      expect(result).toBe("/projects/12345/errors?offset=30&per_page=30");
+    });
+
+    it("should handle case-insensitive Link header name", () => {
+      const headers = new Headers();
+        headers.append(
+          "link",
+          '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
+      );
+
+      const result = getNextUrlPathFromHeader(
+        headers,
+          "https://api.bugsnag.com"
+      );
+      expect(result).toBe("/projects/12345/errors?offset=30&per_page=30");
+    });
+
+    it("should return null when Link header is missing", () => {
+      const headers = new Headers();
+      const result = getNextUrlPathFromHeader(
+        headers,
+        "https://api.bugsnag.com"
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null when rel="next" is not in the Link header', () => {
+      const headers = new Headers();
+      headers.append(
+        "Link",
+        '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="prev"'
+      );
+
+      const result = getNextUrlPathFromHeader(
+        headers,
+        "https://api.bugsnag.com"
+      );
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/tests/unit/bugsnag/api-utilities.test.ts
+++ b/src/tests/unit/bugsnag/api-utilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getNextUrlPathFromHeader, pickFields, pickFieldsFromArray } from '../../../bugsnag/client/api/base.js';
+import { getNextUrlPathFromHeader, pickFields, pickFieldsFromArray, ensureFullUrl } from '../../../bugsnag/client/api/base.js';
 
 describe('API Utilities', () => {
   describe('pickFields', () => {
@@ -85,6 +85,44 @@ describe('API Utilities', () => {
         "https://api.bugsnag.com"
       );
       expect(result).toBeNull();
+    });
+  });
+
+  describe("ensureFullUrl", () => {
+    it("should return the original URL if it already starts with http", () => {
+      const url = "https://api.bugsnag.com/projects/12345/errors";
+      const basePath = "https://api.bugsnag.com";
+      
+      const result = ensureFullUrl(url, basePath);
+      
+      expect(result).toBe(url);
+    });
+
+    it("should prepend the base path to a relative URL", () => {
+      const url = "/projects/12345/errors";
+      const basePath = "https://api.bugsnag.com";
+      
+      const result = ensureFullUrl(url, basePath);
+      
+      expect(result).toBe("https://api.bugsnag.com/projects/12345/errors");
+    });
+
+    it("should handle URLs with http protocol", () => {
+      const url = "http://api.bugsnag.com/projects/12345/errors";
+      const basePath = "https://api.bugsnag.com";
+      
+      const result = ensureFullUrl(url, basePath);
+      
+      expect(result).toBe(url);
+    });
+
+    it("should handle empty URL input", () => {
+      const url = "";
+      const basePath = "https://api.bugsnag.com";
+      
+      const result = ensureFullUrl(url, basePath);
+      
+      expect(result).toBe("https://api.bugsnag.com");
     });
   });
 });

--- a/src/tests/unit/bugsnag/api-utilities.test.ts
+++ b/src/tests/unit/bugsnag/api-utilities.test.ts
@@ -92,36 +92,36 @@ describe('API Utilities', () => {
     it("should return the original URL if it already starts with http", () => {
       const url = "https://api.bugsnag.com/projects/12345/errors";
       const basePath = "https://api.bugsnag.com";
-      
+
       const result = ensureFullUrl(url, basePath);
-      
+
       expect(result).toBe(url);
     });
 
     it("should prepend the base path to a relative URL", () => {
       const url = "/projects/12345/errors";
       const basePath = "https://api.bugsnag.com";
-      
+
       const result = ensureFullUrl(url, basePath);
-      
+
       expect(result).toBe("https://api.bugsnag.com/projects/12345/errors");
     });
 
     it("should handle URLs with http protocol", () => {
       const url = "http://api.bugsnag.com/projects/12345/errors";
       const basePath = "https://api.bugsnag.com";
-      
+
       const result = ensureFullUrl(url, basePath);
-      
+
       expect(result).toBe(url);
     });
 
     it("should handle empty URL input", () => {
       const url = "";
       const basePath = "https://api.bugsnag.com";
-      
+
       const result = ensureFullUrl(url, basePath);
-      
+
       expect(result).toBe("https://api.bugsnag.com");
     });
   });

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -648,7 +648,7 @@ describe('BugsnagClient', () => {
           meets_critical_stability: true,
           stability_target_type: "user",
         }));
-        
+
         // Create headers with Link for pagination
         const headers = new Headers();
         headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/releases?offset=30&per_page=30>; rel="next"');
@@ -1078,7 +1078,7 @@ describe('BugsnagClient', () => {
           meets_critical_stability: true,
           stability_target_type: "user",
         }));
-        
+
         // Create headers with Link for pagination
         const headers = new Headers();
         headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/release_groups?offset=30&per_page=30>; rel="next"');
@@ -1872,7 +1872,7 @@ describe('BugsnagClient', () => {
         const mockProjects = [
           { id: "proj-1", name: "Project 1" },
           { id: "proj-2", name: "Project 2" },
-        ];        
+        ];
         const mockBuilds = [
           {
             id: "rel-1",

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -23,7 +23,22 @@ const mockErrorAPI = {
 
 const mockProjectAPI = {
   listProjectEventFields: vi.fn(),
-  createProject: vi.fn()
+  createProject: vi.fn(),
+  listReleases: vi.fn(),
+    getRelease: vi.fn(),
+    getProjectStabilityTargets: vi.fn().mockResolvedValue({
+        target_stability: {
+            value: 0.995,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+        },
+        critical_stability: {
+            value: 0.85,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+        },
+        stability_target_type: "user" as const,
+    }),
 } satisfies Omit<ProjectAPI, keyof BaseAPI>;
 
 const mockCache = {
@@ -524,6 +539,411 @@ describe('BugsnagClient', () => {
       });
     });
 
+    describe("getReleases", () => {
+      it("should return releases from API when not cached", async () => {
+        const mockReleases = [
+          {
+            id: "rel-1",
+            release_time: "2023-01-01T00:00:00Z",
+            app_version: "1.0.0",
+            release_stage: { name: "production" },
+            source_control: {
+              service: "github",
+              commit_url:
+                "https://github.com/org/repo/commit/abc123",
+            },
+            errors_introduced_count: 5,
+            errors_seen_count: 10,
+            total_sessions_count: 100,
+            unhandled_sessions_count: 10,
+            accumulative_daily_users_seen: 50,
+            accumulative_daily_users_with_unhandled: 5,
+          },
+        ];
+
+        const enhancedReleases = mockReleases.map((release) => ({
+          ...release,
+          session_stability: 0.9,
+          user_stability: 0.9,
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+          stability_target_type: "user",
+        }));
+
+        // Mock cache to return null first to simulate no cached data
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockResolvedValue({
+          body: mockReleases,
+        });
+
+        const result = await client.listReleases("proj-1", {
+          release_stage: "production",
+        });
+
+        expect(mockCache.get).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1"
+        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          { release_stage: "production" }
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1",
+          enhancedReleases,
+          300
+        );
+        expect(result).toEqual(enhancedReleases);
+      });
+
+      it("should return cached releases when available", async () => {
+        const mockReleases = [
+          {
+            id: "rel-1",
+            release_time: "2023-01-01T00:00:00Z",
+            app_version: "1.0.0",
+            session_stability: "90.00%",
+            user_stability: "90.00%",
+          },
+        ];
+
+        // Mock cache to return releases
+        mockCache.get.mockReturnValueOnce(mockReleases);
+
+        const result = await client.listReleases("proj-1", {
+          release_stage: "production",
+        });
+
+        expect(mockCache.get).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1"
+        );
+        expect(mockProjectAPI.listReleases).not.toHaveBeenCalled();
+        expect(result).toEqual(mockReleases);
+      });
+
+      it("should return empty array when no releases found", async () => {
+        // Mock cache to return null to simulate no cached data
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockResolvedValue({ body: null });
+
+        const result = await client.listReleases("proj-1", {});
+
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          {}
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1",
+          [],
+          300
+        );
+        expect(result).toEqual([]);
+      });
+
+      it("should construct correct URL with release stage", async () => {
+        // Mock cache to return null to simulate no cached data
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockImplementation(() => ({
+          body: [],
+        }));
+
+        await client.listReleases("proj-1", {
+          release_stage: "staging",
+        });
+
+        // This is testing the implementation detail that the ProjectAPI correctly constructs the URL
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          { release_stage: "staging" }
+        );
+      });
+    });
+
+    describe("getRelease", () => {
+      it("should return release from API when not cached", async () => {
+        const mockRelease = {
+          id: "rel-1",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.0",
+          release_stage: { name: "production" },
+          source_control: {
+            service: "github",
+            commit_url: "https://github.com/org/repo/commit/abc123",
+            revision: "abc123",
+            diff_url_to_previous:
+              "https://github.com/org/repo/compare/previous...abc123",
+          },
+          errors_introduced_count: 5,
+          errors_seen_count: 10,
+          total_sessions_count: 100,
+          unhandled_sessions_count: 10,
+          accumulative_daily_users_seen: 50,
+          accumulative_daily_users_with_unhandled: 5,
+        };
+
+        const enhancedRelease = {
+          ...mockRelease,
+          session_stability: 0.9,
+          user_stability: 0.9,
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+          stability_target_type: "user",
+        };
+
+        // Mock cache to return null first to simulate no cached data
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = await client.getRelease("proj-1", "rel-1");
+
+        expect(mockCache.get).toHaveBeenCalledWith(
+          "bugsnag_release_rel-1"
+        );
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
+          "proj-1",
+          "rel-1"
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_release_rel-1",
+          enhancedRelease,
+          300
+        );
+        expect(result).toEqual(enhancedRelease);
+      });
+
+      // Test for division by zero case for user stability
+      it("should handle zero accumulative_daily_users_seen", async () => {
+        const mockRelease = {
+          id: "rel-2",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.1",
+          release_stage: { name: "production" },
+          errors_introduced_count: 0,
+          errors_seen_count: 0,
+          total_sessions_count: 50,
+          unhandled_sessions_count: 5,
+          accumulative_daily_users_seen: 0,
+          accumulative_daily_users_with_unhandled: 0,
+        };
+
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = (await client.getRelease(
+          "proj-1",
+          "rel-2"
+        ));
+
+        expect(result.user_stability).toBe(0);
+        expect(result.meets_target_stability).toBe(false);
+        expect(result.meets_critical_stability).toBe(false);
+      });
+
+      // Test for division by zero case for session stability
+      it("should handle zero total_sessions_count", async () => {
+        const mockRelease = {
+          id: "rel-3",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.2",
+          release_stage: { name: "production" },
+          errors_introduced_count: 0,
+          errors_seen_count: 0,
+          total_sessions_count: 0,
+          unhandled_sessions_count: 0,
+          accumulative_daily_users_seen: 20,
+          accumulative_daily_users_with_unhandled: 2,
+        };
+
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = (await client.getRelease(
+          "proj-1",
+          "rel-3"
+        ));
+
+        expect(result.session_stability).toBe(0);
+        // Since stability_target_type is "user", user_stability is used for comparison
+        expect(result.meets_target_stability).toBe(false);
+        expect(result.meets_critical_stability).toBe(true);
+      });
+
+      // Test for session-based stability type
+      it("should calculate metrics correctly when stability_target_type is session", async () => {
+        const mockRelease = {
+          id: "rel-4",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.3",
+          release_stage: { name: "production" },
+          errors_introduced_count: 2,
+          errors_seen_count: 5,
+          total_sessions_count: 100,
+          unhandled_sessions_count: 5,
+          accumulative_daily_users_seen: 50,
+          accumulative_daily_users_with_unhandled: 10,
+        };
+
+        // Override the default mockProjectAPI.getProjectStabilityTargets for this test only
+        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce(
+          {
+            target_stability: {
+              value: 0.95,
+              updated_at: "2023-01-01",
+              updated_by_id: "user-1",
+            },
+            critical_stability: {
+              value: 0.9,
+              updated_at: "2023-01-01",
+              updated_by_id: "user-1",
+            },
+            stability_target_type: "session" as const,
+          }
+        );
+
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = (await client.getRelease(
+          "proj-1",
+          "rel-4"
+        ));
+
+        expect(result.stability_target_type).toBe("session");
+        expect(result.session_stability).toBe(0.95); // (100-5)/100
+        expect(result.user_stability).toBe(0.8); // (50-10)/50
+        // Since stability_target_type is "session", session_stability is used for comparison
+        expect(result.meets_target_stability).toBe(true);
+        expect(result.meets_critical_stability).toBe(true);
+      });
+
+      // Test for a release that meets target stability
+      it("should correctly identify a release that meets target stability", async () => {
+        const mockRelease = {
+          id: "rel-5",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.4",
+          release_stage: { name: "production" },
+          errors_introduced_count: 1,
+          errors_seen_count: 2,
+          total_sessions_count: 1000,
+          unhandled_sessions_count: 5,
+          accumulative_daily_users_seen: 500,
+          accumulative_daily_users_with_unhandled: 2,
+        };
+
+        // Override the default mockProjectAPI.getProjectStabilityTargets for this test only
+        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce(
+          {
+            target_stability: {
+              value: 0.99,
+              updated_at: "2023-01-01",
+              updated_by_id: "user-1",
+            },
+            critical_stability: {
+              value: 0.95,
+              updated_at: "2023-01-01",
+              updated_by_id: "user-1",
+            },
+            stability_target_type: "user" as const,
+          }
+        );
+
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = (await client.getRelease(
+          "proj-1",
+          "rel-5"
+        ));
+
+        expect(result.user_stability).toBe(0.996); // (500-2)/500
+        expect(result.meets_target_stability).toBe(true);
+        expect(result.meets_critical_stability).toBe(true);
+      });
+
+      // Test for a release that fails both critical and target stability
+      it("should correctly identify a release that fails both critical and target stability", async () => {
+        const mockRelease = {
+          id: "rel-6",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.5",
+          release_stage: { name: "production" },
+          errors_introduced_count: 10,
+          errors_seen_count: 20,
+          total_sessions_count: 100,
+          unhandled_sessions_count: 30,
+          accumulative_daily_users_seen: 100,
+          accumulative_daily_users_with_unhandled: 20,
+        };
+
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        const result = (await client.getRelease(
+          "proj-1",
+          "rel-6"
+        ));
+
+        expect(result.user_stability).toBe(0.8); // (100-20)/100
+        expect(result.meets_target_stability).toBe(false); // 0.8 < 0.995
+        expect(result.meets_critical_stability).toBe(false); // 0.8 < 0.85
+      });
+
+      it("should return cached release when available", async () => {
+        const mockRelease = {
+          id: "rel-1",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.0",
+          release_stage: { name: "production" },
+          session_stability: "90.00%",
+          user_stability: "90.00%",
+        };
+
+        // Mock cache to return release
+        mockCache.get.mockReturnValueOnce(mockRelease);
+
+        const result = await client.getRelease("proj-1", "rel-1");
+
+        expect(mockCache.get).toHaveBeenCalledWith(
+          "bugsnag_release_rel-1"
+        );
+        expect(mockProjectAPI.getRelease).not.toHaveBeenCalled();
+        expect(result).toEqual(mockRelease);
+      });
+
+      it("should return null when release not found", async () => {
+        // Mock cache to return null to simulate no cached data
+        mockCache.get.mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({ body: null });
+
+        await expect(
+          client.getRelease("proj-1", "non-existent-release-id")
+        ).rejects.toThrow(
+          "No release for non-existent-release-id found."
+        );
+
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
+          "proj-1",
+          "non-existent-release-id"
+        );
+      });
+    });
+
     describe('getEventById', () => {
       it('should find event across multiple projects', async () => {
         const mockOrgs = [{ id: 'org-1', name: 'Test Org' }];
@@ -952,6 +1372,343 @@ describe('BugsnagClient', () => {
       });
     });
 
+    describe("list_releases tool handler", () => {
+      it("should list releases with project from cache", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+        const mockReleases = [
+          {
+            id: "rel-1",
+            release_time: "2023-01-01T00:00:00Z",
+            app_version: "1.0.0",
+            release_stage: { name: "production" },
+            source_control: {
+              service: "github",
+              commit_url:
+                "https://github.com/org/repo/commit/abc123",
+            },
+            errors_introduced_count: 5,
+            errors_seen_count: 10,
+            total_sessions_count: 100,
+            unhandled_sessions_count: 10,
+            accumulative_daily_users_seen: 50,
+            accumulative_daily_users_with_unhandled: 5,
+          },
+        ];
+
+        const enhancedReleases = mockReleases.map((release) => ({
+          ...release,
+          user_stability: 0.9,
+          session_stability: 0.9,
+          stability_target_type: "user",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+        }));
+
+        // First get for the project, second for cached releases (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockResolvedValue({
+          body: mockReleases,
+        });
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Releases"
+        )[1];
+
+        const result = await toolHandler({
+          releaseStage: "production",
+        });
+
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          { release_stage: "production" }
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1",
+          enhancedReleases,
+          300
+        );
+        expect(result.content[0].text).toBe(
+          JSON.stringify(enhancedReleases)
+        );
+            });
+
+      it("should list releases with explicit project ID", async () => {
+        const mockProjects = [
+          { id: "proj-1", name: "Project 1" },
+          { id: "proj-2", name: "Project 2" },
+        ];
+        const mockReleases = [
+          {
+            id: "rel-1",
+            release_time: "2023-01-01T00:00:00Z",
+            app_version: "1.0.0",
+            release_stage: { name: "staging" },
+            total_sessions_count: 50,
+            unhandled_sessions_count: 5,
+            accumulative_daily_users_seen: 30,
+            accumulative_daily_users_with_unhandled: 3,
+          },
+        ];
+
+        const enhancedReleases = mockReleases.map((release) => ({
+          ...release,
+          user_stability: 0.9,
+          session_stability: 0.9,
+          stability_target_type: "user",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+        }));
+
+        // First get for projects, second for cached releases (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProjects)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockResolvedValue({
+          body: mockReleases,
+        });
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Releases"
+        )[1];
+
+        const result = await toolHandler({
+          projectId: "proj-1",
+          releaseStage: "staging",
+        });
+
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          { release_stage: "staging" }
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1",
+          enhancedReleases,
+          300
+        );
+        expect(result.content[0].text).toBe(
+          JSON.stringify(enhancedReleases)
+        );
+      });
+
+      it("should handle empty releases list", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+
+        // First get for the project, second for cached releases (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.listReleases.mockResolvedValue({ body: [] });
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Releases"
+        )[1];
+
+        const result = await toolHandler({});
+
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
+          "proj-1",
+          {}
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_releases_proj-1",
+          [],
+          300
+        );
+        expect(result.content[0].text).toBe(JSON.stringify([]));
+      });
+
+      it("should throw error when no project ID available", async () => {
+        mockCache.get.mockReturnValue(null);
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Releases"
+        )[1];
+
+        await expect(toolHandler({})).rejects.toThrow(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
+      });
+    });
+
+    describe("get_release tool handler", () => {
+      it("should get release details with project from cache", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+        const mockRelease = {
+          id: "rel-1",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.0",
+          release_stage: { name: "production" },
+          source_control: {
+            service: "github",
+            commit_url: "https://github.com/org/repo/commit/abc123",
+            revision: "abc123",
+            diff_url_to_previous:
+              "https://github.com/org/repo/compare/previous...abc123",
+          },
+          errors_introduced_count: 5,
+          errors_seen_count: 10,
+          total_sessions_count: 100,
+          unhandled_sessions_count: 10,
+          accumulative_daily_users_seen: 50,
+          accumulative_daily_users_with_unhandled: 5,
+        }  
+        const enhancedRelease = {
+          ...mockRelease,
+          user_stability: 0.9,
+          session_stability: 0.9,
+          stability_target_type: "user",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+        };
+
+        // First get for the project, second for cached release (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Release"
+        )[1];
+
+        const result = await toolHandler({ releaseId: "rel-1" });
+
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
+          "proj-1",
+          "rel-1"
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_release_rel-1",
+          enhancedRelease,
+          300
+        );
+        expect(result.content[0].text).toBe(
+          JSON.stringify(enhancedRelease)
+        );
+      });
+
+      it("should get release with explicit project ID", async () => {
+        const mockProjects = [
+          { id: "proj-1", name: "Project 1" },
+          { id: "proj-2", name: "Project 2" },
+        ];
+        const mockRelease = {
+          id: "rel-1",
+          release_time: "2023-01-01T00:00:00Z",
+          app_version: "1.0.0",
+          release_stage: { name: "production" },
+          total_sessions_count: 50,
+          unhandled_sessions_count: 5,
+          accumulative_daily_users_seen: 30,
+          accumulative_daily_users_with_unhandled: 3,
+        };
+
+        const enhancedRelease = {
+          ...mockRelease,
+          user_stability: 0.9,
+          session_stability: 0.9,
+          stability_target_type: "user",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: true,
+        };
+
+        // First get for projects, second for cached release (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProjects)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({
+          body: mockRelease,
+        });
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Release"
+        )[1];
+
+        const result = await toolHandler({
+          projectId: "proj-1",
+          releaseId: "rel-1",
+        });
+
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
+          "proj-1",
+          "rel-1"
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_release_rel-1",
+          enhancedRelease,
+          300
+        );
+        expect(result.content[0].text).toBe(
+          JSON.stringify(enhancedRelease)
+        );
+      });
+
+      it("should throw error when release not found", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+
+        mockCache.get
+          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(null);
+        mockProjectAPI.getRelease.mockResolvedValue({ body: null });
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Release"
+        )[1];
+
+        await expect(
+          toolHandler({ releaseId: "non-existent-release-id" })
+        ).rejects.toThrow(
+          "No release for non-existent-release-id found."
+        );
+      });
+
+      it("should throw error when releaseId argument is missing", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+
+        mockCache.get.mockReturnValueOnce(mockProject);
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Release"
+        )[1];
+
+        await expect(toolHandler({})).rejects.toThrow(
+          "releaseId argument is required"
+        );
+      });
+
+      it("should throw error when no project ID available", async () => {
+        mockCache.get.mockReturnValue(null);
+
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Release"
+        )[1];
+
+        await expect(
+          toolHandler({ releaseId: "rel-1" })
+        ).rejects.toThrow("No release for rel-1 found.");
+      });
+    });
+    
     describe('update_error tool handler', () => {
       it('should update error successfully with project from cache', async () => {
         const mockProject = { id: 'proj-1', name: 'Project 1' };

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -1446,7 +1446,6 @@ describe('BugsnagClient', () => {
       const registeredTools = registerToolsSpy.mock.calls.map((call: any) => call[0].title);
       expect(registeredTools).toContain('Get Error');
       expect(registeredTools).toContain('Get Event Details');
-      expect(registeredTools).toContain('Get Project');
       expect(registeredTools).toContain('List Project Errors');
       expect(registeredTools).toContain('List Project Event Filters');
       expect(registeredTools).toContain('Update Error');

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -2113,7 +2113,8 @@ describe('BugsnagClient', () => {
       });
 
       it("should throw error when no project ID available", async () => {
-        mockCache.get.mockReturnValue(null);
+        mockCache.get
+          .mockReturnValue(null);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
@@ -2122,7 +2123,7 @@ describe('BugsnagClient', () => {
 
         await expect(
           toolHandler({ buildId: "rel-1" })
-        ).rejects.toThrow("No build for rel-1 found.");
+        ).rejects.toThrow("No current project found. Please provide a projectId or configure a project API key.");
       });
     });
 

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -542,7 +542,7 @@ describe('BugsnagClient', () => {
       });
     });
 
-    describe("getBuilds", () => {
+    describe("listBuilds", () => {
       it("should return builds from API", async () => {
         const mockBuilds = [
           {

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -621,7 +621,7 @@ describe('BugsnagClient', () => {
           { release_stage: "staging" }
         );
       });
-      
+
       it("should handle pagination with next URL", async () => {
         const mockBuilds = [
           {
@@ -652,7 +652,7 @@ describe('BugsnagClient', () => {
         // Create headers with Link for pagination
         const headers = new Headers();
         headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/releases?offset=30&per_page=30>; rel="next"');
-        
+
         mockProjectAPI.listBuilds.mockResolvedValue({
           body: mockBuilds,
           headers,
@@ -665,7 +665,7 @@ describe('BugsnagClient', () => {
         expect(result.builds).toEqual(enhancedBuilds);
         expect(result.nextUrl).toBe('/projects/proj-1/releases?offset=30&per_page=30');
       });
-      
+
       it("should pass next_url parameter to ProjectAPI", async () => {
         mockProjectAPI.listBuilds.mockImplementation(() => ({
           body: [],
@@ -1049,7 +1049,7 @@ describe('BugsnagClient', () => {
           { release_stage_name: "staging", visible_only: false }
         );
       });
-      
+
       it("should handle pagination with next URL in listReleases", async () => {
         const mockReleases = [
           {
@@ -1082,7 +1082,7 @@ describe('BugsnagClient', () => {
         // Create headers with Link for pagination
         const headers = new Headers();
         headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/release_groups?offset=30&per_page=30>; rel="next"');
-        
+
         mockProjectAPI.listReleases.mockResolvedValue({
           body: mockReleases,
           headers,
@@ -1097,7 +1097,7 @@ describe('BugsnagClient', () => {
         expect(result.releases).toEqual(enhancedReleases);
         expect(result.nextUrl).toBe('/projects/proj-1/release_groups?offset=30&per_page=30');
       });
-      
+
       it("should pass next_url parameter to ProjectAPI in listReleases", async () => {
         mockProjectAPI.listReleases.mockImplementation(() => ({
           body: [],
@@ -1446,6 +1446,7 @@ describe('BugsnagClient', () => {
       const registeredTools = registerToolsSpy.mock.calls.map((call: any) => call[0].title);
       expect(registeredTools).toContain('Get Error');
       expect(registeredTools).toContain('Get Event Details');
+      expect(registeredTools).toContain('Get Project');
       expect(registeredTools).toContain('List Project Errors');
       expect(registeredTools).toContain('List Project Event Filters');
       expect(registeredTools).toContain('Update Error');


### PR DESCRIPTION
__Resubmitting as a fork, because I still don't have the GH access__

## Goal

Adding BugSnag release fetching in order to allow LLMs to get insight into application's releases and their stability.

## Design

New functionality was added alongside the current ones and uses the same approach.

## Changeset

- Added release fetching
- Added tests

## Testing

The change was tested manually and via the new unit tests.