### PR TITLE
chore(ci): avoid running node ci on every push

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -3,7 +3,11 @@
 
 name: Node CI
 
-on: [push]
+on:
+  push:
+    branches: [ main, next ]
+  pull_request:
+    branches: [ main, next ]
 
 permissions: read-all
 


### PR DESCRIPTION
## Goal

Instead, run only on pushes to certain branches, and on PRs targeting these branches.
