### PR TITLE
feat: add support for fetching pactflow AI entitlement

### DIFF
--- a/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
+++ b/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
@@ -121,6 +121,11 @@ Read more on PactFlow [Docs](https://docs.pactflow.io/).
   - Perform advanced queries using selectors to understand compatibility within specific branches or environments
   - Support informed deployment decisions by answering "can I deploy version X of this service to production?"
 
+### PactFlow AI Credits
+
+- Purpose: Retrieve the AI feature status for the PactFlow account, including whether AI is enabled, the number of remaining and consumed AI credits, and entitlement or permission issues preventing usage.
+
+
 ## Configuration Notes
 
 - **Required Environment Variables**: `PACT_BROKER_BASE_URL` is required for all operations.

--- a/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
+++ b/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
@@ -121,10 +121,9 @@ Read more on PactFlow [Docs](https://docs.pactflow.io/).
   - Perform advanced queries using selectors to understand compatibility within specific branches or environments
   - Support informed deployment decisions by answering "can I deploy version X of this service to production?"
 
-### PactFlow AI Credits
+### PactFlow AI Status
 
-- Purpose: Retrieve the AI feature status for the PactFlow account, including whether AI is enabled, the number of remaining and consumed AI credits, and entitlement or permission issues preventing usage.
-
+- Purpose: Retrieve the status of AI features for the PactFlow workspace, including whether AI features are enabled, the number of remaining and consumed AI credits, and user-level permissions issues preventing usage.
 
 ## Configuration Notes
 

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -140,14 +140,14 @@ export class PactflowClient implements Client {
     }
 
     /**
-     * Retrieves AI credits and entitlements information for the current user
+     * Retrieves AI status information for the current user
      * and organization.
      *
-     * @returns Entitlement containing AI credits information, organization
+     * @returns Entitlement containing AI status information, organization
      *   entitlements, and user entitlements.
      * @throws Error if the request fails or returns a non-OK response.
      */
-    async getAICredits(): Promise<Entitlement> {
+    async getAIStatus(): Promise<Entitlement> {
       const url = `${this.aiBaseUrl}/entitlement`;
 
       try {
@@ -159,7 +159,7 @@ export class PactflowClient implements Client {
         if (!response.ok) {
           const errorText = await response.text().catch(() => "");
           throw new Error(
-            `PactFlow AI Credits Request Failed - status: ${response.status} ${response.statusText}${
+            `PactFlow AI Status Request Failed - status: ${response.status} ${response.statusText}${
               errorText ? ` - ${errorText}` : ""
             }`
           );

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -11,6 +11,7 @@ import {
   RefineResponse,
   RefineInput,
   StatusResponse,
+  Entitlement
 } from "./client/ai.js";
 import {
   CanIDeployInput,
@@ -136,6 +137,39 @@ export class PactflowClient implements Client {
         status_response,
         "Review Pacts"
       );
+    }
+
+    /**
+     * Retrieves AI credits and entitlements information for the current user
+     * and organization.
+     *
+     * @returns Entitlement containing AI credits information, organization
+     *   entitlements, and user entitlements.
+     * @throws Error if the request fails or returns a non-OK response.
+     */
+    async getAICredits(): Promise<Entitlement> {
+      const url = `${this.aiBaseUrl}/entitlement`;
+
+      try {
+        const response = await fetch(url, {
+          method: "GET",
+          headers: this.headers,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "");
+          throw new Error(
+            `PactFlow AI Credits Request Failed - status: ${response.status} ${response.statusText}${
+              errorText ? ` - ${errorText}` : ""
+            }`
+          );
+        }
+
+        return (await response.json()) as Entitlement;
+      } catch (error) {
+        process.stderr.write(`[GetAICredits] Unexpected error: ${error}\n`);
+        throw error;
+      }
     }
 
     async getStatus(

--- a/src/pactflow/client/ai.ts
+++ b/src/pactflow/client/ai.ts
@@ -231,6 +231,44 @@ export const GenerationInputSchema = z.object({
 
 export const MatcherRecommendationInputSchema = z.array(EndpointMatcherSchema);
 
+export const AiCreditsSchema = z.object({
+  total: z
+    .number()
+    .describe("The total number of AI credits available."),
+  used: z
+    .number()
+    .describe("The number of AI credits used."),
+}).describe("AI credits information.");
+
+
+export const OrganizationEntitlementsSchema = z.object({
+  name: z
+    .string()
+    .describe("The name of the organization."),
+  planAiEnabled: z
+    .boolean()
+    .describe("Whether AI features are enabled at the plan level."),
+  preferencesAiEnabled: z
+    .boolean()
+    .describe("Whether AI features are enabled at the preferences level."),
+  aiCredits: AiCreditsSchema.describe("AI credits information."),
+}).describe("Organization entitlements information.");
+
+export const UserEntitlementsSchema = z.object({
+  aiPermissions: z
+    .array(z.string())
+    .describe("List of AI permissions."),
+}).describe("User entitlements information.");
+
+export const EntitlementsSchema = z.object({
+  organizationEntitlements: OrganizationEntitlementsSchema.describe(
+    "Organization entitlements information."
+  ),
+  userEntitlements: UserEntitlementsSchema.describe(
+    "User entitlements information."
+  ),
+}).describe("Entitlements information.");
+
 // types inferred from schemas
 export type RefineInput = z.infer<typeof RefineInputSchema>;
 export type FileInput = z.infer<typeof FileInputSchema>;
@@ -243,3 +281,4 @@ export type RemoteOpenAPIDocument = z.infer<typeof RemoteOpenAPIDocumentSchema>;
 export type MatcherRecommendations = z.infer<
   typeof MatcherRecommendationInputSchema
 >;
+export type Entitlement = z.infer<typeof EntitlementsSchema>;

--- a/src/pactflow/client/tools.ts
+++ b/src/pactflow/client/tools.ts
@@ -87,7 +87,7 @@ export const TOOLS: PactflowToolParams[] = [
     clients: ["pactflow", "pact_broker"]
   },
   {
-    title: "PactFlow AI Credits",
+    title: "PactFlow AI Status",
     summary: "Check PactFlow AI usage status, remaining credits, and eligibility",
     purpose: "Retrieve the AI feature status for the PactFlow account, including whether AI is enabled, the number of remaining and consumed AI credits, and entitlement or permission issues preventing usage.",
     useCases: [
@@ -97,7 +97,7 @@ export const TOOLS: PactflowToolParams[] = [
       "Integrate into deployment pipelines to ensure the environment is correctly configured with necessary entitlements and sufficient credits before executing AI-driven tasks",
       "Fetches usage and entitlement reports for auditing, budgeting, and compliance purposes"
     ],
-    handler: "getAICredits",
+    handler: "getAIStatus",
     clients: ["pactflow"]
   }
 ];

--- a/src/pactflow/client/tools.ts
+++ b/src/pactflow/client/tools.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { ToolParams } from "../../common/types.js";
 import {
   GenerationInputSchema,
-  RefineInputSchema
+  RefineInputSchema,
 } from "./ai.js";
 import { CanIDeploySchema, MatrixSchema } from "./base.js";
 
@@ -85,5 +85,19 @@ export const TOOLS: PactflowToolParams[] = [
     zodSchema: MatrixSchema,
     handler: "getMatrix",
     clients: ["pactflow", "pact_broker"]
+  },
+  {
+    title: "PactFlow AI Credits",
+    summary: "Check PactFlow AI usage status, remaining credits, and eligibility",
+    purpose: "Retrieve the AI feature status for the PactFlow account, including whether AI is enabled, the number of remaining and consumed AI credits, and entitlement or permission issues preventing usage.",
+    useCases: [
+      "Verify if AI functionality is enabled for the account before attempting to use AI-powered features",
+      "Monitor remaining and consumed AI credits to manage usage and avoid unexpected disruptions",
+      "Detect entitlement or permission issues when a user tries to access AI features and guide corrective actions",
+      "Integrate into deployment pipelines to ensure the environment is correctly configured with necessary entitlements and sufficient credits before executing AI-driven tasks",
+      "Fetches usage and entitlement reports for auditing, budgeting, and compliance purposes"
+    ],
+    handler: "getAICredits",
+    clients: ["pactflow"]
   }
 ];


### PR DESCRIPTION
## Goal

This PR adds support for fetching PactFlow AI entitlement - which Retrieves the AI feature status for the PactFlow account, including whether AI is enabled, the number of remaining and consumed AI credits, and entitlement or permission issues preventing its usage.

## Testing

The change was tested manually locally and via the unit tests.

- For valid Input
<img width="359" height="618" alt="Screenshot 2025-09-16 at 11 33 53 PM" src="https://github.com/user-attachments/assets/e65ebec8-1aa8-4263-9e90-9b6892ee194f" />

<img width="362" height="628" alt="Screenshot 2025-09-16 at 11 34 35 PM" src="https://github.com/user-attachments/assets/abb1fdbc-6ad1-4809-b490-aad814e5992b" />

- For Invalid Input ( with incorrect credentials )

<img width="378" height="534" alt="Screenshot 2025-09-16 at 11 32 46 PM" src="https://github.com/user-attachments/assets/d7b67152-9715-4109-9f5a-6feed1c8d76b" />
