### PR TITLE
Added code formatting tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,6 +25,18 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run format:check
+
   linting:
     runs-on: ubuntu-latest
     steps:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "objectWrap": "preserve",
+  "arrowParens": "always"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,22 +2,23 @@ import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
+import eslintConfigPrettier from "eslint-config-prettier/flat";
 
 /** @type {import("eslint").Linter.RulesRecord} */
 const customRules = {
   "@typescript-eslint/no-explicit-any": "off", // (Explicit) any has its valid use cases
-  "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }] // Allow unused arguments if they start with an underscore
-}
+  "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }], // Allow unused arguments if they start with an underscore
+};
 
 export default defineConfig([
   {
-    ignores: ["dist/**", "**/node_modules/**", "**/coverage/**"]
+    ignores: ["dist/**", "**/node_modules/**", "**/coverage/**"],
   },
   {
     files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
     plugins: { js },
     extends: ["js/recommended"],
-    languageOptions: { globals: globals.node }
+    languageOptions: { globals: globals.node },
   },
   tseslint.configs.recommended,
   { rules: customRules },
@@ -30,9 +31,13 @@ export default defineConfig([
       "@typescript-eslint/no-non-null-assertion": "off", // Sometimes needed for test assertions
       "@typescript-eslint/no-unused-expressions": "off", // Vitest expect statements
       // Allow longer lines in tests for descriptive test names
-      "max-len": ["error", { code: 120, ignoreStrings: true, ignoreTemplateLiterals: true }],
+      "max-len": [
+        "error",
+        { code: 120, ignoreStrings: true, ignoreTemplateLiterals: true },
+      ],
       // Allow console statements in tests (for debugging)
-      "no-console": "off"
-    }
-  }
+      "no-console": "off",
+    },
+  },
+  eslintConfigPrettier,
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^22",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.8",
         "globals": "^16.2.0",
         "prettier": "^3.6.2",
         "shx": "^0.3.4",
@@ -2952,6 +2953,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.29.0",
         "globals": "^16.2.0",
+        "prettier": "^3.6.2",
         "shx": "^0.3.4",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.34.1",
@@ -4497,6 +4498,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test:coverage:ci": "vitest --coverage --reporter=verbose",
     "test:run": "vitest run",
     "coverage:check": "vitest --coverage --reporter=verbose --config vitest.config.coverage.ts",
-    "format": "prettier --write src"
+    "format": "prettier --write src",
+    "format:check": "prettier --check src"
   },
   "dependencies": {
     "@bugsnag/js": "^8.2.0",
@@ -54,6 +55,7 @@
     "@types/node": "^22",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.8",
     "globals": "^16.2.0",
     "prettier": "^3.6.2",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:coverage": "vitest --coverage",
     "test:coverage:ci": "vitest --coverage --reporter=verbose",
     "test:run": "vitest run",
-    "coverage:check": "vitest --coverage --reporter=verbose --config vitest.config.coverage.ts"
+    "coverage:check": "vitest --coverage --reporter=verbose --config vitest.config.coverage.ts",
+    "format": "prettier --write src"
   },
   "dependencies": {
     "@bugsnag/js": "^8.2.0",
@@ -54,6 +55,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.29.0",
     "globals": "^16.2.0",
+    "prettier": "^3.6.2",
     "shx": "^0.3.4",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.34.1",

--- a/src/api-hub/client.ts
+++ b/src/api-hub/client.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
-import { Client, GetInputFunction, RegisterToolsFunction } from "../common/types.js";
+import {
+  Client,
+  GetInputFunction,
+  RegisterToolsFunction,
+} from "../common/types.js";
 
 // Type definitions for tool arguments
 export interface portalArgs {
@@ -19,7 +23,7 @@ export interface createPortalArgs {
   credentialsEnabled?: string;
   swaggerHubOrganizationId: string;
   openapiRenderer?: string;
-  pageContentFormat?: string
+  pageContentFormat?: string;
 }
 
 export interface updatePortalArgs extends portalArgs {
@@ -54,45 +58,56 @@ export interface updateProductArgs extends productArgs {
 
 // Tool definitions for API Hub API client
 export class ApiHubClient implements Client {
-  private headers: { "Authorization": string; "Content-Type": string, "User-Agent": string };
+  private headers: {
+    Authorization: string;
+    "Content-Type": string;
+    "User-Agent": string;
+  };
 
   name = "API Hub";
   prefix = "api_hub";
 
   constructor(token: string) {
     this.headers = {
-      "Authorization": `Bearer ${token}`,
+      Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
     };
   }
 
   async getPortals(): Promise<any> {
-    const response = await fetch("https://api.portal.swaggerhub.com/v1/portals", {
-      method: "GET",
-      headers: this.headers,
-    });
+    const response = await fetch(
+      "https://api.portal.swaggerhub.com/v1/portals",
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
 
     return response.json();
   }
 
   async createPortal(body: createPortalArgs): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals`,
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/portals`,
       {
         method: "POST",
         headers: this.headers,
         body: JSON.stringify(body),
-      },
+      }
     );
 
     return response.json();
   }
 
   async getPortal(portalId: string): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${portalId}`, {
-      method: "GET",
-      headers: this.headers,
-    });
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/portals/${portalId}`,
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
 
     return response.json();
   }
@@ -105,41 +120,54 @@ export class ApiHubClient implements Client {
   }
 
   async updatePortal(portalId: string, body: updatePortalArgs): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${portalId}`, {
-      method: "PATCH",
-      headers: this.headers,
-      body: JSON.stringify(body),
-    });
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/portals/${portalId}`,
+      {
+        method: "PATCH",
+        headers: this.headers,
+        body: JSON.stringify(body),
+      }
+    );
 
     return response.json();
   }
 
   async getPortalProducts(portalId: string): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${portalId}/products`, {
-      method: "GET",
-      headers: this.headers,
-    });
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/portals/${portalId}/products`,
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
 
     return response.json();
   }
 
-  async createPortalProduct(portalId: string, body: createProductArgs): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/portals/${portalId}/products`,
+  async createPortalProduct(
+    portalId: string,
+    body: createProductArgs
+  ): Promise<any> {
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/portals/${portalId}/products`,
       {
         method: "POST",
         headers: this.headers,
         body: JSON.stringify(body),
-      },
+      }
     );
 
     return response.json();
   }
 
   async getPortalProduct(productId: string): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/products/${productId}`, {
-      method: "GET",
-      headers: this.headers,
-    });
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/products/${productId}`,
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
 
     return response.json();
   }
@@ -151,21 +179,31 @@ export class ApiHubClient implements Client {
     });
   }
 
-  async updatePortalProduct(productId: string, body: updateProductArgs): Promise<any> {
-    const response = await fetch(`https://api.portal.swaggerhub.com/v1/products/${productId}`, {
-      method: "PATCH",
-      headers: this.headers,
-      body: JSON.stringify(body),
-    });
+  async updatePortalProduct(
+    productId: string,
+    body: updateProductArgs
+  ): Promise<any> {
+    const response = await fetch(
+      `https://api.portal.swaggerhub.com/v1/products/${productId}`,
+      {
+        method: "PATCH",
+        headers: this.headers,
+        body: JSON.stringify(body),
+      }
+    );
 
     return response.json();
   }
 
-  registerTools(register: RegisterToolsFunction, _getInput: GetInputFunction): void {
+  registerTools(
+    register: RegisterToolsFunction,
+    _getInput: GetInputFunction
+  ): void {
     register(
       {
         title: "List Portals",
-        summary: "Search for available portals within API Hub. Only portals where you have at least a designer role, either at the product level or organization level, are returned.",
+        summary:
+          "Search for available portals within API Hub. Only portals where you have at least a designer role, either at the product level or organization level, are returned.",
         parameters: [],
       },
       async (_args, _extra) => {
@@ -173,7 +211,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -196,13 +234,15 @@ export class ApiHubClient implements Client {
             name: "offline",
             type: z.boolean(),
             required: false,
-            description: "If set to true the portal will not be visible to customers.",
+            description:
+              "If set to true the portal will not be visible to customers.",
           },
           {
             name: "routing",
             type: z.string(),
             required: false,
-            description: "Determines the routing strategy ('browser' or 'proxy').",
+            description:
+              "Determines the routing strategy ('browser' or 'proxy').",
           },
           {
             name: "credentialsEnabled",
@@ -214,7 +254,8 @@ export class ApiHubClient implements Client {
             name: "swaggerHubOrganizationId",
             type: z.string(),
             required: true,
-            description: "The corresponding API Hub (formerly SwaggerHub) organization UUID.",
+            description:
+              "The corresponding API Hub (formerly SwaggerHub) organization UUID.",
           },
           {
             name: "openapiRenderer",
@@ -227,9 +268,8 @@ export class ApiHubClient implements Client {
             name: "pageContentFormat",
             type: z.string(),
             required: false,
-            description:
-              "The format of the page content.",
-          }
+            description: "The format of the page content.",
+          },
         ],
       },
       async (args, _extra) => {
@@ -238,7 +278,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -249,7 +289,7 @@ export class ApiHubClient implements Client {
             name: "portalId",
             type: z.string(),
             description: "Portal UUID or subdomain.",
-            required: true
+            required: true,
           },
         ],
       },
@@ -259,7 +299,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -270,8 +310,8 @@ export class ApiHubClient implements Client {
             name: "portalId",
             type: z.string(),
             description: "Portal UUID or subdomain.",
-            required: true
-          }
+            required: true,
+          },
         ],
       },
       async (args, _extra) => {
@@ -280,7 +320,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: "Portal deleted successfully." }],
         };
-      },
+      }
     );
     register(
       {
@@ -291,71 +331,77 @@ export class ApiHubClient implements Client {
             name: "portalId",
             type: z.string(),
             description: "Portal UUID or subdomain.",
-            required: true
+            required: true,
           },
           {
             name: "name",
             type: z.string(),
             description: "The portal name.",
-            required: false
+            required: false,
           },
           {
             name: "subdomain",
             type: z.string(),
             description: "The portal subdomain.",
-            required: false
+            required: false,
           },
           {
             name: "customDomain",
             type: z.boolean(),
             description: "Indicates if the portal has a custom domain.",
-            required: false
+            required: false,
           },
           {
             name: "gtmKey",
             type: z.string(),
             description: "Google Tag Manager key for the portal.",
-            required: false
+            required: false,
           },
           {
             name: "offline",
             type: z.boolean(),
-            description: "If set to true the portal will not be visible to customers.",
-            required: false
+            description:
+              "If set to true the portal will not be visible to customers.",
+            required: false,
           },
           {
             name: "routing",
             type: z.string(),
-            description: "Determines the routing strategy ('browser' or 'proxy').",
-            required: false
+            description:
+              "Determines the routing strategy ('browser' or 'proxy').",
+            required: false,
           },
           {
             name: "credentialsEnabled",
             type: z.boolean(),
             description: "Indicates if credentials are enabled for the portal.",
-            required: false
+            required: false,
           },
           {
             name: "openapiRenderer",
             type: z.string(),
-            description: "Portal level setting for the OpenAPI renderer. SWAGGER_UI - Use the Swagger UI renderer. ELEMENTS - Use the Elements renderer. TOGGLE - Switch between the two renderers with elements set as the default.",
-            required: false
+            description:
+              "Portal level setting for the OpenAPI renderer. SWAGGER_UI - Use the Swagger UI renderer. ELEMENTS - Use the Elements renderer. TOGGLE - Switch between the two renderers with elements set as the default.",
+            required: false,
           },
           {
             name: "pageContentFormat",
             type: z.string(),
             description: "The format of the page content.",
-            required: false
-          }
+            required: false,
+          },
         ],
       },
       async (args, _extra) => {
         const updatePortalArgs = args as updatePortalArgs;
-        const response = await this.updatePortal(updatePortalArgs.portalId, updatePortalArgs);
+        const response = await this.updatePortal(
+          updatePortalArgs.portalId,
+          updatePortalArgs
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -366,8 +412,8 @@ export class ApiHubClient implements Client {
             name: "portalId",
             type: z.string(),
             description: "Portal UUID or subdomain.",
-            required: true
-          }
+            required: true,
+          },
         ],
       },
       async (args, _extra) => {
@@ -376,7 +422,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -387,59 +433,63 @@ export class ApiHubClient implements Client {
             name: "portalId",
             type: z.string(),
             description: "Portal UUID or subdomain.",
-            required: true
+            required: true,
           },
           {
             name: "type",
             type: z.string(),
             description: "Product type (Allowed values: 'new', 'copy').",
-            required: true
+            required: true,
           },
           {
             name: "name",
             type: z.string(),
             description: "Product name.",
-            required: true
+            required: true,
           },
           {
             name: "slug",
             type: z.string(),
-            description: "URL component for this product. Must be unique within the portal.",
-            required: true
+            description:
+              "URL component for this product. Must be unique within the portal.",
+            required: true,
           },
           {
             name: "description",
             type: z.string(),
             description: "Product description.",
-            required: false
+            required: false,
           },
           {
             name: "public",
             type: z.boolean(),
             description: "Indicates if the product is public.",
-            required: false
+            required: false,
           },
           {
             name: "hidden",
             type: z.string(),
             description: "Indicates if the product is hidden.",
-            required: false
+            required: false,
           },
           {
             name: "role",
             type: z.boolean(),
             description: "Indicates if the product has a role.",
-            required: false
-          }
+            required: false,
+          },
         ],
       },
       async (args, _extra) => {
         const createProductArgs = args as createProductArgs;
-        const response = await this.createPortalProduct(createProductArgs.portalId, createProductArgs);
+        const response = await this.createPortalProduct(
+          createProductArgs.portalId,
+          createProductArgs
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -450,8 +500,8 @@ export class ApiHubClient implements Client {
             name: "productId",
             type: z.string(),
             description: "Product UUID, or identifier in the format.",
-            required: true
-          }
+            required: true,
+          },
         ],
       },
       async (args, _extra) => {
@@ -460,7 +510,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
     register(
       {
@@ -471,8 +521,8 @@ export class ApiHubClient implements Client {
             name: "productId",
             type: z.string(),
             description: "Product UUID, or identifier in the format.",
-            required: true
-          }
+            required: true,
+          },
         ],
       },
       async (args, _extra) => {
@@ -481,7 +531,7 @@ export class ApiHubClient implements Client {
         return {
           content: [{ type: "text", text: "Product deleted successfully." }],
         };
-      },
+      }
     );
     register(
       {
@@ -492,47 +542,51 @@ export class ApiHubClient implements Client {
             name: "productId",
             type: z.string(),
             description: "Product UUID, or identifier in the format.",
-            required: true
+            required: true,
           },
           {
             name: "name",
             type: z.string(),
             description: "Product name.",
-            required: false
+            required: false,
           },
           {
             name: "slug",
             type: z.string(),
-            description: "URL component for this product. Must be unique within the portal.",
-            required: false
+            description:
+              "URL component for this product. Must be unique within the portal.",
+            required: false,
           },
           {
             name: "description",
             type: z.string(),
             description: "Product description.",
-            required: false
+            required: false,
           },
           {
             name: "public",
             type: z.boolean(),
             description: "Indicates if the product is public.",
-            required: false
+            required: false,
           },
           {
             name: "hidden",
             type: z.string(),
             description: "Indicates if the product is hidden.",
-            required: false
-          }
+            required: false,
+          },
         ],
       },
       async (args, _extra) => {
         const updateProductArgs = args as updateProductArgs;
-        const response = await this.updatePortalProduct(updateProductArgs.productId, updateProductArgs);
+        const response = await this.updatePortalProduct(
+          updateProductArgs.productId,
+          updateProductArgs
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
-      },
+      }
     );
   }
 }

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -2,10 +2,19 @@ import NodeCache from "node-cache";
 import { z } from "zod";
 
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
-import { Client, GetInputFunction, RegisterResourceFunction, RegisterToolsFunction } from "../common/types.js";
+import {
+  Client,
+  GetInputFunction,
+  RegisterResourceFunction,
+  RegisterToolsFunction,
+} from "../common/types.js";
 import { CurrentUserAPI, ErrorAPI, Configuration } from "./client/index.js";
 import { Organization, Project } from "./client/api/CurrentUser.js";
-import { FilterObject, FilterObjectSchema, toQueryString } from "./client/api/filters.js";
+import {
+  FilterObject,
+  FilterObjectSchema,
+  toQueryString,
+} from "./client/api/filters.js";
 import { ListProjectErrorsOptions } from "./client/api/Error.js";
 import {
   EventField,
@@ -32,12 +41,12 @@ const cacheKeys = {
   CURRENT_PROJECT_EVENT_FILTERS: "bugsnag_current_project_event_filters",
   BUILD: "bugsnag_build", // + buildId
   RELEASE: "bugsnag_release", // + releaseId
-  BUILDS_IN_RELEASE: "bugsnag_builds_in_release" // + releaseId
-}
+  BUILDS_IN_RELEASE: "bugsnag_builds_in_release", // + releaseId
+};
 
 // Exclude certain event fields from the project event filters to improve agent usage
 const EXCLUDED_EVENT_FIELDS = new Set([
-  "search" // This is searches multiple fields and is more a convenience for humans, we're removing to avoid over-matching
+  "search", // This is searches multiple fields and is more a convenience for humans, we're removing to avoid over-matching
 ]);
 
 const PERMITTED_UPDATE_OPERATIONS = [
@@ -46,7 +55,7 @@ const PERMITTED_UPDATE_OPERATIONS = [
   "fix",
   "ignore",
   "discard",
-  "undiscard"
+  "undiscard",
 ] as const;
 
 // Type definitions for tool arguments
@@ -112,7 +121,7 @@ export class BugsnagClient implements Client {
   // If the endpoint is not provided, it will use the default API endpoint based on the project API key.
   // if the project api key is not provided, the endpoint will be the default API endpoint.
   // if the endpoint is provided, it will be used as is for custom domains, or normalized for known domains.
-  getEndpoint(subdomain: string, apiKey?: string, endpoint?: string,): string {
+  getEndpoint(subdomain: string, apiKey?: string, endpoint?: string): string {
     let subDomainEndpoint: string;
     if (!endpoint) {
       if (apiKey && apiKey.startsWith(HUB_PREFIX)) {
@@ -123,7 +132,10 @@ export class BugsnagClient implements Client {
     } else {
       // check if the endpoint matches either the HUB_DOMAIN or DEFAULT_DOMAIN
       const url = new URL(endpoint);
-      if (url.hostname.endsWith(HUB_DOMAIN) || url.hostname.endsWith(DEFAULT_DOMAIN)) {
+      if (
+        url.hostname.endsWith(HUB_DOMAIN) ||
+        url.hostname.endsWith(DEFAULT_DOMAIN)
+      ) {
         // For known domains (Hub or Bugsnag), always use HTTPS and standard format
         if (url.hostname.endsWith(HUB_DOMAIN)) {
           subDomainEndpoint = `https://${subdomain}.${HUB_DOMAIN}`;
@@ -142,7 +154,11 @@ export class BugsnagClient implements Client {
     return `${this.appEndpoint}/${(await this.getOrganization()).slug}/${project.slug}`;
   }
 
-  async getErrorUrl(project: Project, errorId: string, queryString = ''): Promise<string> {
+  async getErrorUrl(
+    project: Project,
+    errorId: string,
+    queryString = ""
+  ): Promise<string> {
     const dashboardUrl = await this.getDashboardUrl(project);
     return `${dashboardUrl}/errors/${errorId}${queryString}`;
   }
@@ -169,7 +185,9 @@ export class BugsnagClient implements Client {
     let projects = this.cache.get<Project[]>(cacheKeys.PROJECTS);
     if (!projects) {
       const org = await this.getOrganization();
-      const response = await this.currentUserApi.getOrganizationProjects(org.id);
+      const response = await this.currentUserApi.getOrganizationProjects(
+        org.id
+      );
       projects = response.body || [];
       this.cache.set(cacheKeys.PROJECTS, projects);
     }
@@ -187,42 +205,68 @@ export class BugsnagClient implements Client {
       const projects = await this.getProjects();
       project = projects.find((p) => p.api_key === this.projectApiKey) ?? null;
       if (!project) {
-        throw new Error(`Unable to find project with API key ${this.projectApiKey} in organization.`);
+        throw new Error(
+          `Unable to find project with API key ${this.projectApiKey} in organization.`
+        );
       }
       this.cache.set(cacheKeys.CURRENT_PROJECT, project);
       if (project) {
-        this.cache.set(cacheKeys.CURRENT_PROJECT_EVENT_FILTERS, await this.getProjectEventFilters(project));
+        this.cache.set(
+          cacheKeys.CURRENT_PROJECT_EVENT_FILTERS,
+          await this.getProjectEventFilters(project)
+        );
       }
     }
     return project;
   }
 
   async getProjectEventFilters(project: Project): Promise<EventField[]> {
-    let filtersResponse = (await this.projectApi.listProjectEventFields(project.id)).body;
+    let filtersResponse = (
+      await this.projectApi.listProjectEventFields(project.id)
+    ).body;
     if (!filtersResponse || filtersResponse.length === 0) {
       throw new Error(`No event fields found for project ${project.name}.`);
     }
-    filtersResponse = filtersResponse.filter(field => !EXCLUDED_EVENT_FIELDS.has(field.display_id));
+    filtersResponse = filtersResponse.filter(
+      (field) => !EXCLUDED_EVENT_FIELDS.has(field.display_id)
+    );
     return filtersResponse;
   }
 
   async getEvent(eventId: string, projectId?: string): Promise<any> {
-    const projectIds = projectId ? [projectId] : (await this.getProjects()).map((p) => p.id);
-    const projectEvents = await Promise.all(projectIds.map((projectId: string) => this.errorsApi.viewEventById(projectId, eventId).catch(_e => null)));
-    return projectEvents.find(event => event && !!event.body)?.body || null;
+    const projectIds = projectId
+      ? [projectId]
+      : (await this.getProjects()).map((p) => p.id);
+    const projectEvents = await Promise.all(
+      projectIds.map((projectId: string) =>
+        this.errorsApi.viewEventById(projectId, eventId).catch((_e) => null)
+      )
+    );
+    return projectEvents.find((event) => event && !!event.body)?.body || null;
   }
 
-  async updateError(projectId: string, errorId: string, operation: string, options?: any): Promise<boolean> {
+  async updateError(
+    projectId: string,
+    errorId: string,
+    operation: string,
+    options?: any
+  ): Promise<boolean> {
     const errorUpdateRequest = {
       operation: operation,
-      ...options
+      ...options,
     };
-    const response = await this.errorsApi.updateErrorOnProject(projectId, errorId, errorUpdateRequest);
+    const response = await this.errorsApi.updateErrorOnProject(
+      projectId,
+      errorId,
+      errorUpdateRequest
+    );
     return response.status === 200 || response.status === 204;
   }
 
-  private async getInputProject(projectId?: unknown | string): Promise<Project> {
-    if (typeof projectId === 'string') {
+  private async getInputProject(
+    projectId?: unknown | string
+  ): Promise<Project> {
+    if (typeof projectId === "string") {
       const maybeProject = await this.getProject(projectId);
       if (!maybeProject) {
         throw new Error(`Project with ID ${projectId} not found.`);
@@ -231,7 +275,9 @@ export class BugsnagClient implements Client {
     } else {
       const currentProject = await this.getCurrentProject();
       if (!currentProject) {
-        throw new Error('No current project found. Please provide a projectId or configure a project API key.');
+        throw new Error(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
       }
       return currentProject;
     }
@@ -240,11 +286,14 @@ export class BugsnagClient implements Client {
   async listBuilds(projectId: string, opts: ListBuildsOptions) {
     const response = await this.projectApi.listBuilds(projectId, opts);
     const fetchedBuilds = response.body || [];
-    const nextUrl = getNextUrlPathFromHeader(response.headers, this.apiEndpoint);
+    const nextUrl = getNextUrlPathFromHeader(
+      response.headers,
+      this.apiEndpoint
+    );
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedBuilds = fetchedBuilds.map(
-      (b) => this.addStabilityData(b, stabilityTargets)
+    const formattedBuilds = fetchedBuilds.map((b) =>
+      this.addStabilityData(b, stabilityTargets)
     );
 
     return { builds: formattedBuilds, nextUrl };
@@ -255,23 +304,30 @@ export class BugsnagClient implements Client {
     const build = this.cache.get<BuildResponse & StabilityData>(cacheKey);
     if (build) return build;
 
-    const fetchedBuild = (await this.projectApi.getBuild(projectId, buildId)).body;
+    const fetchedBuild = (await this.projectApi.getBuild(projectId, buildId))
+      .body;
     if (!fetchedBuild) throw new Error(`No build for ${buildId} found.`);
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedBuild = this.addStabilityData(fetchedBuild, stabilityTargets);
+    const formattedBuild = this.addStabilityData(
+      fetchedBuild,
+      stabilityTargets
+    );
     this.cache.set(cacheKey, formattedBuild, 5 * 60);
     return formattedBuild;
   }
 
   async listReleases(projectId: string, opts: ListReleasesOptions) {
-    const response = await this.projectApi.listReleases(projectId, opts)
+    const response = await this.projectApi.listReleases(projectId, opts);
     const fetchedReleases = response.body || [];
-    const nextUrl = getNextUrlPathFromHeader(response.headers, this.apiEndpoint);
+    const nextUrl = getNextUrlPathFromHeader(
+      response.headers,
+      this.apiEndpoint
+    );
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedReleases = fetchedReleases.map(
-      (r) => this.addStabilityData(r, stabilityTargets)
+    const formattedReleases = fetchedReleases.map((r) =>
+      this.addStabilityData(r, stabilityTargets)
     );
 
     return { releases: formattedReleases, nextUrl };
@@ -286,7 +342,10 @@ export class BugsnagClient implements Client {
     if (!fetchedRelease) throw new Error(`No release for ${releaseId} found.`);
 
     const stabilityTargets = await this.getProjectStabilityTargets(projectId);
-    const formattedRelease = this.addStabilityData(fetchedRelease, stabilityTargets);
+    const formattedRelease = this.addStabilityData(
+      fetchedRelease,
+      stabilityTargets
+    );
     this.cache.set(cacheKey, formattedRelease, 5 * 60);
     return formattedRelease;
   }
@@ -296,7 +355,8 @@ export class BugsnagClient implements Client {
     const builds = this.cache.get<BuildResponse[]>(cacheKey);
     if (builds) return builds;
 
-    const fetchedBuilds = (await this.projectApi.listBuildsInRelease(releaseId)).body || [];
+    const fetchedBuilds =
+      (await this.projectApi.listBuildsInRelease(releaseId)).body || [];
     this.cache.set(cacheKey, fetchedBuilds, 5 * 60);
     return fetchedBuilds;
   }
@@ -309,23 +369,28 @@ export class BugsnagClient implements Client {
     source: T,
     stabilityTargets: ProjectStabilityTargets
   ): T & StabilityData {
-    const { stability_target_type, target_stability, critical_stability } = stabilityTargets;
+    const { stability_target_type, target_stability, critical_stability } =
+      stabilityTargets;
 
     const user_stability =
       source.accumulative_daily_users_seen === 0 // avoid division by zero
         ? 0
-        : (source.accumulative_daily_users_seen - source.accumulative_daily_users_with_unhandled) /
+        : (source.accumulative_daily_users_seen -
+            source.accumulative_daily_users_with_unhandled) /
           source.accumulative_daily_users_seen;
 
     const session_stability =
       source.total_sessions_count === 0 // avoid division by zero
         ? 0
-        : (source.total_sessions_count - source.unhandled_sessions_count) / source.total_sessions_count;
+        : (source.total_sessions_count - source.unhandled_sessions_count) /
+          source.total_sessions_count;
 
-    const stabilityMetric = stability_target_type === "user" ? user_stability : session_stability;
+    const stabilityMetric =
+      stability_target_type === "user" ? user_stability : session_stability;
 
     const meets_target_stability = stabilityMetric >= target_stability.value;
-    const meets_critical_stability = stabilityMetric >= critical_stability.value;
+    const meets_critical_stability =
+      stabilityMetric >= critical_stability.value;
 
     return {
       ...source,
@@ -339,53 +404,60 @@ export class BugsnagClient implements Client {
     };
   }
 
-  registerTools(register: RegisterToolsFunction, getInput: GetInputFunction): void {
+  registerTools(
+    register: RegisterToolsFunction,
+    getInput: GetInputFunction
+  ): void {
     if (!this.projectApiKey) {
       register(
         {
           title: "List Projects",
-          summary: "List all projects in the organization with optional pagination",
-          purpose: "Retrieve available projects for browsing and selecting which project to analyze",
+          summary:
+            "List all projects in the organization with optional pagination",
+          purpose:
+            "Retrieve available projects for browsing and selecting which project to analyze",
           useCases: [
             "Browse available projects when no specific project API key is configured",
             "Find project IDs needed for other tools",
-            "Get an overview of all projects in the organization"
+            "Get an overview of all projects in the organization",
           ],
           parameters: [
             {
               name: "page_size",
               type: z.number(),
-              description: "Number of projects to return per page for pagination",
+              description:
+                "Number of projects to return per page for pagination",
               required: false,
-              examples: ["10", "25", "50"]
+              examples: ["10", "25", "50"],
             },
             {
               name: "page",
               type: z.number(),
               description: "Page number to return (starts from 1)",
               required: false,
-              examples: ["1", "2", "3"]
-            }
+              examples: ["1", "2", "3"],
+            },
           ],
           examples: [
             {
               description: "Get first 10 projects",
               parameters: {
                 page_size: 10,
-                page: 1
+                page: 1,
               },
-              expectedOutput: "JSON array of project objects with IDs, names, and metadata",
+              expectedOutput:
+                "JSON array of project objects with IDs, names, and metadata",
             },
             {
               description: "Get all projects (no pagination)",
               parameters: {},
-              expectedOutput: "JSON array of all available projects"
-            }
+              expectedOutput: "JSON array of all available projects",
+            },
           ],
           hints: [
             "Use pagination for organizations with many projects to avoid large responses",
-            "Project IDs from this list can be used with other tools when no project API key is configured"
-          ]
+            "Project IDs from this list can be used with other tools when no project API key is configured",
+          ],
         },
         async (args: any, _extra: any) => {
           let projects = await this.getProjects();
@@ -403,7 +475,7 @@ export class BugsnagClient implements Client {
           const result = {
             data: projects,
             count: projects.length,
-          }
+          };
           return {
             content: [{ type: "text", text: JSON.stringify(result) }],
           };
@@ -414,13 +486,15 @@ export class BugsnagClient implements Client {
     register(
       {
         title: "Get Error",
-        summary: "Get full details on an error, including aggregated and summarized data across all events (occurrences) and details of the latest event (occurrence), such as breadcrumbs, metadata and the stacktrace. Use the filters parameter to narrow down the summaries further.",
-        purpose: "Retrieve all the information required on a specified error to understand who it is affecting and why.",
+        summary:
+          "Get full details on an error, including aggregated and summarized data across all events (occurrences) and details of the latest event (occurrence), such as breadcrumbs, metadata and the stacktrace. Use the filters parameter to narrow down the summaries further.",
+        purpose:
+          "Retrieve all the information required on a specified error to understand who it is affecting and why.",
         useCases: [
           "Investigate a specific error found through the List Project Errors tool",
           "Understand which types of user are affected by the error using summarized event data",
           "Get error details for debugging and root cause analysis",
-          "Retrieve error metadata for incident reports and documentation"
+          "Retrieve error metadata for incident reports and documentation",
         ],
         parameters: [
           {
@@ -428,35 +502,39 @@ export class BugsnagClient implements Client {
             type: z.string(),
             required: true,
             description: "Unique identifier of the error to retrieve",
-            examples: ["6863e2af8c857c0a5023b411"]
+            examples: ["6863e2af8c857c0a5023b411"],
           },
-          ...(this.projectApiKey ? [] : [
-            {
-              name: "projectId",
-              type: z.string(),
-              required: true,
-              description: "ID of the project containing the error",
-            }
-          ]),
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  required: true,
+                  description: "ID of the project containing the error",
+                },
+              ]),
           {
             name: "filters",
             type: FilterObjectSchema,
             required: false,
-            description: "Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields",
+            description:
+              "Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields",
             examples: [
               '{"error.status": [{"type": "eq", "value": "open"}]}',
               '{"event.since": [{"type": "eq", "value": "7d"}]} // Relative time: last 7 days',
               '{"event.since": [{"type": "eq", "value": "2018-05-20T00:00:00Z"}]} // ISO 8601 UTC format',
-              '{"user.email": [{"type": "eq", "value": "user@example.com"}]}'
+              '{"user.email": [{"type": "eq", "value": "user@example.com"}]}',
             ],
             constraints: [
               "Time filters support ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h)",
               "ISO 8601 times must be in UTC and use extended format",
-              "Relative time periods: h (hours), d (days)"
-            ]
-          }
+              "Relative time periods: h (hours), d (days)",
+            ],
+          },
         ],
-        outputFormat: "JSON object containing: " +
+        outputFormat:
+          "JSON object containing: " +
           " - error_details: Aggregated data about the error, including first and last seen occurrence" +
           " - latest_event: Detailed information about the most recent occurrence of the error, including stacktrace, breadcrumbs, user and context" +
           " - pivots: List of pivots (summaries) for the error, which can be used to analyze patterns in occurrences" +
@@ -465,10 +543,11 @@ export class BugsnagClient implements Client {
           {
             description: "Get details for a specific error",
             parameters: {
-              errorId: "6863e2af8c857c0a5023b411"
+              errorId: "6863e2af8c857c0a5023b411",
             },
-            expectedOutput: "JSON object with error details including message, stack trace, occurrence count, and metadata"
-          }
+            expectedOutput:
+              "JSON object with error details including message, stack trace, occurrence count, and metadata",
+          },
         ],
         hints: [
           "Error IDs can be found using the List Project Errors tool",
@@ -479,25 +558,30 @@ export class BugsnagClient implements Client {
       },
       async (args, _extra) => {
         const project = await this.getInputProject(args.projectId);
-        if (!args.errorId) throw new Error("Both projectId and errorId arguments are required");
-        const errorDetails = (await this.errorsApi.viewErrorOnProject(project.id, args.errorId)).body;
+        if (!args.errorId)
+          throw new Error("Both projectId and errorId arguments are required");
+        const errorDetails = (
+          await this.errorsApi.viewErrorOnProject(project.id, args.errorId)
+        ).body;
         if (!errorDetails) {
-          throw new Error(`Error with ID ${args.errorId} not found in project ${project.id}.`);
+          throw new Error(
+            `Error with ID ${args.errorId} not found in project ${project.id}.`
+          );
         }
 
         // Build query parameters
         const params = new URLSearchParams();
 
         // Add sorting and pagination parameters to get the latest event
-        params.append('sort', 'timestamp');
-        params.append('direction', 'desc');
-        params.append('per_page', '1');
-        params.append('full_reports', 'true');
+        params.append("sort", "timestamp");
+        params.append("direction", "desc");
+        params.append("per_page", "1");
+        params.append("full_reports", "true");
 
         const filters: FilterObject = {
-          "error": [{ type: "eq", value: args.errorId }],
-          ...args.filters
-        }
+          error: [{ type: "eq", value: args.errorId }],
+          ...args.filters,
+        };
 
         const filtersQueryString = toQueryString(filters);
         const listEventsQueryString = `?${params}&${filtersQueryString}`;
@@ -505,7 +589,10 @@ export class BugsnagClient implements Client {
         // Get the latest event for this error using the events endpoint with filters
         let latestEvent = null;
         try {
-          const eventsResponse = await this.errorsApi.listEventsOnProject(project.id, listEventsQueryString);
+          const eventsResponse = await this.errorsApi.listEventsOnProject(
+            project.id,
+            listEventsQueryString
+          );
           const events = eventsResponse.body || [];
           latestEvent = events[0] || null;
         } catch (e) {
@@ -516,11 +603,17 @@ export class BugsnagClient implements Client {
         const content = {
           error_details: errorDetails,
           latest_event: latestEvent,
-          pivots: (await this.errorsApi.listErrorPivots(project.id, args.errorId)).body || [],
-          url: await this.getErrorUrl(project, args.errorId, `?${filtersQueryString}`),
-        }
+          pivots:
+            (await this.errorsApi.listErrorPivots(project.id, args.errorId))
+              .body || [],
+          url: await this.getErrorUrl(
+            project,
+            args.errorId,
+            `?${filtersQueryString}`
+          ),
+        };
         return {
-          content: [{ type: "text", text: JSON.stringify(content) }]
+          content: [{ type: "text", text: JSON.stringify(content) }],
         };
       }
     );
@@ -528,47 +621,54 @@ export class BugsnagClient implements Client {
     register(
       {
         title: "Get Event Details",
-        summary: "Get detailed information about a specific event using its dashboard URL",
-        purpose: "Retrieve event details directly from a dashboard URL for quick debugging",
+        summary:
+          "Get detailed information about a specific event using its dashboard URL",
+        purpose:
+          "Retrieve event details directly from a dashboard URL for quick debugging",
         useCases: [
           "Get event details when given a dashboard URL from a user or notification",
           "Extract event information from shared links or browser URLs",
-          "Quick lookup of event details without needing separate project and event IDs"
+          "Quick lookup of event details without needing separate project and event IDs",
         ],
         parameters: [
           {
             name: "link",
             type: z.string(),
-            description: "Full URL to the event details page in the BugSnag dashboard (web interface)",
+            description:
+              "Full URL to the event details page in the BugSnag dashboard (web interface)",
             required: true,
             examples: [
-              "https://app.bugsnag.com/my-org/my-project/errors/6863e2af8c857c0a5023b411?event_id=6863e2af012caf1d5c320000"
+              "https://app.bugsnag.com/my-org/my-project/errors/6863e2af8c857c0a5023b411?event_id=6863e2af012caf1d5c320000",
             ],
             constraints: [
-              "Must be a valid dashboard URL containing project slug and event_id parameter"
-            ]
-          }
+              "Must be a valid dashboard URL containing project slug and event_id parameter",
+            ],
+          },
         ],
         examples: [
           {
             description: "Get event details from a dashboard URL",
             parameters: {
-              link: "https://app.bugsnag.com/my-org/my-project/errors/6863e2af8c857c0a5023b411?event_id=6863e2af012caf1d5c320000"
+              link: "https://app.bugsnag.com/my-org/my-project/errors/6863e2af8c857c0a5023b411?event_id=6863e2af012caf1d5c320000",
             },
-            expectedOutput: "JSON object with complete event details including stack trace, metadata, and context"
-          }
+            expectedOutput:
+              "JSON object with complete event details including stack trace, metadata, and context",
+          },
         ],
         hints: [
           "The URL must contain both project slug in the path and event_id in query parameters",
-          "This is useful when users share BugSnag dashboard URLs and you need to extract the event data"
-        ]
+          "This is useful when users share BugSnag dashboard URLs and you need to extract the event data",
+        ],
       },
       async (args: any, _extra: any) => {
         if (!args.link) throw new Error("link argument is required");
         const url = new URL(args.link);
         const eventId = url.searchParams.get("event_id");
-        const projectSlug = url.pathname.split('/')[2];
-        if (!projectSlug || !eventId) throw new Error("Both projectSlug and eventId must be present in the link");
+        const projectSlug = url.pathname.split("/")[2];
+        if (!projectSlug || !eventId)
+          throw new Error(
+            "Both projectSlug and eventId must be present in the link"
+          );
 
         // get the project id from list of projects
         const projects = await this.getProjects();
@@ -587,105 +687,122 @@ export class BugsnagClient implements Client {
     register(
       {
         title: "List Project Errors",
-        summary: "List and search errors in a project using customizable filters and pagination",
-        purpose: "Retrieve filtered list of errors from a project for analysis, debugging, and reporting",
+        summary:
+          "List and search errors in a project using customizable filters and pagination",
+        purpose:
+          "Retrieve filtered list of errors from a project for analysis, debugging, and reporting",
         useCases: [
           "Debug recent application errors by filtering for open errors in the last 7 days",
           "Generate error reports for stakeholders by filtering specific error types or severity levels",
           "Monitor error trends over time using date range filters",
-          "Find errors affecting specific users or environments using metadata filters"
+          "Find errors affecting specific users or environments using metadata filters",
         ],
         parameters: [
           {
             name: "filters",
             type: FilterObjectSchema.default({
               "event.since": [{ type: "eq", value: "30d" }],
-              "error.status": [{ type: "eq", value: "open" }]
+              "error.status": [{ type: "eq", value: "open" }],
             }),
-            description: "Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields",
+            description:
+              "Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields",
             required: false,
             examples: [
-                '{"error.status": [{"type": "eq", "value": "open"}]}',
-                '{"event.since": [{"type": "eq", "value": "7d"}]} // Relative time: last 7 days',
-                '{"event.since": [{"type": "eq", "value": "2018-05-20T00:00:00Z"}]} // ISO 8601 UTC format',
-                '{"user.email": [{"type": "eq", "value": "user@example.com"}]}'
+              '{"error.status": [{"type": "eq", "value": "open"}]}',
+              '{"event.since": [{"type": "eq", "value": "7d"}]} // Relative time: last 7 days',
+              '{"event.since": [{"type": "eq", "value": "2018-05-20T00:00:00Z"}]} // ISO 8601 UTC format',
+              '{"user.email": [{"type": "eq", "value": "user@example.com"}]}',
             ],
             constraints: [
               "Time filters support ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h)",
               "ISO 8601 times must be in UTC and use extended format",
-              "Relative time periods: h (hours), d (days)"
-            ]
+              "Relative time periods: h (hours), d (days)",
+            ],
           },
           {
             name: "sort",
-            type: z.enum(["first_seen", "last_seen", "events", "users", "unsorted"]).default("last_seen"),
+            type: z
+              .enum(["first_seen", "last_seen", "events", "users", "unsorted"])
+              .default("last_seen"),
             description: "Field to sort the errors by",
             required: false,
-            examples: ["last_seen"]
+            examples: ["last_seen"],
           },
           {
             name: "direction",
             type: z.enum(["asc", "desc"]).default("desc"),
             description: "Sort direction for ordering results",
             required: false,
-            examples: ["desc"]
+            examples: ["desc"],
           },
           {
             name: "per_page",
             type: z.number().min(1).max(100).default(30),
             description: "How many results to return per page.",
             required: false,
-            examples: ["30", "50", "100"]
+            examples: ["30", "50", "100"],
           },
           {
             name: "next",
             type: z.string().url(),
-            description: "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available.",
+            description:
+              "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available.",
             required: false,
-            examples: ["https://api.bugsnag.com/projects/515fb9337c1074f6fd000003/errors?offset=30&per_page=30&sort=last_seen"],
-            constraints: ["Only values provided in the output from this tool can be used. Do not attempt to construct it manually."]
+            examples: [
+              "https://api.bugsnag.com/projects/515fb9337c1074f6fd000003/errors?offset=30&per_page=30&sort=last_seen",
+            ],
+            constraints: [
+              "Only values provided in the output from this tool can be used. Do not attempt to construct it manually.",
+            ],
           },
-          ...(this.projectApiKey ? [] : [
-            {
-              name: "projectId",
-              type: z.string(),
-              description: "ID of the project to query for errors",
-              required: true,
-            }
-          ])
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  description: "ID of the project to query for errors",
+                  required: true,
+                },
+              ]),
         ],
         examples: [
           {
-            description: "Find errors affecting a specific user in the last 24 hours",
+            description:
+              "Find errors affecting a specific user in the last 24 hours",
             parameters: {
               filters: {
-                "user.email": [{ "type": "eq", "value": "user@example.com" }],
-                "event.since": [{ "type": "eq", "value": "24h" }]
-              }
+                "user.email": [{ type: "eq", value: "user@example.com" }],
+                "event.since": [{ type: "eq", value: "24h" }],
+              },
             },
-            expectedOutput: "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field"
+            expectedOutput:
+              "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field",
           },
           {
-            description: "Get the 10 open errors with the most users affected in the last 30 days",
+            description:
+              "Get the 10 open errors with the most users affected in the last 30 days",
             parameters: {
               filters: {
-                "event.since": [{ "type": "eq", "value": "30d" }],
-                "error.status": [{ "type": "eq", "value": "open" }]
+                "event.since": [{ type: "eq", value: "30d" }],
+                "error.status": [{ type: "eq", value: "open" }],
               },
               sort: "users",
               direction: "desc",
-              per_page: 10
+              per_page: 10,
             },
-            expectedOutput: "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field"
+            expectedOutput:
+              "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field",
           },
           {
             description: "Get the next 50 results",
             parameters: {
               next: "https://api.bugsnag.com/projects/515fb9337c1074f6fd000003/errors?base=2025-08-29T13%3A11%3A37Z&direction=desc&filters%5Berror.status%5D%5B%5D%5Btype%5D=eq&filters%5Berror.status%5D%5B%5D%5Bvalue%5D=open&offset=10&per_page=10&sort=users",
-              per_page: 50
+              per_page: 50,
             },
-            expectedOutput: "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field"
-          }
+            expectedOutput:
+              "JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field",
+          },
         ],
         hints: [
           "Use list_project_event_filters tool first to discover valid filter field names for your project",
@@ -696,16 +813,19 @@ export class BugsnagClient implements Client {
           "There may not be any errors matching the filters - this is not a problem with the tool, in fact it might be a good thing that the user's application had no errors",
           "This tool returns paged results. The 'count' field indicates the number of results returned in the current page, and the 'total' field indicates the total number of results across all pages.",
           "If the output contains a 'next' value, there are more results available - call this tool again supplying the next URL as a parameter to retrieve the next page.",
-          "Do not modify the next URL as this can cause incorrect results. The only other parameter that can be used with 'next' is 'per_page' to control the page size."
-        ]
+          "Do not modify the next URL as this can cause incorrect results. The only other parameter that can be used with 'next' is 'per_page' to control the page size.",
+        ],
       },
       async (args: any, _extra: any) => {
         const project = await this.getInputProject(args.projectId);
 
         // Validate filter keys against cached event fields
         if (args.filters) {
-          const eventFields = this.cache.get<EventField[]>(cacheKeys.CURRENT_PROJECT_EVENT_FILTERS) || [];
-          const validKeys = new Set(eventFields.map(f => f.display_id));
+          const eventFields =
+            this.cache.get<EventField[]>(
+              cacheKeys.CURRENT_PROJECT_EVENT_FILTERS
+            ) || [];
+          const validKeys = new Set(eventFields.map((f) => f.display_id));
           for (const key of Object.keys(args.filters)) {
             if (!validKeys.has(key)) {
               throw new Error(`Invalid filter key: ${key}`);
@@ -714,12 +834,12 @@ export class BugsnagClient implements Client {
         }
 
         const defaultFilters: FilterObject = {
-          "event.since": [{ "type": "eq", "value": "30d" }],
-          "error.status": [{ "type": "eq", "value": "open" }]
-        }
+          "event.since": [{ type: "eq", value: "30d" }],
+          "error.status": [{ type: "eq", value: "open" }],
+        };
 
         const options: ListProjectErrorsOptions = {
-          filters: { ...defaultFilters, ...args.filters }
+          filters: { ...defaultFilters, ...args.filters },
         };
 
         if (args.sort !== undefined) options.sort = args.sort;
@@ -727,11 +847,14 @@ export class BugsnagClient implements Client {
         if (args.per_page !== undefined) options.per_page = args.per_page;
         if (args.next !== undefined) options.next = args.next;
 
-        const response = await this.errorsApi.listProjectErrors(project.id, options);
+        const response = await this.errorsApi.listProjectErrors(
+          project.id,
+          options
+        );
 
         const errors = response.body || [];
-        const totalCount = response.headers.get('X-Total-Count');
-        const linkHeader = response.headers.get('Link');
+        const totalCount = response.headers.get("X-Total-Count");
+        const linkHeader = response.headers.get("Link");
 
         const result = {
           data: errors,
@@ -749,27 +872,31 @@ export class BugsnagClient implements Client {
       {
         title: "List Project Event Filters",
         summary: "Get available event filter fields for the current project",
-        purpose: "Discover valid filter field names and options that can be used with the List Errors or Get Error tools",
+        purpose:
+          "Discover valid filter field names and options that can be used with the List Errors or Get Error tools",
         useCases: [
           "Discover what filter fields are available before searching for errors",
           "Find the correct field names for filtering by user, environment, or custom metadata",
-          "Understand filter options and data types for building complex queries"
+          "Understand filter options and data types for building complex queries",
         ],
         parameters: [],
         examples: [
           {
             description: "Get all available filter fields",
             parameters: {},
-            expectedOutput: "JSON array of EventField objects containing display_id, custom flag, and filter/pivot options"
-          }
+            expectedOutput:
+              "JSON array of EventField objects containing display_id, custom flag, and filter/pivot options",
+          },
         ],
         hints: [
           "Use this tool before the List Errors or Get Error tools to understand available filters",
-          "Look for display_id field in the response - these are the field names to use in filters"
-        ]
+          "Look for display_id field in the response - these are the field names to use in filters",
+        ],
       },
       async (_args: any, _extra: any) => {
-        const projectFields = this.cache.get<EventField[]>(cacheKeys.CURRENT_PROJECT_EVENT_FILTERS);
+        const projectFields = this.cache.get<EventField[]>(
+          cacheKeys.CURRENT_PROJECT_EVENT_FILTERS
+        );
         if (!projectFields) throw new Error("No event filters found in cache.");
 
         return {
@@ -782,48 +909,53 @@ export class BugsnagClient implements Client {
       {
         title: "Update Error",
         summary: "Update the status of an error",
-        purpose: "Change an error's workflow state, such as marking it as resolved or ignored",
+        purpose:
+          "Change an error's workflow state, such as marking it as resolved or ignored",
         useCases: [
           "Mark an error as open, fixed or ignored",
           "Discard or un-discard an error",
-          "Update the severity of an error"
+          "Update the severity of an error",
         ],
         parameters: [
-          ...(this.projectApiKey ? [] : [
-            {
-              name: "projectId",
-              type: z.string(),
-              description: "ID of the project that contains the error to be updated",
-              required: true,
-            }
-          ]),
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  description:
+                    "ID of the project that contains the error to be updated",
+                  required: true,
+                },
+              ]),
           {
             name: "errorId",
             type: z.string(),
             description: "ID of the error to update",
             required: true,
-            examples: ["6863e2af8c857c0a5023b411"]
+            examples: ["6863e2af8c857c0a5023b411"],
           },
           {
             name: "operation",
             type: z.enum(PERMITTED_UPDATE_OPERATIONS),
             description: "The operation to apply to the error",
             required: true,
-            examples: ["fix", "open", "ignore", "discard", "undiscard"]
-          }
+            examples: ["fix", "open", "ignore", "discard", "undiscard"],
+          },
         ],
         examples: [
           {
             description: "Mark an error as fixed",
             parameters: {
               errorId: "6863e2af8c857c0a5023b411",
-              operation: "fix"
+              operation: "fix",
             },
-            expectedOutput: "Success response indicating the error was marked as fixed"
-          }
+            expectedOutput:
+              "Success response indicating the error was marked as fixed",
+          },
         ],
         hints: [
-          "Only use valid operations - BugSnag may reject invalid values"
+          "Only use valid operations - BugSnag may reject invalid values",
         ],
         readOnly: false,
         idempotent: false,
@@ -833,31 +965,36 @@ export class BugsnagClient implements Client {
         const project = await this.getInputProject(args.projectId);
 
         let severity = undefined;
-        if (operation === 'override_severity') {
+        if (operation === "override_severity") {
           // illicit the severity from the user
           const result = await getInput({
-            message: "Please provide the new severity for the error (e.g. 'info', 'warning', 'error', 'critical')",
+            message:
+              "Please provide the new severity for the error (e.g. 'info', 'warning', 'error', 'critical')",
             requestedSchema: {
               type: "object",
               properties: {
                 severity: {
                   type: "string",
-                  enum: ['info', 'warning', 'error'],
-                  description: "The new severity level for the error"
-                }
-              }
+                  enum: ["info", "warning", "error"],
+                  description: "The new severity level for the error",
+                },
+              },
             },
-            required: ["severity"]
-          })
+            required: ["severity"],
+          });
 
           if (result.action === "accept" && result.content?.severity) {
             severity = result.content.severity;
           }
         }
 
-        const result = await this.updateError(project.id!, errorId, operation, { severity });
+        const result = await this.updateError(project.id!, errorId, operation, {
+          severity,
+        });
         return {
-          content: [{ type: "text", text: JSON.stringify({ success: result }) }],
+          content: [
+            { type: "text", text: JSON.stringify({ success: result }) },
+          ],
         };
       }
     );
@@ -865,8 +1002,10 @@ export class BugsnagClient implements Client {
     register(
       {
         title: "List Builds",
-        summary: "List builds for a project with optional filtering by release stage",
-        purpose: "Retrieve a list of build summaries to analyze deployment history and associated errors",
+        summary:
+          "List builds for a project with optional filtering by release stage",
+        purpose:
+          "Retrieve a list of build summaries to analyze deployment history and associated errors",
         useCases: [
           "View recent builds to correlate with error spikes",
           "Filter builds by stage (e.g. production, staging) for targeted analysis",
@@ -885,7 +1024,8 @@ export class BugsnagClient implements Client {
           {
             name: "releaseStage",
             type: z.string(),
-            description: "Filter builds by this stage (e.g. production, staging)",
+            description:
+              "Filter builds by this stage (e.g. production, staging)",
             required: false,
             examples: ["production", "staging"],
           },
@@ -911,15 +1051,18 @@ export class BugsnagClient implements Client {
             parameters: {
               releaseStage: "production",
             },
-            expectedOutput: "JSON array of build objects in the production stage",
+            expectedOutput:
+              "JSON array of build objects in the production stage",
           },
           {
             description: "Get the next page of results",
             parameters: {
-              nextUrl: "/projects/515fb9337c1074f6fd000003/builds?offset=30&per_page=30",
+              nextUrl:
+                "/projects/515fb9337c1074f6fd000003/builds?offset=30&per_page=30",
             },
-            expectedOutput: "JSON array of build objects with metadata from the next page",
-          }
+            expectedOutput:
+              "JSON array of build objects with metadata from the next page",
+          },
         ],
         hints: ["For more detailed results use the Get Build tool"],
         readOnly: true,
@@ -931,7 +1074,7 @@ export class BugsnagClient implements Client {
         const { builds, nextUrl } = await this.listBuilds(project.id, {
           release_stage: args.releaseStage,
           next_url: args.nextUrl,
-        })
+        });
 
         return {
           content: [
@@ -941,7 +1084,7 @@ export class BugsnagClient implements Client {
                 builds,
                 next: nextUrl,
               }),
-            }
+            },
           ],
         };
       }
@@ -951,7 +1094,8 @@ export class BugsnagClient implements Client {
       {
         title: "Get Build",
         summary: "Get more details for a specific build by its ID",
-        purpose: "Retrieve detailed information about a build for analysis and debugging",
+        purpose:
+          "Retrieve detailed information about a build for analysis and debugging",
         useCases: [
           "View build metadata such as version, source control info, and error counts",
           "Analyze a specific build to correlate with error spikes or deployments",
@@ -994,214 +1138,239 @@ export class BugsnagClient implements Client {
       },
       async (args, _extra) => {
         if (!args.buildId) throw new Error("buildId argument is required");
-        const build = await this.getBuild((await this.getInputProject(args.projectId)).id, args.buildId);
+        const build = await this.getBuild(
+          (await this.getInputProject(args.projectId)).id,
+          args.buildId
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(build) }],
         };
       }
     );
 
-    register({
-      title: "List Releases",
-      summary: "List releases for a project with optional filtering by release stage",
-      purpose: "Retrieve a list of release summaries to analyze deployment history and associated errors",
-      useCases: [
-        "View recent releases to correlate with error spikes",
-        "Filter releases by stage (e.g. production, staging) for targeted analysis",
-      ],
-      parameters: [
-        ...(this.projectApiKey
-          ? []
-          : [
-              {
-                name: "projectId",
-                type: z.string(),
-                description: "ID of the project to list releases for",
-                required: true,
-              },
-            ]),
-        {
-          name: "releaseStage",
-          type: z.string(),
-          description: "Filter releases by this stage (e.g. production, staging)",
-          required: false,
-          examples: ["production", "staging"],
-        },
-        {
-          name: "visibleOnly",
-          type: z.boolean().default(true),
-          description: "Whether to only include releases that are marked as visible (default: true)",
-          required: true,
-          examples: ["true", "false"],
-        },
-        {
-          name: "nextUrl",
-          type: z.string(),
-          description:
-            "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. If provided, other parameters are ignored.",
-          required: false,
-          examples: [
-            "/projects/515fb9337c1074f6fd000003/releases?offset=30&per_page=30",
-          ],
-        },
-      ],
-      examples: [
-        {
-          description: "List all releases for a project",
-          parameters: {},
-          expectedOutput: "JSON array of release objects with metadata",
-        },
-        {
-          description: "List production releases for a project",
-          parameters: {
-            releaseStage: "production",
-          },
-          expectedOutput: "JSON array of release objects in the production stage",
-        },
-        {
-          description: "Get the next page of results",
-          parameters: {
-            nextUrl: "/projects/515fb9337c1074f6fd000003/releases?offset=30&per_page=30",
-          },
-          expectedOutput: "JSON array of release objects with metadata from the next page",
-        },
-      ],
-      hints: ["For more detailed results use the Get Release tool"],
-      readOnly: true,
-      idempotent: true,
-      outputFormat: "JSON array of release summary objects with metadata",
-    }, async (args, _extra) => {
-      const { releases, nextUrl } = await this.listReleases((await this.getInputProject(args.projectId)).id, {
-        release_stage_name: args.releaseStage ?? "production",
-        visible_only: args.visibleOnly,
-        next_url: args.nextUrl ?? null,
-      })
-
-      return {
-        content: [
+    register(
+      {
+        title: "List Releases",
+        summary:
+          "List releases for a project with optional filtering by release stage",
+        purpose:
+          "Retrieve a list of release summaries to analyze deployment history and associated errors",
+        useCases: [
+          "View recent releases to correlate with error spikes",
+          "Filter releases by stage (e.g. production, staging) for targeted analysis",
+        ],
+        parameters: [
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  description: "ID of the project to list releases for",
+                  required: true,
+                },
+              ]),
           {
-            type: "text",
-            text: JSON.stringify({
-              releases,
-              next: nextUrl ?? null,
-            }),
+            name: "releaseStage",
+            type: z.string(),
+            description:
+              "Filter releases by this stage (e.g. production, staging)",
+            required: false,
+            examples: ["production", "staging"],
+          },
+          {
+            name: "visibleOnly",
+            type: z.boolean().default(true),
+            description:
+              "Whether to only include releases that are marked as visible (default: true)",
+            required: true,
+            examples: ["true", "false"],
+          },
+          {
+            name: "nextUrl",
+            type: z.string(),
+            description:
+              "URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. If provided, other parameters are ignored.",
+            required: false,
+            examples: [
+              "/projects/515fb9337c1074f6fd000003/releases?offset=30&per_page=30",
+            ],
           },
         ],
-      };
-    })
-
-    register({
-      title: "Get Release",
-      summary: "Get more details for a specific release by its ID",
-      purpose: "Retrieve detailed information about a release for analysis and debugging",
-      useCases: [
-        "View release metadata such as version, source control info, and error counts",
-        "Analyze a specific release to correlate with error spikes or deployments",
-        "See the stability targets for a project and if the release meets them",
-      ],
-      parameters: [
-        ...(this.projectApiKey
-          ? []
-          : [
-              {
-                name: "projectId",
-                type: z.string(),
-                description: "ID of the project containing the release",
-                required: true,
-              },
-            ]),
-        {
-          name: "releaseId",
-          type: z.string(),
-          description: "ID of the release to retrieve",
-          required: true,
-          examples: ["5f8d0d55c9e77c0017a1b2c3"],
-        },
-      ],
-      examples: [
-        {
-          description: "Get details for a specific release",
-          parameters: {
-            releaseId: "5f8d0d55c9e77c0017a1b2c3",
+        examples: [
+          {
+            description: "List all releases for a project",
+            parameters: {},
+            expectedOutput: "JSON array of release objects with metadata",
           },
-          expectedOutput:
-            "JSON object with release details including version, source control info, error counts and stability data.",
-        },
-      ],
-      hints: ["Release IDs can be found using the List releases tool"],
-      readOnly: true,
-      idempotent: true,
-      outputFormat:
-        "JSON object containing release details along with stability metrics such as user and session stability, and whether it meets project targets",
-    }, async (args, _extra) => {
-      if (!args.releaseId) throw new Error("releaseId argument is required");
-      const release = await this.getRelease((await this.getInputProject(args.projectId)).id, args.releaseId);
-      return {
-        content: [{ type: "text", text: JSON.stringify(release) }],
-      };
-    })
-
-    register({
-      title: "List Builds in Release",
-      summary: "List builds associated with a specific release",
-      purpose: "Retrieve a list of builds for a given release to analyze deployment history and associated errors",
-      useCases: [
-        "View builds within a release to correlate with error spikes",
-        "Analyze the composition of a release by examining its builds",
-      ],
-      parameters: [
-        ...(this.projectApiKey
-          ? []
-          : [
-              {
-                name: "projectId",
-                type: z.string(),
-                description: "ID of the project containing the release",
-                required: true,
-              },
-            ]),
-        {
-          name: "releaseId",
-          type: z.string(),
-          description: "ID of the release to list builds for",
-          required: true,
-          examples: ["5f8d0d55c9e77c0017a1b2c3"],
-        },
-      ],
-      examples: [
-        {
-          description: "List all builds in a specific release",
-          parameters: {
-            releaseId: "5f8d0d55c9e77c0017a1b2c3",
+          {
+            description: "List production releases for a project",
+            parameters: {
+              releaseStage: "production",
+            },
+            expectedOutput:
+              "JSON array of release objects in the production stage",
           },
-          expectedOutput: "JSON array of build objects with metadata",
-        },
-      ],
-      hints: ["Release IDs can be found using the List releases tool"],
-      readOnly: true,
-      idempotent: true,
-      outputFormat: "JSON array of build summary objects with metadata",
-    }, async (args, _extra) => {
-      if (!args.releaseId) throw new Error("releaseId argument is required");
-      const builds = await this.listBuildsInRelease(args.releaseId);
-      return {
-        content: [{ type: "text", text: JSON.stringify(builds) }],
-      };
-    })
+          {
+            description: "Get the next page of results",
+            parameters: {
+              nextUrl:
+                "/projects/515fb9337c1074f6fd000003/releases?offset=30&per_page=30",
+            },
+            expectedOutput:
+              "JSON array of release objects with metadata from the next page",
+          },
+        ],
+        hints: ["For more detailed results use the Get Release tool"],
+        readOnly: true,
+        idempotent: true,
+        outputFormat: "JSON array of release summary objects with metadata",
+      },
+      async (args, _extra) => {
+        const { releases, nextUrl } = await this.listReleases(
+          (await this.getInputProject(args.projectId)).id,
+          {
+            release_stage_name: args.releaseStage ?? "production",
+            visible_only: args.visibleOnly,
+            next_url: args.nextUrl ?? null,
+          }
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                releases,
+                next: nextUrl ?? null,
+              }),
+            },
+          ],
+        };
+      }
+    );
+
+    register(
+      {
+        title: "Get Release",
+        summary: "Get more details for a specific release by its ID",
+        purpose:
+          "Retrieve detailed information about a release for analysis and debugging",
+        useCases: [
+          "View release metadata such as version, source control info, and error counts",
+          "Analyze a specific release to correlate with error spikes or deployments",
+          "See the stability targets for a project and if the release meets them",
+        ],
+        parameters: [
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  description: "ID of the project containing the release",
+                  required: true,
+                },
+              ]),
+          {
+            name: "releaseId",
+            type: z.string(),
+            description: "ID of the release to retrieve",
+            required: true,
+            examples: ["5f8d0d55c9e77c0017a1b2c3"],
+          },
+        ],
+        examples: [
+          {
+            description: "Get details for a specific release",
+            parameters: {
+              releaseId: "5f8d0d55c9e77c0017a1b2c3",
+            },
+            expectedOutput:
+              "JSON object with release details including version, source control info, error counts and stability data.",
+          },
+        ],
+        hints: ["Release IDs can be found using the List releases tool"],
+        readOnly: true,
+        idempotent: true,
+        outputFormat:
+          "JSON object containing release details along with stability metrics such as user and session stability, and whether it meets project targets",
+      },
+      async (args, _extra) => {
+        if (!args.releaseId) throw new Error("releaseId argument is required");
+        const release = await this.getRelease(
+          (await this.getInputProject(args.projectId)).id,
+          args.releaseId
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(release) }],
+        };
+      }
+    );
+
+    register(
+      {
+        title: "List Builds in Release",
+        summary: "List builds associated with a specific release",
+        purpose:
+          "Retrieve a list of builds for a given release to analyze deployment history and associated errors",
+        useCases: [
+          "View builds within a release to correlate with error spikes",
+          "Analyze the composition of a release by examining its builds",
+        ],
+        parameters: [
+          ...(this.projectApiKey
+            ? []
+            : [
+                {
+                  name: "projectId",
+                  type: z.string(),
+                  description: "ID of the project containing the release",
+                  required: true,
+                },
+              ]),
+          {
+            name: "releaseId",
+            type: z.string(),
+            description: "ID of the release to list builds for",
+            required: true,
+            examples: ["5f8d0d55c9e77c0017a1b2c3"],
+          },
+        ],
+        examples: [
+          {
+            description: "List all builds in a specific release",
+            parameters: {
+              releaseId: "5f8d0d55c9e77c0017a1b2c3",
+            },
+            expectedOutput: "JSON array of build objects with metadata",
+          },
+        ],
+        hints: ["Release IDs can be found using the List releases tool"],
+        readOnly: true,
+        idempotent: true,
+        outputFormat: "JSON array of build summary objects with metadata",
+      },
+      async (args, _extra) => {
+        if (!args.releaseId) throw new Error("releaseId argument is required");
+        const builds = await this.listBuildsInRelease(args.releaseId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(builds) }],
+        };
+      }
+    );
   }
 
   registerResources(register: RegisterResourceFunction): void {
-    register(
-      "event",
-      "{id}",
-      async (uri, variables, _extra) => {
-        return {
-          contents: [{
+    register("event", "{id}", async (uri, variables, _extra) => {
+      return {
+        contents: [
+          {
             uri: uri.href,
-            text: JSON.stringify(await this.getEvent(variables.id as string))
-          }]
-        }
-      }
-    )
+            text: JSON.stringify(await this.getEvent(variables.id as string)),
+          },
+        ],
+      };
+    });
   }
 }

--- a/src/bugsnag/client/api/CurrentUser.ts
+++ b/src/bugsnag/client/api/CurrentUser.ts
@@ -1,5 +1,5 @@
-import { BaseAPI, pickFieldsFromArray, ApiResponse } from './base.js';
-import { Configuration } from '../configuration.js';
+import { BaseAPI, pickFieldsFromArray, ApiResponse } from "./base.js";
+import { Configuration } from "../configuration.js";
 
 // --- Response Types ---
 
@@ -21,9 +21,13 @@ export interface Project {
 // --- API Class ---
 
 export class CurrentUserAPI extends BaseAPI {
-  static filterFields: string[] = ["collaborators_url", "projects_url", "upgrade_url"]
-  static organizationFields: (keyof Organization)[] = ['id', 'name', 'slug'];
-  static projectFields: (keyof Project)[] = ['id', 'name', 'slug', 'api_key'];
+  static filterFields: string[] = [
+    "collaborators_url",
+    "projects_url",
+    "upgrade_url",
+  ];
+  static organizationFields: (keyof Organization)[] = ["id", "name", "slug"];
+  static projectFields: (keyof Project)[] = ["id", "name", "slug", "api_key"];
 
   constructor(configuration: Configuration) {
     super(configuration, CurrentUserAPI.filterFields);
@@ -33,22 +37,32 @@ export class CurrentUserAPI extends BaseAPI {
    * List the current user's organizations
    * GET /user/organizations
    */
-  async listUserOrganizations(options: ListUserOrganizationsOptions = {}): Promise<ApiResponse<ListUserOrganizationsResponse>> {
+  async listUserOrganizations(
+    options: ListUserOrganizationsOptions = {}
+  ): Promise<ApiResponse<ListUserOrganizationsResponse>> {
     const { admin, paginate = false, ...queryOptions } = options;
     const params = new URLSearchParams();
-    if (admin !== undefined) params.append('admin', String(admin));
+    if (admin !== undefined) params.append("admin", String(admin));
     for (const [key, value] of Object.entries(queryOptions)) {
       if (value !== undefined) params.append(key, String(value));
     }
-    const url = params.toString() ? `/user/organizations?${params}` : '/user/organizations';
-    const data = await this.request<ListUserOrganizationsResponse>({
-      method: 'GET',
-      url,
-    }, paginate);
+    const url = params.toString()
+      ? `/user/organizations?${params}`
+      : "/user/organizations";
+    const data = await this.request<ListUserOrganizationsResponse>(
+      {
+        method: "GET",
+        url,
+      },
+      paginate
+    );
     // Only return allowed fields
     return {
       ...data,
-      body: pickFieldsFromArray<Organization>(data.body || [], CurrentUserAPI.organizationFields)
+      body: pickFieldsFromArray<Organization>(
+        data.body || [],
+        CurrentUserAPI.organizationFields
+      ),
     };
   }
 
@@ -59,7 +73,10 @@ export class CurrentUserAPI extends BaseAPI {
    * @param options Optional parameters for filtering, pagination, etc.
    * @returns A promise that resolves to the list of projects in the organization
    */
-  async getOrganizationProjects(organizationId: string, options: GetOrganizationProjectsOptions = {}): Promise<ApiResponse<Project[]>> {
+  async getOrganizationProjects(
+    organizationId: string,
+    options: GetOrganizationProjectsOptions = {}
+  ): Promise<ApiResponse<Project[]>> {
     const { ...queryOptions } = options;
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(queryOptions)) {
@@ -68,13 +85,19 @@ export class CurrentUserAPI extends BaseAPI {
     const url = params.toString()
       ? `/organizations/${organizationId}/projects?${params}`
       : `/organizations/${organizationId}/projects`;
-    const data = await this.request<Project[]>({
-      method: 'GET',
-      url,
-    }, true); // Always paginate for projects
+    const data = await this.request<Project[]>(
+      {
+        method: "GET",
+        url,
+      },
+      true
+    ); // Always paginate for projects
     return {
       ...data,
-      body: pickFieldsFromArray<Project>(data.body || [], CurrentUserAPI.projectFields)
+      body: pickFieldsFromArray<Project>(
+        data.body || [],
+        CurrentUserAPI.projectFields
+      ),
     };
   }
 }

--- a/src/bugsnag/client/api/Error.ts
+++ b/src/bugsnag/client/api/Error.ts
@@ -1,6 +1,6 @@
-import { ApiResponse, BaseAPI } from './base.js';
-import { Configuration } from '../configuration.js';
-import { FilterObject, toQueryString } from './filters.js';
+import { ApiResponse, BaseAPI } from "./base.js";
+import { Configuration } from "../configuration.js";
+import { FilterObject, toQueryString } from "./filters.js";
 
 // --- Response Types ---
 
@@ -47,8 +47,8 @@ export interface ViewEventByIdOptions {
 
 export interface ListProjectErrorsOptions {
   base?: string; // date-time format
-  sort?: 'last_seen' | 'first_seen' | 'users' | 'events' | 'unsorted';
-  direction?: 'asc' | 'desc';
+  sort?: "last_seen" | "first_seen" | "users" | "events" | "unsorted";
+  direction?: "asc" | "desc";
   per_page?: number;
   filters?: FilterObject; // Filters object as defined in the API spec
   next?: string;
@@ -78,22 +78,22 @@ export interface ListPivotsOptions {
 }
 
 export const ErrorOperations = [
-  'override_severity',
-  'assign',
-  'create_issue',
-  'link_issue',
-  'unlink_issue',
-  'open',
-  'snooze',
-  'fix',
-  'ignore',
-  'delete',
-  'discard',
-  'undiscard'
+  "override_severity",
+  "assign",
+  "create_issue",
+  "link_issue",
+  "unlink_issue",
+  "open",
+  "snooze",
+  "fix",
+  "ignore",
+  "delete",
+  "discard",
+  "undiscard",
 ] as const;
 
 export interface ErrorUpdateRequest {
-  operation: typeof ErrorOperations[number];
+  operation: (typeof ErrorOperations)[number];
   assigned_collaborator_id?: string;
   assigned_team_id?: string;
   issue_url?: string;
@@ -105,14 +105,14 @@ export interface ErrorUpdateRequest {
 }
 
 export const ReopenConditions = [
-  'occurs_after',
-  'n_occurrences_in_m_hours',
-  'n_additional_occurrences',
-  'n_additional_users'
+  "occurs_after",
+  "n_occurrences_in_m_hours",
+  "n_additional_occurrences",
+  "n_additional_users",
 ] as const;
 
 export interface ErrorUpdateReopenRules {
-  reopen_if: typeof ReopenConditions[number];
+  reopen_if: (typeof ReopenConditions)[number];
   additional_users?: number;
   seconds?: number;
   occurrences?: number;
@@ -123,7 +123,7 @@ export interface ErrorUpdateReopenRules {
 // --- API Class ---
 
 export class ErrorAPI extends BaseAPI {
-  static filterFields: string[] = ["url", "project_url", "events_url"]
+  static filterFields: string[] = ["url", "project_url", "events_url"];
   constructor(configuration: Configuration) {
     super(configuration, ErrorAPI.filterFields);
   }
@@ -132,7 +132,11 @@ export class ErrorAPI extends BaseAPI {
    * View an Error on a Project
    * GET /projects/{project_id}/errors/{error_id}
    */
-  async viewErrorOnProject(projectId: string, errorId: string, options: ViewErrorOnProjectOptions = {}): Promise<ApiResponse<ViewErrorOnProjectResponse>> {
+  async viewErrorOnProject(
+    projectId: string,
+    errorId: string,
+    options: ViewErrorOnProjectOptions = {}
+  ): Promise<ApiResponse<ViewErrorOnProjectResponse>> {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(options)) {
       if (value !== undefined) params.append(key, String(value));
@@ -141,7 +145,7 @@ export class ErrorAPI extends BaseAPI {
       ? `/projects/${projectId}/errors/${errorId}?${params}`
       : `/projects/${projectId}/errors/${errorId}`;
     return (await this.request<ViewErrorOnProjectResponse>({
-      method: 'GET',
+      method: "GET",
       url,
     })) as ApiResponse<ViewErrorOnProjectResponse>;
   }
@@ -150,7 +154,10 @@ export class ErrorAPI extends BaseAPI {
    * View the latest Event on an Error
    * GET /errors/{error_id}/latest_event
    */
-  async viewLatestEventOnError(errorId: string, options: ViewLatestEventOnErrorOptions = {}): Promise<ApiResponse<ViewLatestEventOnErrorResponse>> {
+  async viewLatestEventOnError(
+    errorId: string,
+    options: ViewLatestEventOnErrorOptions = {}
+  ): Promise<ApiResponse<ViewLatestEventOnErrorResponse>> {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(options)) {
       if (value !== undefined) params.append(key, String(value));
@@ -159,7 +166,7 @@ export class ErrorAPI extends BaseAPI {
       ? `/errors/${errorId}/latest_event?${params}`
       : `/errors/${errorId}/latest_event`;
     return (await this.request<ViewLatestEventOnErrorResponse>({
-      method: 'GET',
+      method: "GET",
       url,
     })) as ApiResponse<ViewLatestEventOnErrorResponse>;
   }
@@ -168,11 +175,14 @@ export class ErrorAPI extends BaseAPI {
    * List the Events on a Project
    * GET /projects/{project_id}/events
    */
-  async listEventsOnProject(projectId: string, queryString = ''): Promise<ApiResponse<Event[]>> {
+  async listEventsOnProject(
+    projectId: string,
+    queryString = ""
+  ): Promise<ApiResponse<Event[]>> {
     const url = `/projects/${projectId}/events${queryString}`;
 
     return await this.request<Event[]>({
-      method: 'GET',
+      method: "GET",
       url,
     });
   }
@@ -181,7 +191,11 @@ export class ErrorAPI extends BaseAPI {
    * View an Event by ID
    * GET /projects/{project_id}/events/{event_id}
    */
-  async viewEventById(projectId: string, eventId: string, options: ViewEventByIdOptions = {}): Promise<ApiResponse<ViewEventByIdResponse>> {
+  async viewEventById(
+    projectId: string,
+    eventId: string,
+    options: ViewEventByIdOptions = {}
+  ): Promise<ApiResponse<ViewEventByIdResponse>> {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(options)) {
       if (value !== undefined) params.append(key, String(value));
@@ -190,7 +204,7 @@ export class ErrorAPI extends BaseAPI {
       ? `/projects/${projectId}/events/${eventId}?${params}`
       : `/projects/${projectId}/events/${eventId}`;
     return (await this.request<ViewEventByIdResponse>({
-      method: 'GET',
+      method: "GET",
       url,
     })) as ApiResponse<ViewEventByIdResponse>;
   }
@@ -199,15 +213,18 @@ export class ErrorAPI extends BaseAPI {
    * List the Errors on a Project
    * GET /projects/{project_id}/errors
    */
-  async listProjectErrors(projectId: string, options: ListProjectErrorsOptions = {}): Promise<ApiResponse<ErrorApiView[]>> {
-    let url = `/projects/${projectId}/errors`
+  async listProjectErrors(
+    projectId: string,
+    options: ListProjectErrorsOptions = {}
+  ): Promise<ApiResponse<ErrorApiView[]>> {
+    let url = `/projects/${projectId}/errors`;
 
     // Next links need to be used as-is to ensure results are consistent, so only the page size can be modified
     if (options.next !== undefined) {
       const nextUrl = new URL(options.next);
 
       if (options.per_page !== undefined) {
-        nextUrl.searchParams.set('per_page', options.per_page.toString());
+        nextUrl.searchParams.set("per_page", options.per_page.toString());
       }
 
       url = nextUrl.toString();
@@ -216,7 +233,9 @@ export class ErrorAPI extends BaseAPI {
 
       // Add filter parameters
       if (options.filters) {
-        const filterParams = new URLSearchParams(toQueryString(options.filters));
+        const filterParams = new URLSearchParams(
+          toQueryString(options.filters)
+        );
         filterParams.forEach((value, key) => {
           params.append(key, value);
         });
@@ -224,19 +243,19 @@ export class ErrorAPI extends BaseAPI {
 
       // Add pagination and sorting parameters
       if (options.base !== undefined) {
-        params.append('base', options.base);
+        params.append("base", options.base);
       }
 
       if (options.sort !== undefined) {
-        params.append('sort', options.sort);
+        params.append("sort", options.sort);
       }
 
       if (options.direction !== undefined) {
-        params.append('direction', options.direction);
+        params.append("direction", options.direction);
       }
 
       if (options.per_page !== undefined) {
-        params.append('per_page', options.per_page.toString());
+        params.append("per_page", options.per_page.toString());
       }
 
       if (params.size > 0) {
@@ -245,7 +264,7 @@ export class ErrorAPI extends BaseAPI {
     }
 
     return (await this.request<ErrorApiView[]>({
-      method: 'GET',
+      method: "GET",
       url,
     })) as ApiResponse<ErrorApiView[]>;
   }
@@ -268,7 +287,7 @@ export class ErrorAPI extends BaseAPI {
       ? `/projects/${projectId}/errors/${errorId}?${params}`
       : `/projects/${projectId}/errors/${errorId}`;
     return (await this.request<ErrorApiView>({
-      method: 'PATCH',
+      method: "PATCH",
       url,
       body: data,
     })) as ApiResponse<ErrorApiView>;
@@ -278,7 +297,11 @@ export class ErrorAPI extends BaseAPI {
    * List Pivots on an Error
    * GET /projects/{project_id}/errors/{error_id}/pivots
    */
-  async listErrorPivots(projectId: string, errorId: string, options: ListPivotsOptions = {}): Promise<ApiResponse<PivotApiView[]>> {
+  async listErrorPivots(
+    projectId: string,
+    errorId: string,
+    options: ListPivotsOptions = {}
+  ): Promise<ApiResponse<PivotApiView[]>> {
     const params = new URLSearchParams();
 
     if (options.filters) {
@@ -289,17 +312,17 @@ export class ErrorAPI extends BaseAPI {
     }
 
     if (options.summary_size !== undefined) {
-      params.append('summary_size', options.summary_size.toString());
+      params.append("summary_size", options.summary_size.toString());
     }
 
     if (options.pivots && options.pivots.length > 0) {
-      options.pivots.forEach(pivot => {
-        params.append('pivots[]', pivot);
+      options.pivots.forEach((pivot) => {
+        params.append("pivots[]", pivot);
       });
     }
 
     if (options.per_page !== undefined) {
-      params.append('per_page', options.per_page.toString());
+      params.append("per_page", options.per_page.toString());
     }
 
     const url = params.toString()
@@ -307,7 +330,7 @@ export class ErrorAPI extends BaseAPI {
       : `/projects/${projectId}/errors/${errorId}/pivots`;
 
     return await this.request<PivotApiView[]>({
-      method: 'GET',
+      method: "GET",
       url,
     });
   }

--- a/src/bugsnag/client/api/Project.ts
+++ b/src/bugsnag/client/api/Project.ts
@@ -1,5 +1,10 @@
 import { Configuration } from "../configuration.js";
-import { BaseAPI, pickFieldsFromArray, ApiResponse, pickFields } from "./base.js";
+import {
+  BaseAPI,
+  pickFieldsFromArray,
+  ApiResponse,
+  pickFields,
+} from "./base.js";
 import { Project as ProjectApiView } from "./CurrentUser.js";
 
 // --- Response Types ---
@@ -29,72 +34,72 @@ export interface ListProjectEventFieldsOptions {
 }
 
 export type ProjectType =
-  | 'android'
-  | 'angular'
-  | 'asgi'
-  | 'aspnet'
-  | 'aspnet_core'
-  | 'backbone'
-  | 'bottle'
-  | 'cocos2dx'
-  | 'connect'
-  | 'django'
-  | 'dotnet'
-  | 'dotnet_desktop'
-  | 'dotnet_mvc'
-  | 'electron'
-  | 'ember'
-  | 'eventmachine'
-  | 'expo'
-  | 'express'
-  | 'flask'
-  | 'flutter'
-  | 'gin'
-  | 'go'
-  | 'go_net_http'
-  | 'heroku'
-  | 'ios'
-  | 'java'
-  | 'java_desktop'
-  | 'js'
-  | 'koa'
-  | 'laravel'
-  | 'lumen'
-  | 'magento'
-  | 'martini'
-  | 'minidump'
-  | 'ndk'
-  | 'negroni'
-  | 'nintendo_switch'
-  | 'node'
-  | 'osx'
-  | 'other_desktop'
-  | 'other_mobile'
-  | 'other_tv'
-  | 'php'
-  | 'python'
-  | 'rack'
-  | 'rails'
-  | 'react'
-  | 'reactnative'
-  | 'restify'
-  | 'revel'
-  | 'ruby'
-  | 'silex'
-  | 'sinatra'
-  | 'spring'
-  | 'symfony'
-  | 'tornado'
-  | 'tvos'
-  | 'unity'
-  | 'unrealengine'
-  | 'vue'
-  | 'watchos'
-  | 'webapi'
-  | 'wordpress'
-  | 'wpf'
-  | 'wsgi'
-  | 'other';
+  | "android"
+  | "angular"
+  | "asgi"
+  | "aspnet"
+  | "aspnet_core"
+  | "backbone"
+  | "bottle"
+  | "cocos2dx"
+  | "connect"
+  | "django"
+  | "dotnet"
+  | "dotnet_desktop"
+  | "dotnet_mvc"
+  | "electron"
+  | "ember"
+  | "eventmachine"
+  | "expo"
+  | "express"
+  | "flask"
+  | "flutter"
+  | "gin"
+  | "go"
+  | "go_net_http"
+  | "heroku"
+  | "ios"
+  | "java"
+  | "java_desktop"
+  | "js"
+  | "koa"
+  | "laravel"
+  | "lumen"
+  | "magento"
+  | "martini"
+  | "minidump"
+  | "ndk"
+  | "negroni"
+  | "nintendo_switch"
+  | "node"
+  | "osx"
+  | "other_desktop"
+  | "other_mobile"
+  | "other_tv"
+  | "php"
+  | "python"
+  | "rack"
+  | "rails"
+  | "react"
+  | "reactnative"
+  | "restify"
+  | "revel"
+  | "ruby"
+  | "silex"
+  | "sinatra"
+  | "spring"
+  | "symfony"
+  | "tornado"
+  | "tvos"
+  | "unity"
+  | "unrealengine"
+  | "vue"
+  | "watchos"
+  | "webapi"
+  | "wordpress"
+  | "wpf"
+  | "wsgi"
+  | "other";
 
 // Project create
 export interface ProjectCreateRequest {
@@ -166,7 +171,7 @@ export interface ListReleasesOptions {
 }
 
 export interface ReleaseSummaryResponse {
-  id: string
+  id: string;
   release_stage_name: string;
   app_version: string;
   first_released_at: string;
@@ -230,8 +235,18 @@ export interface StabilityTargetData {
 // --- API Class ---
 
 export class ProjectAPI extends BaseAPI {
-  static filterFields: string[] = ["errors_url", "events_url", "url", "html_url"]
-  static eventFieldFields: (keyof EventField)[] = ["custom", "display_id", "filter_options", "pivot_options"];
+  static filterFields: string[] = [
+    "errors_url",
+    "events_url",
+    "url",
+    "html_url",
+  ];
+  static eventFieldFields: (keyof EventField)[] = [
+    "custom",
+    "display_id",
+    "filter_options",
+    "pivot_options",
+  ];
   static buildFields: (keyof BuildSummaryResponse)[] = [
     "id",
     "release_time",
@@ -257,7 +272,7 @@ export class ProjectAPI extends BaseAPI {
     "sessions_count_in_last_24h",
     "accumulative_daily_users_seen",
     "accumulative_daily_users_with_unhandled",
-  ]
+  ];
   static stabilityFields: (keyof ProjectStabilityTargets)[] = [
     "critical_stability",
     "target_stability",
@@ -274,18 +289,23 @@ export class ProjectAPI extends BaseAPI {
    * @param projectId The project ID
    * @returns A promise that resolves to the list of event fields
    */
-  async listProjectEventFields(projectId: string): Promise<ApiResponse<EventField[]>> {
+  async listProjectEventFields(
+    projectId: string
+  ): Promise<ApiResponse<EventField[]>> {
     const url = `/projects/${projectId}/event_fields`;
 
     const data = await this.request<EventField[]>({
-      method: 'GET',
+      method: "GET",
       url,
     });
 
     // Only return allowed fields
     return {
       ...data,
-      body: pickFieldsFromArray<EventField>(data.body || [], ProjectAPI.eventFieldFields)
+      body: pickFieldsFromArray<EventField>(
+        data.body || [],
+        ProjectAPI.eventFieldFields
+      ),
     };
   }
 
@@ -296,10 +316,13 @@ export class ProjectAPI extends BaseAPI {
    * @param data The project creation request body
    * @returns A promise that resolves to the created project
    */
-  async createProject(organizationId: string, data: ProjectCreateRequest): Promise<ApiResponse<ProjectApiView>> {
+  async createProject(
+    organizationId: string,
+    data: ProjectCreateRequest
+  ): Promise<ApiResponse<ProjectApiView>> {
     const url = `/organizations/${organizationId}/projects`;
     return await this.request<ProjectApiView>({
-      method: 'POST',
+      method: "POST",
       url,
       body: data,
     });
@@ -318,7 +341,10 @@ export class ProjectAPI extends BaseAPI {
       url,
     });
 
-    return pickFields<ProjectStabilityTargets>(response.body || {}, ProjectAPI.stabilityFields);
+    return pickFields<ProjectStabilityTargets>(
+      response.body || {},
+      ProjectAPI.stabilityFields
+    );
   }
 
   /**
@@ -329,7 +355,9 @@ export class ProjectAPI extends BaseAPI {
    * @returns A promise that resolves to an array of `ListReleasesResponse` objects.
    */
   async listBuilds(projectId: string, opts: ListBuildsOptions) {
-    const url = opts.next_url ?? `/projects/${projectId}/releases${opts.release_stage ? `?release_stage=${opts.release_stage}` : ""}`;
+    const url =
+      opts.next_url ??
+      `/projects/${projectId}/releases${opts.release_stage ? `?release_stage=${opts.release_stage}` : ""}`;
     const response = await this.request<BuildSummaryResponse[]>({
       method: "GET",
       url,
@@ -337,7 +365,10 @@ export class ProjectAPI extends BaseAPI {
 
     return {
       ...response,
-      body: pickFieldsFromArray<BuildSummaryResponse>(response.body || [], ProjectAPI.buildFields),
+      body: pickFieldsFromArray<BuildSummaryResponse>(
+        response.body || [],
+        ProjectAPI.buildFields
+      ),
     };
   }
 
@@ -364,15 +395,20 @@ export class ProjectAPI extends BaseAPI {
    * @returns A promise that resolves to an array of `ReleaseSummaryResponse` objects.
    */
   async listReleases(projectId: string, opts: ListReleasesOptions) {
-    const url = opts.next_url ?? `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}&top_only=true`
+    const url =
+      opts.next_url ??
+      `/projects/${projectId}/release_groups?release_stage_name=${opts.release_stage_name}&visible_only=${opts.visible_only}&top_only=true`;
     const response = await this.request<ReleaseSummaryResponse[]>({
       method: "GET",
-      url
+      url,
     });
 
     return {
       ...response,
-      body: pickFieldsFromArray<ReleaseSummaryResponse>(response.body || [], ProjectAPI.releaseFields),
+      body: pickFieldsFromArray<ReleaseSummaryResponse>(
+        response.body || [],
+        ProjectAPI.releaseFields
+      ),
     };
   }
 
@@ -398,9 +434,12 @@ export class ProjectAPI extends BaseAPI {
    */
   async listBuildsInRelease(releaseId: string) {
     const url = `/release_groups/${releaseId}/releases`;
-    return await this.request<BuildResponse[]>({
-      method: "GET",
-      url,
-    }, true);
+    return await this.request<BuildResponse[]>(
+      {
+        method: "GET",
+        url,
+      },
+      true
+    );
   }
 }

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -1,6 +1,13 @@
-import { Configuration } from '../configuration.js';
+import { Configuration } from "../configuration.js";
 
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
+export type HttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS"
+  | "HEAD";
 
 export interface RequestOptions {
   method: HttpMethod;
@@ -28,7 +35,7 @@ export function pickFields<T>(obj: any, keys: (keyof T)[]): T {
 
 // Utility to pick only allowed fields from an array of objects
 export function pickFieldsFromArray<T>(arr: any[], keys: (keyof T)[]): T[] {
-  return arr.map(obj => pickFields<T>(obj, keys));
+  return arr.map((obj) => pickFields<T>(obj, keys));
 }
 
 // Utility to extract next URL path from Link header
@@ -45,7 +52,7 @@ export function getNextUrlPathFromHeader(headers: Headers, basePath: string) {
 // The MCP tools exposed use only the path for pagination
 // For making requests, we need to ensure the URL is absolute
 export function ensureFullUrl(url: string, basePath: string) {
-  return url.startsWith('http') ? url : `${basePath}${url}`;
+  return url.startsWith("http") ? url : `${basePath}${url}`;
 }
 
 export class BaseAPI {
@@ -66,7 +73,7 @@ export class BaseAPI {
       ...options.headers,
     };
 
-    headers['Authorization'] = `token ${this.configuration.authToken}`;
+    headers["Authorization"] = `token ${this.configuration.authToken}`;
 
     const fetchOptions: RequestInit = {
       method: options.method,
@@ -75,24 +82,29 @@ export class BaseAPI {
     };
     let results: T[] = [];
     let nextUrl: string | null = options.url;
-    let apiResponse: ApiResponse<T>
+    let apiResponse: ApiResponse<T>;
     do {
       nextUrl = ensureFullUrl(nextUrl!, this.configuration.basePath!);
       const response: Response = await fetch(nextUrl!, fetchOptions);
       if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+        const errorText = await response.text();
+        throw new Error(
+          `Request failed with status ${response.status}: ${errorText}`
+        );
       }
 
       apiResponse = {
         status: response.status,
-        headers: response.headers
-      }
+        headers: response.headers,
+      };
 
       const data: T = await response.json();
       if (paginate) {
         results = results.concat(data);
-        nextUrl = getNextUrlPathFromHeader(response.headers, this.configuration.basePath!);
+        nextUrl = getNextUrlPathFromHeader(
+          response.headers,
+          this.configuration.basePath!
+        );
       } else {
         apiResponse.body = data;
       }

--- a/src/bugsnag/client/api/filters.ts
+++ b/src/bugsnag/client/api/filters.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 /**
  * Types of filter comparison operations
  */
-export type FilterType = 'eq' | 'ne' | 'empty';
+export type FilterType = "eq" | "ne" | "empty";
 
 /**
  * Single filter value with its comparison type
@@ -35,7 +35,7 @@ export interface FilterObject {
 }
 
 export const FilterValueSchema = z.object({
-  type: z.enum(['eq', 'ne', 'empty']),
+  type: z.enum(["eq", "ne", "empty"]),
   value: z.union([z.string(), z.boolean(), z.number()]),
 });
 
@@ -49,7 +49,7 @@ export const FilterObjectSchema = z.record(z.array(FilterValueSchema));
  */
 export function equals(value: string | number): FilterValue {
   return {
-    type: 'eq',
+    type: "eq",
     value,
   };
 }
@@ -62,7 +62,7 @@ export function equals(value: string | number): FilterValue {
  */
 export function notEquals(value: string | number): FilterValue {
   return {
-    type: 'ne',
+    type: "ne",
     value,
   };
 }
@@ -75,7 +75,7 @@ export function notEquals(value: string | number): FilterValue {
  */
 export function empty(isEmpty: boolean): FilterValue {
   return {
-    type: 'empty',
+    type: "empty",
     value: isEmpty.toString(),
   };
 }
@@ -87,9 +87,9 @@ export function empty(isEmpty: boolean): FilterValue {
  * @param unit The time unit ('h' for hours, 'd' for days)
  * @returns FilterValue for the relative time
  */
-export function relativeTime(value: number, unit: 'h' | 'd'): FilterValue {
+export function relativeTime(value: number, unit: "h" | "d"): FilterValue {
   return {
-    type: 'eq',
+    type: "eq",
     value: `${value}${unit}`,
   };
 }
@@ -102,7 +102,7 @@ export function relativeTime(value: number, unit: 'h' | 'd'): FilterValue {
  */
 export function isoTime(date: Date): FilterValue {
   return {
-    type: 'eq',
+    type: "eq",
     value: date.toISOString(),
   };
 }
@@ -178,8 +178,8 @@ export function addTimeRange(
   since: Date,
   before: Date
 ): FilterObject {
-  addFilter(filters, 'event.since', isoTime(since));
-  addFilter(filters, 'event.before', isoTime(before));
+  addFilter(filters, "event.since", isoTime(since));
+  addFilter(filters, "event.before", isoTime(before));
   return filters;
 }
 
@@ -194,9 +194,9 @@ export function addTimeRange(
 export function addRelativeTimeRange(
   filters: FilterObject,
   amount: number,
-  unit: 'h' | 'd'
+  unit: "h" | "d"
 ): FilterObject {
-  addFilter(filters, 'event.since', relativeTime(amount, unit));
+  addFilter(filters, "event.since", relativeTime(amount, unit));
   return filters;
 }
 

--- a/src/bugsnag/client/configuration.ts
+++ b/src/bugsnag/client/configuration.ts
@@ -1,17 +1,17 @@
 export interface ConfigurationParameters {
-    authToken: string; // API auth token (required)
-    basePath?: string; // Base path for API requests
-    headers?: Record<string, string>; // Additional headers for API requests
+  authToken: string; // API auth token (required)
+  basePath?: string; // Base path for API requests
+  headers?: Record<string, string>; // Additional headers for API requests
 }
 
 export class Configuration {
-    authToken: string;
-    basePath?: string;
-    headers?: Record<string, string>;
+  authToken: string;
+  basePath?: string;
+  headers?: Record<string, string>;
 
-    constructor(param: ConfigurationParameters) {
-        this.authToken = param.authToken;
-        this.basePath = param.basePath;
-        this.headers = param.headers || {};
-    }
+  constructor(param: ConfigurationParameters) {
+    this.authToken = param.authToken;
+    this.basePath = param.basePath;
+    this.headers = param.headers || {};
+  }
 }

--- a/src/bugsnag/client/custom.d.ts
+++ b/src/bugsnag/client/custom.d.ts
@@ -1,1 +1,1 @@
-declare module 'url';
+declare module "url";

--- a/src/common/info.ts
+++ b/src/common/info.ts
@@ -1,3 +1,3 @@
-import packageJson from '../../package.json' with { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 export const MCP_SERVER_NAME = packageJson.config.mcpServerName;
 export const MCP_SERVER_VERSION = packageJson.version;

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,182 +1,213 @@
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import { ZodAny, ZodArray, ZodBoolean, ZodEnum, ZodLiteral, ZodNumber, ZodObject, ZodRawShape, ZodString, ZodType, ZodUnion, } from "zod";
+import {
+  ZodAny,
+  ZodArray,
+  ZodBoolean,
+  ZodEnum,
+  ZodLiteral,
+  ZodNumber,
+  ZodObject,
+  ZodRawShape,
+  ZodString,
+  ZodType,
+  ZodUnion,
+} from "zod";
 import Bugsnag from "../common/bugsnag.js";
 
 import { Client, ToolParams } from "./types.js";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info.js";
 
 export class SmartBearMcpServer extends McpServer {
-    constructor() {
-        super(
-            {
-                name: MCP_SERVER_NAME,
-                version: MCP_SERVER_VERSION,
-            },
-            {
-                capabilities: {
-                    resources: { listChanged: true },   // Server supports dynamic resource lists
-                    tools: { listChanged: true },       // Server supports dynamic tool lists
-                },
-            },
-        );
-    }
-    addClient(client: Client): void {
-        client.registerTools(
-            (params, cb) => {
-                const toolName = `${client.prefix}_${params.title.replace(/\s+/g, "_").toLowerCase()}`;
-                const toolTitle = `${client.name}: ${params.title}`;
-                return super.registerTool(
-                    toolName,
-                    {
-                        title: toolTitle,
-                        description: this.getDescription(params),
-                        inputSchema: this.getInputSchema(params),
-                        annotations: this.getAnnotations(toolTitle, params),
-                    },
-                    async (args: any, extra: any) => {
-                        try {
-                            return await cb(args, extra);
-                        } catch (e) {
-                            Bugsnag.notify(e as unknown as Error);
-                            throw e;
-                        }
-                    });
-            },
-            (params, options) => {
-                return this.server.elicitInput(params, options);
-            }
-        );
-        if (client.registerResources) {
-            client.registerResources((name, path, cb) => {
-                return super.registerResource(
-                    name,
-                    new ResourceTemplate(`${client.prefix}://${name}/${path}`, { list: undefined }),
-                    {},
-                    async (url: any, variables: any, extra: any) => {
-                        try {
-                            return await cb(url, variables, extra);
-                        } catch (e) {
-                            Bugsnag.notify(e as unknown as Error);
-                            throw e;
-                        }
-                    });
-            });
-        }
-    }
-
-    private getAnnotations(toolTitle: string, params: ToolParams): any {
-        const annotations: ToolAnnotations = {
+  constructor() {
+    super(
+      {
+        name: MCP_SERVER_NAME,
+        version: MCP_SERVER_VERSION,
+      },
+      {
+        capabilities: {
+          resources: { listChanged: true }, // Server supports dynamic resource lists
+          tools: { listChanged: true }, // Server supports dynamic tool lists
+        },
+      }
+    );
+  }
+  addClient(client: Client): void {
+    client.registerTools(
+      (params, cb) => {
+        const toolName = `${client.prefix}_${params.title.replace(/\s+/g, "_").toLowerCase()}`;
+        const toolTitle = `${client.name}: ${params.title}`;
+        return super.registerTool(
+          toolName,
+          {
             title: toolTitle,
-            readOnlyHint: params.readOnly ?? true,
-            destructiveHint: params.destructive ?? false,
-            idempotentHint: params.idempotent ?? true,
-            openWorldHint: params.openWorld ?? false,
-        };
-        return annotations;
-    }
-
-    private getInputSchema(params: ToolParams): any {
-        const args: ZodRawShape = {};
-        for (const param of params.parameters ?? []) {
-            args[param.name] = param.type;
-            if (param.description) {
-                args[param.name] = args[param.name].describe(param.description);
+            description: this.getDescription(params),
+            inputSchema: this.getInputSchema(params),
+            annotations: this.getAnnotations(toolTitle, params),
+          },
+          async (args: any, extra: any) => {
+            try {
+              return await cb(args, extra);
+            } catch (e) {
+              Bugsnag.notify(e as unknown as Error);
+              throw e;
             }
-            if (!param.required) {
-                args[param.name] = args[param.name].optional();
+          }
+        );
+      },
+      (params, options) => {
+        return this.server.elicitInput(params, options);
+      }
+    );
+    if (client.registerResources) {
+      client.registerResources((name, path, cb) => {
+        return super.registerResource(
+          name,
+          new ResourceTemplate(`${client.prefix}://${name}/${path}`, {
+            list: undefined,
+          }),
+          {},
+          async (url: any, variables: any, extra: any) => {
+            try {
+              return await cb(url, variables, extra);
+            } catch (e) {
+              Bugsnag.notify(e as unknown as Error);
+              throw e;
             }
-        }
+          }
+        );
+      });
+    }
+  }
 
-        if (params.zodSchema && params.zodSchema instanceof ZodObject) {
-            for (const key of Object.keys(params.zodSchema.shape)) {
-                const field = params.zodSchema.shape[key];
-                args[key] = field;
-                if (field.description) {
-                    args[key] = args[key].describe(field.description);
-                }
+  private getAnnotations(toolTitle: string, params: ToolParams): any {
+    const annotations: ToolAnnotations = {
+      title: toolTitle,
+      readOnlyHint: params.readOnly ?? true,
+      destructiveHint: params.destructive ?? false,
+      idempotentHint: params.idempotent ?? true,
+      openWorldHint: params.openWorld ?? false,
+    };
+    return annotations;
+  }
 
-                if (field.isOptional()) {
-                    args[key] = args[key].optional();
-                }
-            }
-        }
-
-        return args;
+  private getInputSchema(params: ToolParams): any {
+    const args: ZodRawShape = {};
+    for (const param of params.parameters ?? []) {
+      args[param.name] = param.type;
+      if (param.description) {
+        args[param.name] = args[param.name].describe(param.description);
+      }
+      if (!param.required) {
+        args[param.name] = args[param.name].optional();
+      }
     }
 
-    private getDescription(params: ToolParams): string {
-        const {
-            summary,
-            useCases,
-            examples,
-            parameters,
-            zodSchema,
-            hints,
-            outputFormat
-        } = params;
-
-        let description = summary;
-
-        // Parameters if available otherwise use zodSchema
-        if ((parameters ?? []).length > 0) {
-            description += `\n\n**Parameters:**\n${parameters?.map(p =>
-                `- ${p.name} (${this.getReadableTypeName(p.type)})${p.required ? ' *required*' : ''}` +
-                `${p.description ? `: ${p.description}` : ''}` +
-                `${p.examples ? ` (e.g. ${p.examples.join(', ')})` : ''}` +
-                `${p.constraints ? `\n  - ${p.constraints.join('\n  - ')}` : ''}`
-            ).join('\n')}`;
+    if (params.zodSchema && params.zodSchema instanceof ZodObject) {
+      for (const key of Object.keys(params.zodSchema.shape)) {
+        const field = params.zodSchema.shape[key];
+        args[key] = field;
+        if (field.description) {
+          args[key] = args[key].describe(field.description);
         }
 
-        if (zodSchema && zodSchema instanceof ZodObject) {
-            description += "\n\n**Parameters:**\n";
-            description += Object.keys(zodSchema.shape)
-                .map(key => this.formatParameterDescription(key, zodSchema.shape[key]))
-                .join('\n');
+        if (field.isOptional()) {
+          args[key] = args[key].optional();
         }
-
-        if (outputFormat) {
-            description += `\n\n**Output Format:** ${outputFormat}`;
-        }
-
-        // Use Cases
-        if (useCases && useCases.length > 0) {
-            description += `\n\n**Use Cases:** ${useCases.map((uc, i) => `${i + 1}. ${uc}`).join(' ')}`;
-        }
-
-        // Examples
-        if (examples && examples.length > 0) {
-            description += `\n\n**Examples:**\n` + examples.map((ex, idx) =>
-                `${idx + 1}. ${ex.description}\n\`\`\`json\n${JSON.stringify(ex.parameters, null, 2)}\n\`\`\`${ex.expectedOutput ? `\nExpected Output: ${ex.expectedOutput}` : ''}`
-            ).join('\n\n');
-        }
-
-        // Hints
-        if (hints && hints.length > 0) {
-            description += `\n\n**Hints:** ${hints.map((hint, i) => `${i + 1}. ${hint}`).join(' ')}`;
-        }
-
-        return description.trim();
+      }
     }
 
-    private formatParameterDescription(key: string, field: any) {
-        return `- ${key} (${this.getReadableTypeName(field)})` +
-            `${field.isOptional() ? '' : ' *required*'}` +
-            `${field.description ? `: ${field.description}` : ''}` +
-            `${key === "examples" && field instanceof ZodEnum ? ` (e.g. ${Object.keys(field.enum).join(', ')})` : ''}` +
-            `${key === "constraints" && field instanceof ZodEnum ? `\n  - ${Object.keys(field.enum).join('\n  - ')}` : ''}`;
+    return args;
+  }
+
+  private getDescription(params: ToolParams): string {
+    const {
+      summary,
+      useCases,
+      examples,
+      parameters,
+      zodSchema,
+      hints,
+      outputFormat,
+    } = params;
+
+    let description = summary;
+
+    // Parameters if available otherwise use zodSchema
+    if ((parameters ?? []).length > 0) {
+      description += `\n\n**Parameters:**\n${parameters
+        ?.map(
+          (p) =>
+            `- ${p.name} (${this.getReadableTypeName(p.type)})${p.required ? " *required*" : ""}` +
+            `${p.description ? `: ${p.description}` : ""}` +
+            `${p.examples ? ` (e.g. ${p.examples.join(", ")})` : ""}` +
+            `${p.constraints ? `\n  - ${p.constraints.join("\n  - ")}` : ""}`
+        )
+        .join("\n")}`;
     }
 
-    private getReadableTypeName(zodType: ZodType): string {
-        if (zodType instanceof ZodString) return 'string';
-        if (zodType instanceof ZodNumber) return 'number';
-        if (zodType instanceof ZodBoolean) return 'boolean';
-        if (zodType instanceof ZodArray) return 'array';
-        if (zodType instanceof ZodObject) return 'object';
-        if (zodType instanceof ZodEnum) return 'enum';
-        if (zodType instanceof ZodLiteral) return 'literal';
-        if (zodType instanceof ZodUnion) return 'union';
-        if (zodType instanceof ZodAny) return 'any';
-        return 'any';
+    if (zodSchema && zodSchema instanceof ZodObject) {
+      description += "\n\n**Parameters:**\n";
+      description += Object.keys(zodSchema.shape)
+        .map((key) =>
+          this.formatParameterDescription(key, zodSchema.shape[key])
+        )
+        .join("\n");
     }
+
+    if (outputFormat) {
+      description += `\n\n**Output Format:** ${outputFormat}`;
+    }
+
+    // Use Cases
+    if (useCases && useCases.length > 0) {
+      description += `\n\n**Use Cases:** ${useCases.map((uc, i) => `${i + 1}. ${uc}`).join(" ")}`;
+    }
+
+    // Examples
+    if (examples && examples.length > 0) {
+      description +=
+        `\n\n**Examples:**\n` +
+        examples
+          .map(
+            (ex, idx) =>
+              `${idx + 1}. ${ex.description}\n\`\`\`json\n${JSON.stringify(ex.parameters, null, 2)}\n\`\`\`${ex.expectedOutput ? `\nExpected Output: ${ex.expectedOutput}` : ""}`
+          )
+          .join("\n\n");
+    }
+
+    // Hints
+    if (hints && hints.length > 0) {
+      description += `\n\n**Hints:** ${hints.map((hint, i) => `${i + 1}. ${hint}`).join(" ")}`;
+    }
+
+    return description.trim();
+  }
+
+  private formatParameterDescription(key: string, field: any) {
+    return (
+      `- ${key} (${this.getReadableTypeName(field)})` +
+      `${field.isOptional() ? "" : " *required*"}` +
+      `${field.description ? `: ${field.description}` : ""}` +
+      `${key === "examples" && field instanceof ZodEnum ? ` (e.g. ${Object.keys(field.enum).join(", ")})` : ""}` +
+      `${key === "constraints" && field instanceof ZodEnum ? `\n  - ${Object.keys(field.enum).join("\n  - ")}` : ""}`
+    );
+  }
+
+  private getReadableTypeName(zodType: ZodType): string {
+    if (zodType instanceof ZodString) return "string";
+    if (zodType instanceof ZodNumber) return "number";
+    if (zodType instanceof ZodBoolean) return "boolean";
+    if (zodType instanceof ZodArray) return "array";
+    if (zodType instanceof ZodObject) return "object";
+    if (zodType instanceof ZodEnum) return "enum";
+    if (zodType instanceof ZodLiteral) return "literal";
+    if (zodType instanceof ZodUnion) return "union";
+    if (zodType instanceof ZodAny) return "any";
+    return "any";
+  }
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,13 @@
-import { ReadResourceTemplateCallback, RegisteredResourceTemplate, RegisteredTool, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ElicitRequest, ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ReadResourceTemplateCallback,
+  RegisteredResourceTemplate,
+  RegisteredTool,
+  ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ElicitRequest,
+  ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { ZodRawShape, ZodType, ZodTypeAny } from "zod";
 import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 
@@ -24,20 +32,20 @@ export interface ToolParams {
 }
 
 export type RegisterToolsFunction = <InputArgs extends ZodRawShape>(
-    params: ToolParams,
-    cb: ToolCallback<InputArgs>
+  params: ToolParams,
+  cb: ToolCallback<InputArgs>
 ) => RegisteredTool;
 
 export type RegisterResourceFunction = (
-    name: string,
-    path: string,
-    cb: ReadResourceTemplateCallback
+  name: string,
+  path: string,
+  cb: ReadResourceTemplateCallback
 ) => RegisteredResourceTemplate;
 
 export type GetInputFunction = (
-    params: ElicitRequest["params"],
-    options?: RequestOptions
-) => Promise<ElicitResult>
+  params: ElicitRequest["params"],
+  options?: RequestOptions
+) => Promise<ElicitResult>;
 
 export type Parameters = Array<{
   name: string;
@@ -49,8 +57,11 @@ export type Parameters = Array<{
 }>;
 
 export interface Client {
-    name: string;
-    prefix: string;
-    registerTools(register: RegisterToolsFunction, getInput: GetInputFunction): void;
-    registerResources?(register: RegisterResourceFunction): void;
+  name: string;
+  prefix: string;
+  registerTools(
+    register: RegisterToolsFunction,
+    getInput: GetInputFunction
+  ): void;
+  registerResources?(register: RegisterResourceFunction): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,26 +44,36 @@ async function main() {
     client_defined = true;
   }
 
-  if(apiHubToken) {
+  if (apiHubToken) {
     server.addClient(new ApiHubClient(apiHubToken));
     client_defined = true;
   }
 
   if (pactBrokerUrl) {
     if (pactBrokerToken) {
-      server.addClient(new PactflowClient(pactBrokerToken, pactBrokerUrl, "pactflow"));
+      server.addClient(
+        new PactflowClient(pactBrokerToken, pactBrokerUrl, "pactflow")
+      );
       client_defined = true;
     } else if (pactBrokerUsername && pactBrokerPassword) {
-      server.addClient(new PactflowClient({ username: pactBrokerUsername, password: pactBrokerPassword }, pactBrokerUrl, "pact_broker"));
+      server.addClient(
+        new PactflowClient(
+          { username: pactBrokerUsername, password: pactBrokerPassword },
+          pactBrokerUrl,
+          "pact_broker"
+        )
+      );
       client_defined = true;
     } else {
-      console.error("If the Pact Broker base URL is specified, you must specify either (a) a PactFlow token, or (b) a Pact Broker username and password pair.")
+      console.error(
+        "If the Pact Broker base URL is specified, you must specify either (a) a PactFlow token, or (b) a Pact Broker username and password pair."
+      );
     }
   }
 
   if (!client_defined) {
     console.error(
-      "Please set one of REFLECT_API_TOKEN, BUGSNAG_AUTH_TOKEN, API_HUB_API_KEY or PACT_BROKER_BASE_URL / (and relevant Pact auth) environment variables",
+      "Please set one of REFLECT_API_TOKEN, BUGSNAG_AUTH_TOKEN, API_HUB_API_KEY or PACT_BROKER_BASE_URL / (and relevant Pact auth) environment variables"
     );
     process.exit(1);
   }

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -2,320 +2,348 @@ import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
 import {
   Client,
   GetInputFunction,
-  RegisterToolsFunction
+  RegisterToolsFunction,
 } from "../common/types.js";
 import {
   GenerationResponse,
   GenerationInput,
   RefineResponse,
   RefineInput,
-  StatusResponse
+  StatusResponse,
 } from "./client/ai.js";
-import { CanIDeployInput, CanIDeployResponse, ProviderStatesResponse, MatrixInput, MatrixResponse } from "./client/base.js";
+import {
+  CanIDeployInput,
+  CanIDeployResponse,
+  ProviderStatesResponse,
+  MatrixInput,
+  MatrixResponse,
+} from "./client/base.js";
 import { ClientType, TOOLS } from "./client/tools.js";
-
-
 
 // Tool definitions for PactFlow AI API client
 export class PactflowClient implements Client {
-    name = "Contract Testing";
-    prefix = "contract-testing";
+  name = "Contract Testing";
+  prefix = "contract-testing";
 
-    private readonly headers: {
-      Authorization: string;
-      "Content-Type": string;
-      "User-Agent": string;
-    };
-    private readonly aiBaseUrl: string;
-    private readonly baseUrl: string;
-    private readonly clientType: ClientType;
+  private readonly headers: {
+    Authorization: string;
+    "Content-Type": string;
+    "User-Agent": string;
+  };
+  private readonly aiBaseUrl: string;
+  private readonly baseUrl: string;
+  private readonly clientType: ClientType;
 
-    constructor(auth: string | { username: string; password: string }, baseUrl: string, clientType: ClientType) {
-      // Set headers based on the type of auth provided
-      if (typeof auth === "string") {
-        this.headers = {
-          Authorization: `Bearer ${auth}`,
-          "Content-Type": "application/json",
-          "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
-        };
-      } else {
-        const authString = `${auth.username}:${auth.password}`;
-        this.headers = {
-          Authorization: `Basic ${Buffer.from(authString).toString("base64")}`,
-          "Content-Type": "application/json",
-          "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
-        };
-      }
-      this.baseUrl = baseUrl;
-      this.aiBaseUrl = `${this.baseUrl}/api/ai`;
-      this.clientType = clientType;
-    }
-
-    // PactFlow AI client methods
-
-    /**
-     * Generate new Pact tests based on the provided input.
-     *
-     * @param toolInput The input data for the generation process.
-     * @returns The result of the generation process.
-     * @throws Error if the HTTP request fails or the operation times out.
-     */
-    async generate(toolInput: GenerationInput): Promise<GenerationResponse> {
-      // Submit the generation request
-      const response = await fetch(`${this.aiBaseUrl}/generate`, {
-        method: "POST",
-        headers: this.headers,
-        body: JSON.stringify(toolInput),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status} - ${await response.text()}`);
-      }
-
-      const status_response: StatusResponse = await response.json();
-      return await this.pollForCompletion<GenerationResponse>(
-        status_response,
-        "Generation"
-      );
-    }
-
-    /**
-     * Review the provided Pact tests and suggest improvements.
-     *
-     * @param toolInput The input data for the review process.
-     * @returns The result of the review process.
-     * @throws Error if the HTTP request fails or the operation times out.
-     */
-    async review(toolInput: RefineInput): Promise<RefineResponse> {
-      // Submit review request
-      const response = await fetch(`${this.aiBaseUrl}/review`, {
-        method: "POST",
-        headers: this.headers,
-        body: JSON.stringify(toolInput),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status} - ${await response.text()}`);
-      }
-
-      const status_response: StatusResponse = await response.json();
-      return await this.pollForCompletion<RefineResponse>(
-        status_response,
-        "Review Pacts"
-      );
-    }
-
-    async getStatus(
-      statusUrl: string
-    ): Promise<{ status: number; isComplete: boolean }> {
-      const response = await fetch(statusUrl, {
-        method: "HEAD",
-        headers: this.headers,
-      });
-
-      return {
-        status: response.status,
-        isComplete: response.status === 200,
+  constructor(
+    auth: string | { username: string; password: string },
+    baseUrl: string,
+    clientType: ClientType
+  ) {
+    // Set headers based on the type of auth provided
+    if (typeof auth === "string") {
+      this.headers = {
+        Authorization: `Bearer ${auth}`,
+        "Content-Type": "application/json",
+        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      };
+    } else {
+      const authString = `${auth.username}:${auth.password}`;
+      this.headers = {
+        Authorization: `Basic ${Buffer.from(authString).toString("base64")}`,
+        "Content-Type": "application/json",
+        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
       };
     }
+    this.baseUrl = baseUrl;
+    this.aiBaseUrl = `${this.baseUrl}/api/ai`;
+    this.clientType = clientType;
+  }
 
-    async getResult<T>(resultUrl: string): Promise<T> {
-      const response = await fetch(resultUrl, {
-        method: "GET",
-        headers: this.headers,
-      });
-      // Check if the response is OK (status 200)
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
+  // PactFlow AI client methods
 
-      return response.json();
-    }
+  /**
+   * Generate new Pact tests based on the provided input.
+   *
+   * @param toolInput The input data for the generation process.
+   * @returns The result of the generation process.
+   * @throws Error if the HTTP request fails or the operation times out.
+   */
+  async generate(toolInput: GenerationInput): Promise<GenerationResponse> {
+    // Submit the generation request
+    const response = await fetch(`${this.aiBaseUrl}/generate`, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(toolInput),
+    });
 
-    private async pollForCompletion<T>(
-      status_response: StatusResponse,
-      operationName: string
-    ): Promise<T> {
-      // Polling for completion
-      const startTime = Date.now();
-      const timeout = 120000; // 120 seconds
-      const pollInterval = 1000; // 1 second
-
-      while (Date.now() - startTime < timeout) {
-        const statusCheck = await this.getStatus(status_response.status_url);
-
-        if (statusCheck.isComplete) {
-          // Operation is complete, get the result
-          return await this.getResult<T>(status_response.result_url);
-        }
-
-        if (statusCheck.status !== 202) {
-          throw new Error(
-            `${operationName} failed with status: ${statusCheck.status}`
-          );
-        }
-
-        // Wait before next poll
-        await new Promise((resolve) => setTimeout(resolve, pollInterval));
-      }
-
+    if (!response.ok) {
       throw new Error(
-        `${operationName} timed out after ${timeout / 1000} seconds`
+        `HTTP error! status: ${response.status} - ${await response.text()}`
       );
     }
 
+    const status_response: StatusResponse = await response.json();
+    return await this.pollForCompletion<GenerationResponse>(
+      status_response,
+      "Generation"
+    );
+  }
 
-    // PactFlow / Pact_Broker client methods
+  /**
+   * Review the provided Pact tests and suggest improvements.
+   *
+   * @param toolInput The input data for the review process.
+   * @returns The result of the review process.
+   * @throws Error if the HTTP request fails or the operation times out.
+   */
+  async review(toolInput: RefineInput): Promise<RefineResponse> {
+    // Submit review request
+    const response = await fetch(`${this.aiBaseUrl}/review`, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(toolInput),
+    });
 
-    async getProviderStates({ provider }: { provider: string }): Promise<ProviderStatesResponse> {
-      const uri_encoded_provider_name = encodeURIComponent(provider);
-      const response = await fetch(`${this.baseUrl}/pacts/provider/${uri_encoded_provider_name}/provider-states`, {
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error! status: ${response.status} - ${await response.text()}`
+      );
+    }
+
+    const status_response: StatusResponse = await response.json();
+    return await this.pollForCompletion<RefineResponse>(
+      status_response,
+      "Review Pacts"
+    );
+  }
+
+  async getStatus(
+    statusUrl: string
+  ): Promise<{ status: number; isComplete: boolean }> {
+    const response = await fetch(statusUrl, {
+      method: "HEAD",
+      headers: this.headers,
+    });
+
+    return {
+      status: response.status,
+      isComplete: response.status === 200,
+    };
+  }
+
+  async getResult<T>(resultUrl: string): Promise<T> {
+    const response = await fetch(resultUrl, {
+      method: "GET",
+      headers: this.headers,
+    });
+    // Check if the response is OK (status 200)
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  private async pollForCompletion<T>(
+    status_response: StatusResponse,
+    operationName: string
+  ): Promise<T> {
+    // Polling for completion
+    const startTime = Date.now();
+    const timeout = 120000; // 120 seconds
+    const pollInterval = 1000; // 1 second
+
+    while (Date.now() - startTime < timeout) {
+      const statusCheck = await this.getStatus(status_response.status_url);
+
+      if (statusCheck.isComplete) {
+        // Operation is complete, get the result
+        return await this.getResult<T>(status_response.result_url);
+      }
+
+      if (statusCheck.status !== 202) {
+        throw new Error(
+          `${operationName} failed with status: ${statusCheck.status}`
+        );
+      }
+
+      // Wait before next poll
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+
+    throw new Error(
+      `${operationName} timed out after ${timeout / 1000} seconds`
+    );
+  }
+
+  // PactFlow / Pact_Broker client methods
+
+  async getProviderStates({
+    provider,
+  }: {
+    provider: string;
+  }): Promise<ProviderStatesResponse> {
+    const uri_encoded_provider_name = encodeURIComponent(provider);
+    const response = await fetch(
+      `${this.baseUrl}/pacts/provider/${uri_encoded_provider_name}/provider-states`,
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error! status: ${response.status} - ${await response.text()}`
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Checks if a given pacticipant version is safe to deploy
+   * to a specified environment.
+   *
+   * @param body - Input containing:
+   *   - `pacticipant`: The name of the service (pacticipant).
+   *   - `version`: The version of the pacticipant being evaluated for deployment.
+   *   - `environment`: The target environment (e.g., staging, production).
+   * @returns CanIDeployResponse containing deployment decision and verification results.
+   * @throws Error if the request fails or returns a non-OK response.
+   */
+  async canIDeploy(body: CanIDeployInput): Promise<CanIDeployResponse> {
+    const { pacticipant, version, environment } = body;
+    const queryParams = new URLSearchParams({
+      pacticipant,
+      version,
+      environment,
+    });
+    const url = `${this.baseUrl}/can-i-deploy?${queryParams.toString()}`;
+
+    try {
+      const response = await fetch(url, {
         method: "GET",
         headers: this.headers,
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status} - ${await response.text()}`);
-      }
-
-      return response.json();
-    }
-
-    /**
-     * Checks if a given pacticipant version is safe to deploy
-     * to a specified environment.
-     *
-     * @param body - Input containing:
-     *   - `pacticipant`: The name of the service (pacticipant).
-     *   - `version`: The version of the pacticipant being evaluated for deployment.
-     *   - `environment`: The target environment (e.g., staging, production).
-     * @returns CanIDeployResponse containing deployment decision and verification results.
-     * @throws Error if the request fails or returns a non-OK response.
-     */
-    async canIDeploy(body: CanIDeployInput): Promise<CanIDeployResponse> {
-      const { pacticipant, version, environment } = body;
-      const queryParams = new URLSearchParams({
-        pacticipant,
-        version,
-        environment,
-      });
-      const url = `${this.baseUrl}/can-i-deploy?${queryParams.toString()}`;
-
-      try {
-        const response = await fetch(url, {
-          method: "GET",
-          headers: this.headers,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text().catch(() => "");
-          throw new Error(
-            `Can-I-Deploy Request Failed - status: ${response.status} ${response.statusText}${
-              errorText ? ` - ${errorText}` : ""
-            }`
-          );
-        }
-
-        return (await response.json()) as CanIDeployResponse;
-      } catch (error) {
-        console.error(`[CanIDeploy] Unexpected error: ${error}\n`);
-        throw error;
-      }
-    }
-
-    /**
-     * Retrieves the matrix of pact verification results for the specified pacticipants.
-     * This allows you to see which consumer/provider combinations have been verified
-     * and make deployment decisions based on contract test results.
-     *
-     * @param body - Matrix query parameters including pacticipants, versions, environments, etc.
-     * @returns MatrixResponse containing the verification matrix, notices, and summary
-     * @throws Error if the request fails or returns a non-OK response
-     */
-    async getMatrix(body: MatrixInput): Promise<MatrixResponse> {
-      const { q, latestby, limit } = body;
-
-      // Build query parameters manually to avoid URL encoding of square brackets
-      const queryParts: string[] = [];
-
-      // Add optional parameters
-      if (latestby) {
-        queryParts.push(`latestby=${encodeURIComponent(latestby)}`);
-      }
-      if (limit !== undefined) {
-        queryParts.push(`limit=${limit}`);
-      }
-
-      // Add the q parameters (pacticipant selectors)
-      q.forEach((selector) => {
-        queryParts.push(`q[]pacticipant=${encodeURIComponent(selector.pacticipant)}`);
-
-        if(selector.version){
-          queryParts.push(`q[]version=${encodeURIComponent(selector.version)}`);
-        }
-
-        if (selector.branch) {
-          queryParts.push(`q[]branch=${encodeURIComponent(selector.branch)}`);
-        }
-        if (selector.environment) {
-          queryParts.push(`q[]environment=${encodeURIComponent(selector.environment)}`);
-        }
-        if (selector.latest !== undefined) {
-          queryParts.push(`q[]latest=${selector.latest}`);
-        }
-        if (selector.tag) {
-          queryParts.push(`q[]tag=${encodeURIComponent(selector.tag)}`);
-        }
-        if (selector.mainBranch !== undefined) {
-          queryParts.push(`q[]mainBranch=${selector.mainBranch}`);
-        }
-      });
-
-      const url = `${this.baseUrl}/matrix?${queryParts.join('&')}`;
-
-      try {
-        const response = await fetch(url, {
-          method: "GET",
-          headers: this.headers,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text().catch(() => "");
-          throw new Error(
-            `Matrix Request Failed - status: ${response.status} ${response.statusText}${
-              errorText ? ` - ${errorText}` : ""
-            }`
-          );
-        }
-
-        return (await response.json()) as MatrixResponse;
-      } catch (error) {
-        console.error("[GetMatrix] Unexpected error:", error);
-        throw error;
-      }
-    }
-
-    registerTools(register: RegisterToolsFunction, _getInput: GetInputFunction): void {
-      for (const tool of TOOLS.filter(t => t.clients.includes(this.clientType))) {
-        const {handler, clients: _, formatResponse, ...toolparams} = tool; // eslint-disable-line @typescript-eslint/no-unused-vars
-        register(toolparams, async (args, _extra) => {
-            const handler_fn = (this as any)[handler];
-            if (typeof handler_fn !== "function") {
-              throw new Error(`Handler '${handler}' not found on PactClient`);
-            }
-            const result = await handler_fn.call(this, args);
-
-            // Use custom response formatter if provided
-            if (formatResponse) {
-              return formatResponse(result);
-            }
-
-            // Default fallback
-            return {
-              content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-            };
-          }
+        const errorText = await response.text().catch(() => "");
+        throw new Error(
+          `Can-I-Deploy Request Failed - status: ${response.status} ${response.statusText}${
+            errorText ? ` - ${errorText}` : ""
+          }`
         );
       }
+
+      return (await response.json()) as CanIDeployResponse;
+    } catch (error) {
+      console.error(`[CanIDeploy] Unexpected error: ${error}\n`);
+      throw error;
     }
+  }
+
+  /**
+   * Retrieves the matrix of pact verification results for the specified pacticipants.
+   * This allows you to see which consumer/provider combinations have been verified
+   * and make deployment decisions based on contract test results.
+   *
+   * @param body - Matrix query parameters including pacticipants, versions, environments, etc.
+   * @returns MatrixResponse containing the verification matrix, notices, and summary
+   * @throws Error if the request fails or returns a non-OK response
+   */
+  async getMatrix(body: MatrixInput): Promise<MatrixResponse> {
+    const { q, latestby, limit } = body;
+
+    // Build query parameters manually to avoid URL encoding of square brackets
+    const queryParts: string[] = [];
+
+    // Add optional parameters
+    if (latestby) {
+      queryParts.push(`latestby=${encodeURIComponent(latestby)}`);
+    }
+    if (limit !== undefined) {
+      queryParts.push(`limit=${limit}`);
+    }
+
+    // Add the q parameters (pacticipant selectors)
+    q.forEach((selector) => {
+      queryParts.push(
+        `q[]pacticipant=${encodeURIComponent(selector.pacticipant)}`
+      );
+
+      if (selector.version) {
+        queryParts.push(`q[]version=${encodeURIComponent(selector.version)}`);
+      }
+
+      if (selector.branch) {
+        queryParts.push(`q[]branch=${encodeURIComponent(selector.branch)}`);
+      }
+      if (selector.environment) {
+        queryParts.push(
+          `q[]environment=${encodeURIComponent(selector.environment)}`
+        );
+      }
+      if (selector.latest !== undefined) {
+        queryParts.push(`q[]latest=${selector.latest}`);
+      }
+      if (selector.tag) {
+        queryParts.push(`q[]tag=${encodeURIComponent(selector.tag)}`);
+      }
+      if (selector.mainBranch !== undefined) {
+        queryParts.push(`q[]mainBranch=${selector.mainBranch}`);
+      }
+    });
+
+    const url = `${this.baseUrl}/matrix?${queryParts.join("&")}`;
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: this.headers,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(
+          `Matrix Request Failed - status: ${response.status} ${response.statusText}${
+            errorText ? ` - ${errorText}` : ""
+          }`
+        );
+      }
+
+      return (await response.json()) as MatrixResponse;
+    } catch (error) {
+      console.error("[GetMatrix] Unexpected error:", error);
+      throw error;
+    }
+  }
+
+  registerTools(
+    register: RegisterToolsFunction,
+    _getInput: GetInputFunction
+  ): void {
+    for (const tool of TOOLS.filter((t) =>
+      t.clients.includes(this.clientType)
+    )) {
+      const { handler, clients: _, formatResponse, ...toolparams } = tool; // eslint-disable-line @typescript-eslint/no-unused-vars
+      register(toolparams, async (args, _extra) => {
+        const handler_fn = (this as any)[handler];
+        if (typeof handler_fn !== "function") {
+          throw new Error(`Handler '${handler}' not found on PactClient`);
+        }
+        const result = await handler_fn.call(this, args);
+
+        // Use custom response formatter if provided
+        if (formatResponse) {
+          return formatResponse(result);
+        }
+
+        // Default fallback
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      });
+    }
+  }
 }

--- a/src/pactflow/client/ai.ts
+++ b/src/pactflow/client/ai.ts
@@ -166,7 +166,8 @@ export const OpenAPIWithMatcherSchema = z
   })
   .describe(
     "If provided, the OpenAPI document which describes the API being tested and is accompanied by a matcher which will be used to identify the interactions in the OpenAPI document which are relevant to the Pact refinement process."
-  ).transform(addOpenAPISpecToSchema);
+  )
+  .transform(addOpenAPISpecToSchema);
 
 export const RefineInputSchema = z.object({
   pactTests: FileInputSchema.describe(

--- a/src/pactflow/client/base.ts
+++ b/src/pactflow/client/base.ts
@@ -11,11 +11,22 @@ export interface ProviderStatesResponse {
 }
 
 export const CanIDeploySchema = z.object({
-  pacticipant: z.string().describe("The name of the pacticipant (application/service) being evaluated for deployment"),
-  version: z.string().describe("The version of the pacticipant that you want to check if it's safe to deploy"),
-  environment: z.string().describe("The target environment where the pacticipant version will be deployed (e.g., 'production', 'staging', 'test')"),
+  pacticipant: z
+    .string()
+    .describe(
+      "The name of the pacticipant (application/service) being evaluated for deployment"
+    ),
+  version: z
+    .string()
+    .describe(
+      "The version of the pacticipant that you want to check if it's safe to deploy"
+    ),
+  environment: z
+    .string()
+    .describe(
+      "The target environment where the pacticipant version will be deployed (e.g., 'production', 'staging', 'test')"
+    ),
 });
-
 
 export interface CanIDeployResponse {
   matrix: Array<{
@@ -38,19 +49,60 @@ export interface CanIDeployResponse {
 }
 
 export const MatrixSchema = z.object({
-  latestby: z.string().optional().describe("This property removes the rows for the overridden pacts/verifications from the results. The options are cvp (show only the latest row for each consumer version and provider) and cvpv (show only the latest row each consumer version and provider version). For a can-i-deploy query with one selector, it should be set to cvp. For a can-i-deploy query with two selectors, it should be set to cvpv."),
-  limit: z.number().min(1).max(1000).default(100).optional().describe("The limit on the number of results to return (1-1000, default: 100)"),
-  q: z.array(
-    z.object({
-      pacticipant: z.string().describe("Name of the pacticipant (application)"),
-      version: z.string().optional().describe("Version number"),
-      branch: z.string().optional().describe("Name of the pacticipant version branch"),
-      environment: z.string().optional().describe("The name of the environment that the pacticipant version is deployed to"),
-      latest: z.boolean().optional().describe("Used in conjunction with other properties to indicate whether the selector is describing the latest version from a branch/with a tag/for a pacticipant, or all of them. Note that when used with tags, the 'latest' is calculated using the creation date of the pacticipant version, NOT the creation date of the tag."),
-      tag: z.string().optional().describe("The name of the pacticipant version tag (superseded by branch and environments)"),
-      mainBranch: z.boolean().optional().describe("Whether or not the version(s) described are from the main branch of the pacticipant, as set in the mainBranch property of the pacticipant resource."),
-    })
-  ).min(1).max(2)
+  latestby: z
+    .string()
+    .optional()
+    .describe(
+      "This property removes the rows for the overridden pacts/verifications from the results. The options are cvp (show only the latest row for each consumer version and provider) and cvpv (show only the latest row each consumer version and provider version). For a can-i-deploy query with one selector, it should be set to cvp. For a can-i-deploy query with two selectors, it should be set to cvpv."
+    ),
+  limit: z
+    .number()
+    .min(1)
+    .max(1000)
+    .default(100)
+    .optional()
+    .describe(
+      "The limit on the number of results to return (1-1000, default: 100)"
+    ),
+  q: z
+    .array(
+      z.object({
+        pacticipant: z
+          .string()
+          .describe("Name of the pacticipant (application)"),
+        version: z.string().optional().describe("Version number"),
+        branch: z
+          .string()
+          .optional()
+          .describe("Name of the pacticipant version branch"),
+        environment: z
+          .string()
+          .optional()
+          .describe(
+            "The name of the environment that the pacticipant version is deployed to"
+          ),
+        latest: z
+          .boolean()
+          .optional()
+          .describe(
+            "Used in conjunction with other properties to indicate whether the selector is describing the latest version from a branch/with a tag/for a pacticipant, or all of them. Note that when used with tags, the 'latest' is calculated using the creation date of the pacticipant version, NOT the creation date of the tag."
+          ),
+        tag: z
+          .string()
+          .optional()
+          .describe(
+            "The name of the pacticipant version tag (superseded by branch and environments)"
+          ),
+        mainBranch: z
+          .boolean()
+          .optional()
+          .describe(
+            "Whether or not the version(s) described are from the main branch of the pacticipant, as set in the mainBranch property of the pacticipant resource."
+          ),
+      })
+    )
+    .min(1)
+    .max(2),
 });
 
 export interface MatrixResponse {

--- a/src/pactflow/client/tools.ts
+++ b/src/pactflow/client/tools.ts
@@ -12,10 +12,7 @@
 
 import { z } from "zod";
 import { ToolParams } from "../../common/types.js";
-import {
-  GenerationInputSchema,
-  RefineInputSchema
-} from "./ai.js";
+import { GenerationInputSchema, RefineInputSchema } from "./ai.js";
 import { CanIDeploySchema, MatrixSchema } from "./base.js";
 
 export type ClientType = "pactflow" | "pact_broker";
@@ -38,49 +35,55 @@ export const TOOLS: PactflowToolParams[] = [
   },
   {
     title: "Review Pact Tests",
-    summary: "Review Pact tests using PactFlow AI. You can provide the following inputs: (1) Pact tests to be reviewed along with metadata",
+    summary:
+      "Review Pact tests using PactFlow AI. You can provide the following inputs: (1) Pact tests to be reviewed along with metadata",
     purpose: "Review Pact tests for API interactions",
     zodSchema: RefineInputSchema,
     handler: "review",
-    clients: ["pactflow"]
+    clients: ["pactflow"],
   },
   {
     title: "Get Provider States",
     summary: "Retrieve the states of a specific provider",
-    purpose: "A provider state in Pact defines the specific preconditions that must be met on the provider side before a consumer–provider interaction can be tested. It sets up the provider in the right context—such as ensuring a particular user or record exists—so that the provider can return the response the consumer expects. This makes contract tests reliable, repeatable, and isolated by injecting or configuring the necessary data and conditions directly into the provider before each test runs.",
+    purpose:
+      "A provider state in Pact defines the specific preconditions that must be met on the provider side before a consumer–provider interaction can be tested. It sets up the provider in the right context—such as ensuring a particular user or record exists—so that the provider can return the response the consumer expects. This makes contract tests reliable, repeatable, and isolated by injecting or configuring the necessary data and conditions directly into the provider before each test runs.",
     parameters: [
       {
         name: "provider",
         type: z.string(),
         description: "name of the provider to retrieve states for",
-        required: true
-      }
+        required: true,
+      },
     ],
     handler: "getProviderStates",
-    clients: ["pactflow", "pact_broker"]
+    clients: ["pactflow", "pact_broker"],
   },
   {
     title: "Can I Deploy",
-    summary: "Performs a comprehensive compatibility check to determine whether a specific version of a service (pacticipant) can be safely deployed into a given environment. It analyzes the complete contract matrix of consumer-provider relationships to confirm that all required integrations are verified and compatible.",
-    purpose: "To serve as a deployment safety check within the PactBroker and PactFlow ecosystem, leveraging contract testing results to validate whether a specific service / pacticipant version is compatible with all integrated services. This feature prevents unsafe releases, reduces integration risks, and enables teams to confidently automate deployments across environments with a clear, auditable record of verification results.",
+    summary:
+      "Performs a comprehensive compatibility check to determine whether a specific version of a service (pacticipant) can be safely deployed into a given environment. It analyzes the complete contract matrix of consumer-provider relationships to confirm that all required integrations are verified and compatible.",
+    purpose:
+      "To serve as a deployment safety check within the PactBroker and PactFlow ecosystem, leveraging contract testing results to validate whether a specific service / pacticipant version is compatible with all integrated services. This feature prevents unsafe releases, reduces integration risks, and enables teams to confidently automate deployments across environments with a clear, auditable record of verification results.",
     zodSchema: CanIDeploySchema,
     handler: "canIDeploy",
-    clients: ["pactflow", "pact_broker"]
+    clients: ["pactflow", "pact_broker"],
   },
   {
     title: "Matrix",
-    summary: "Retrieve the comprehensive contract verification matrix that shows the relationship between consumer and provider versions, their associated pact files, and verification results stored in the Pact Broker or Pactflow. The matrix provides detailed visibility into which consumer and provider versions have been successfully verified against each other, and highlights failures with detailed information about the cause.",
-    purpose: "The Matrix serves as a powerful tool for teams to understand the state of their contract testing ecosystem. It enables tracking of all interactions between consumer and provider versions over time, with detailed insights into verification successes and failures. This helps teams rapidly identify compatibility issues, understand why specific verifications failed, and make informed decisions about deployments. Matrix offers a more intuitive and consolidated view of the verification status, making it easier to spot trends or problematic versions. Additionally, the Matrix supports complex queries using selectors, and can answer specific 'can-i-deploy' questions, ensuring that only compatible versions are deployed to production environments.",
+    summary:
+      "Retrieve the comprehensive contract verification matrix that shows the relationship between consumer and provider versions, their associated pact files, and verification results stored in the Pact Broker or Pactflow. The matrix provides detailed visibility into which consumer and provider versions have been successfully verified against each other, and highlights failures with detailed information about the cause.",
+    purpose:
+      "The Matrix serves as a powerful tool for teams to understand the state of their contract testing ecosystem. It enables tracking of all interactions between consumer and provider versions over time, with detailed insights into verification successes and failures. This helps teams rapidly identify compatibility issues, understand why specific verifications failed, and make informed decisions about deployments. Matrix offers a more intuitive and consolidated view of the verification status, making it easier to spot trends or problematic versions. Additionally, the Matrix supports complex queries using selectors, and can answer specific 'can-i-deploy' questions, ensuring that only compatible versions are deployed to production environments.",
     useCases: [
       "Quickly identify which consumer and provider version combinations have passed or failed verification.",
       "Diagnose and investigate why a particular consumer-provider verification failed.",
       "Visualize the overall contract compatibility across two pacticipants / services.",
       "Perform advanced queries using selectors to understand compatibility within specific branches, environments, or version ranges.",
       "Support informed deployment decisions by answering 'can I deploy version X of this service to production?'",
-      "Expose contract verification details to non-frequent API users in a more accessible format."
+      "Expose contract verification details to non-frequent API users in a more accessible format.",
     ],
     zodSchema: MatrixSchema,
     handler: "getMatrix",
-    clients: ["pactflow", "pact_broker"]
-  }
+    clients: ["pactflow", "pact_broker"],
+  },
 ];

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -1,5 +1,9 @@
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
-import { Client, GetInputFunction, RegisterToolsFunction } from "../common/types.js";
+import {
+  Client,
+  GetInputFunction,
+  RegisterToolsFunction,
+} from "../common/types.js";
 import { z } from "zod";
 
 // Type definitions for tool arguments
@@ -23,7 +27,11 @@ export interface testExecutionArgs {
 
 // ReflectClient class implementing the Client interface
 export class ReflectClient implements Client {
-  private headers: { "X-API-KEY": string; "Content-Type": string, "User-Agent": string };
+  private headers: {
+    "X-API-KEY": string;
+    "Content-Type": string;
+    "User-Agent": string;
+  };
 
   name = "Reflect";
   prefix = "reflect";
@@ -51,19 +59,22 @@ export class ReflectClient implements Client {
       {
         method: "GET",
         headers: this.headers,
-      },
+      }
     );
 
     return response.json();
   }
 
-  async getSuiteExecutionStatus(suiteId: string, executionId: string): Promise<any> {
+  async getSuiteExecutionStatus(
+    suiteId: string,
+    executionId: string
+  ): Promise<any> {
     const response = await fetch(
       `https://api.reflect.run/v1/suites/${suiteId}/executions/${executionId}`,
       {
         method: "GET",
         headers: this.headers,
-      },
+      }
     );
 
     return response.json();
@@ -75,19 +86,22 @@ export class ReflectClient implements Client {
       {
         method: "POST",
         headers: this.headers,
-      },
+      }
     );
 
     return response.json();
   }
 
-  async cancelSuiteExecution(suiteId: string, executionId: string): Promise<any> {
+  async cancelSuiteExecution(
+    suiteId: string,
+    executionId: string
+  ): Promise<any> {
     const response = await fetch(
       `https://api.reflect.run/v1/suites/${suiteId}/executions/${executionId}/cancel`,
       {
         method: "PATCH",
         headers: this.headers,
-      },
+      }
     );
 
     return response.json();
@@ -103,27 +117,36 @@ export class ReflectClient implements Client {
   }
 
   async runReflectTest(testId: string): Promise<any> {
-    const response = await fetch(`https://api.reflect.run/v1/tests/${testId}/executions`, {
-      method: "POST",
-      headers: this.headers,
-    });
-
-    return response.json();
-  }
-
-  async getReflectTestStatus(testId: string, executionId: string): Promise<any> {
     const response = await fetch(
-      `https://api.reflect.run/v1/executions/${executionId}`,
+      `https://api.reflect.run/v1/tests/${testId}/executions`,
       {
-        method: "GET",
+        method: "POST",
         headers: this.headers,
-      },
+      }
     );
 
     return response.json();
   }
 
-  registerTools(register: RegisterToolsFunction, _getInput: GetInputFunction): void {
+  async getReflectTestStatus(
+    testId: string,
+    executionId: string
+  ): Promise<any> {
+    const response = await fetch(
+      `https://api.reflect.run/v1/executions/${executionId}`,
+      {
+        method: "GET",
+        headers: this.headers,
+      }
+    );
+
+    return response.json();
+  }
+
+  registerTools(
+    register: RegisterToolsFunction,
+    _getInput: GetInputFunction
+  ): void {
     register(
       {
         title: "List Suites",
@@ -146,7 +169,7 @@ export class ReflectClient implements Client {
             name: "suiteId",
             type: z.string(),
             description: "ID of the reflect suite to list executions for",
-            required: true
+            required: true,
           },
         ],
       },
@@ -167,37 +190,43 @@ export class ReflectClient implements Client {
             name: "suiteId",
             type: z.string(),
             description: "ID of the reflect suite to get execution status for",
-            required: true
+            required: true,
           },
           {
             name: "executionId",
             type: z.string(),
             description: "ID of the reflect suite execution to get status for",
-            required: true
+            required: true,
           },
         ],
       },
       async (args, _extra) => {
-        if (!args.suiteId || !args.executionId) throw new Error("Both suiteId and executionId arguments are required");
-        const response = await this.getSuiteExecutionStatus(args.suiteId, args.executionId);
+        if (!args.suiteId || !args.executionId)
+          throw new Error(
+            "Both suiteId and executionId arguments are required"
+          );
+        const response = await this.getSuiteExecutionStatus(
+          args.suiteId,
+          args.executionId
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
       }
     );
     register(
-        {
-            title: "Execute Suite",
-            summary: "Execute a reflect suite",
-            parameters: [
-                {
-                    name: "suiteId",
-                    type: z.string(),
-                    description: "ID of the reflect suite to list executions for",
-                    required: true
-                }
-            ]
-        },
+      {
+        title: "Execute Suite",
+        summary: "Execute a reflect suite",
+        parameters: [
+          {
+            name: "suiteId",
+            type: z.string(),
+            description: "ID of the reflect suite to list executions for",
+            required: true,
+          },
+        ],
+      },
       async (args, _extra) => {
         if (!args.suiteId) throw new Error("suiteId argument is required");
         const response = await this.executeSuite(args.suiteId);
@@ -215,19 +244,25 @@ export class ReflectClient implements Client {
             name: "suiteId",
             type: z.string(),
             description: "ID of the reflect suite to cancel execution for",
-            required: true
+            required: true,
           },
           {
             name: "executionId",
             type: z.string(),
             description: "ID of the reflect suite execution to cancel",
-            required: true
+            required: true,
           },
         ],
       },
       async (args, _extra) => {
-        if (!args.suiteId || !args.executionId) throw new Error("Both suiteId and executionId arguments are required");
-        const response = await this.cancelSuiteExecution(args.suiteId, args.executionId);
+        if (!args.suiteId || !args.executionId)
+          throw new Error(
+            "Both suiteId and executionId arguments are required"
+          );
+        const response = await this.cancelSuiteExecution(
+          args.suiteId,
+          args.executionId
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };
@@ -255,8 +290,8 @@ export class ReflectClient implements Client {
             name: "testId",
             type: z.string(),
             description: "ID of the reflect test to run",
-            required: true
-          }
+            required: true,
+          },
         ],
       },
       async (args, _extra) => {
@@ -276,19 +311,23 @@ export class ReflectClient implements Client {
             name: "testId",
             type: z.string(),
             description: "ID of the reflect test to run",
-            required: true
+            required: true,
           },
           {
             name: "executionId",
             type: z.string(),
             description: "ID of the reflect test execution to get status for",
-            required: true
+            required: true,
           },
         ],
       },
       async (args, _extra) => {
-        if (!args.testId || !args.executionId) throw new Error("Both testId and executionId arguments are required");
-        const response = await this.getReflectTestStatus(args.testId, args.executionId);
+        if (!args.testId || !args.executionId)
+          throw new Error("Both testId and executionId arguments are required");
+        const response = await this.getReflectTestStatus(
+          args.testId,
+          args.executionId
+        );
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
         };

--- a/src/tests/unit/bugsnag/api-utilities.test.ts
+++ b/src/tests/unit/bugsnag/api-utilities.test.ts
@@ -1,36 +1,41 @@
-import { describe, it, expect } from 'vitest';
-import { getNextUrlPathFromHeader, pickFields, pickFieldsFromArray, ensureFullUrl } from '../../../bugsnag/client/api/base.js';
+import { describe, it, expect } from "vitest";
+import {
+  getNextUrlPathFromHeader,
+  pickFields,
+  pickFieldsFromArray,
+  ensureFullUrl,
+} from "../../../bugsnag/client/api/base.js";
 
-describe('API Utilities', () => {
-  describe('pickFields', () => {
-    it('should pick only specified fields from object', () => {
-      const input = { id: '1', name: 'Test', secret: 'hidden', extra: 'data' };
-      const result = pickFields(input, ['id', 'name']);
+describe("API Utilities", () => {
+  describe("pickFields", () => {
+    it("should pick only specified fields from object", () => {
+      const input = { id: "1", name: "Test", secret: "hidden", extra: "data" };
+      const result = pickFields(input, ["id", "name"]);
 
-      expect(result).toEqual({ id: '1', name: 'Test' });
-      expect(result).not.toHaveProperty('secret');
-      expect(result).not.toHaveProperty('extra');
+      expect(result).toEqual({ id: "1", name: "Test" });
+      expect(result).not.toHaveProperty("secret");
+      expect(result).not.toHaveProperty("extra");
     });
 
-    it('should handle missing fields gracefully', () => {
-      const input = { id: '1' };
-      const result = pickFields(input, ['id', 'name', 'missing']);
+    it("should handle missing fields gracefully", () => {
+      const input = { id: "1" };
+      const result = pickFields(input, ["id", "name", "missing"]);
 
-      expect(result).toEqual({ id: '1' });
+      expect(result).toEqual({ id: "1" });
     });
   });
 
-  describe('pickFieldsFromArray', () => {
-    it('should pick fields from array of objects', () => {
+  describe("pickFieldsFromArray", () => {
+    it("should pick fields from array of objects", () => {
       const input = [
-        { id: '1', name: 'Test1', secret: 'hidden1' },
-        { id: '2', name: 'Test2', secret: 'hidden2' }
+        { id: "1", name: "Test1", secret: "hidden1" },
+        { id: "2", name: "Test2", secret: "hidden2" },
       ];
-      const result = pickFieldsFromArray(input, ['id', 'name']);
+      const result = pickFieldsFromArray(input, ["id", "name"]);
 
       expect(result).toEqual([
-        { id: '1', name: 'Test1' },
-        { id: '2', name: 'Test2' }
+        { id: "1", name: "Test1" },
+        { id: "2", name: "Test2" },
       ]);
     });
   });
@@ -38,10 +43,10 @@ describe('API Utilities', () => {
   describe("getNextUrlPathFromHeader", () => {
     it("should extract next URL path from Link header", () => {
       const headers = new Headers();
-        headers.append(
-          "Link",
-          '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
-        );
+      headers.append(
+        "Link",
+        '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
+      );
 
       const result = getNextUrlPathFromHeader(
         headers,
@@ -52,14 +57,14 @@ describe('API Utilities', () => {
 
     it("should handle case-insensitive Link header name", () => {
       const headers = new Headers();
-        headers.append(
-          "link",
-          '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
+      headers.append(
+        "link",
+        '<https://api.bugsnag.com/projects/12345/errors?offset=30&per_page=30>; rel="next"'
       );
 
       const result = getNextUrlPathFromHeader(
         headers,
-          "https://api.bugsnag.com"
+        "https://api.bugsnag.com"
       );
       expect(result).toBe("/projects/12345/errors?offset=30&per_page=30");
     });

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -1,14 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '../../../common/info.js';
-import { BugsnagClient } from '../../../bugsnag/client.js';
-import { BaseAPI } from '../../../bugsnag/client/api/base.js';
-import { ProjectAPI } from '../../../bugsnag/client/api/Project.js';
-import { CurrentUserAPI, ErrorAPI } from '../../../bugsnag/client/index.js';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../../common/info.js";
+import { BugsnagClient } from "../../../bugsnag/client.js";
+import { BaseAPI } from "../../../bugsnag/client/api/base.js";
+import { ProjectAPI } from "../../../bugsnag/client/api/Project.js";
+import { CurrentUserAPI, ErrorAPI } from "../../../bugsnag/client/index.js";
 
 // Mock the dependencies
 const mockCurrentUserAPI = {
   listUserOrganizations: vi.fn(),
-  getOrganizationProjects: vi.fn()
+  getOrganizationProjects: vi.fn(),
 } satisfies Omit<CurrentUserAPI, keyof BaseAPI>;
 
 const mockErrorAPI = {
@@ -18,7 +18,7 @@ const mockErrorAPI = {
   listProjectErrors: vi.fn(),
   updateErrorOnProject: vi.fn(),
   listErrorPivots: vi.fn(),
-  listEventsOnProject: vi.fn()
+  listEventsOnProject: vi.fn(),
 } satisfies Omit<ErrorAPI, keyof BaseAPI>;
 
 const mockProjectAPI = {
@@ -30,47 +30,47 @@ const mockProjectAPI = {
   getRelease: vi.fn(),
   listBuildsInRelease: vi.fn(),
   getProjectStabilityTargets: vi.fn().mockResolvedValue({
-      target_stability: {
-          value: 0.995,
-          updated_at: "2023-01-01",
-          updated_by_id: "user-1",
-      },
-      critical_stability: {
-          value: 0.85,
-          updated_at: "2023-01-01",
-          updated_by_id: "user-1",
-      },
-      stability_target_type: "user" as const,
+    target_stability: {
+      value: 0.995,
+      updated_at: "2023-01-01",
+      updated_by_id: "user-1",
+    },
+    critical_stability: {
+      value: 0.85,
+      updated_at: "2023-01-01",
+      updated_by_id: "user-1",
+    },
+    stability_target_type: "user" as const,
   }),
 } satisfies Omit<ProjectAPI, keyof BaseAPI>;
 
 const mockCache = {
   set: vi.fn(),
   get: vi.fn(),
-  del: vi.fn()
+  del: vi.fn(),
 };
 
-vi.mock('../../../bugsnag/client/index.js', () => ({
+vi.mock("../../../bugsnag/client/index.js", () => ({
   CurrentUserAPI: vi.fn().mockImplementation(() => mockCurrentUserAPI),
   ErrorAPI: vi.fn().mockImplementation(() => mockErrorAPI),
-  Configuration: vi.fn().mockImplementation((config) => config)
+  Configuration: vi.fn().mockImplementation((config) => config),
 }));
 
-vi.mock('../../../bugsnag/client/api/Project.js', () => ({
-  ProjectAPI: vi.fn().mockImplementation(() => mockProjectAPI)
+vi.mock("../../../bugsnag/client/api/Project.js", () => ({
+  ProjectAPI: vi.fn().mockImplementation(() => mockProjectAPI),
 }));
 
-vi.mock('node-cache', () => ({
-  default: vi.fn().mockImplementation(() => mockCache)
+vi.mock("node-cache", () => ({
+  default: vi.fn().mockImplementation(() => mockCache),
 }));
 
-vi.mock('../../../common/bugsnag.js', () => ({
+vi.mock("../../../common/bugsnag.js", () => ({
   default: {
-    notify: vi.fn()
-  }
+    notify: vi.fn(),
+  },
 }));
 
-describe('BugsnagClient', () => {
+describe("BugsnagClient", () => {
   let client: BugsnagClient;
 
   beforeEach(() => {
@@ -79,299 +79,353 @@ describe('BugsnagClient', () => {
     mockCache.get.mockReset();
     mockCache.set.mockReset();
     mockCache.del.mockReset();
-    client = new BugsnagClient('test-token');
+    client = new BugsnagClient("test-token");
   });
 
-  describe('constructor', () => {
-    it('should create client instance with proper dependencies', () => {
-      const client = new BugsnagClient('test-token');
+  describe("constructor", () => {
+    it("should create client instance with proper dependencies", () => {
+      const client = new BugsnagClient("test-token");
       expect(client).toBeInstanceOf(BugsnagClient);
     });
 
-    it('should configure endpoints correctly during construction', async () => {
-      const { Configuration } = await import('../../../bugsnag/client/index.js');
+    it("should configure endpoints correctly during construction", async () => {
+      const { Configuration } = await import(
+        "../../../bugsnag/client/index.js"
+      );
       const MockedConfiguration = vi.mocked(Configuration);
 
-      new BugsnagClient('test-token', '00000hub-key');
+      new BugsnagClient("test-token", "00000hub-key");
 
       expect(MockedConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
-          basePath: 'https://api.bugsnag.smartbear.com',
-          authToken: 'test-token',
+          basePath: "https://api.bugsnag.smartbear.com",
+          authToken: "test-token",
           headers: expect.objectContaining({
-            'User-Agent': `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
-            'Content-Type': 'application/json',
-            'X-Bugsnag-API': 'true',
-            'X-Version': '2'
-          })
+            "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+            "Content-Type": "application/json",
+            "X-Bugsnag-API": "true",
+            "X-Version": "2",
+          }),
         })
       );
     });
 
-    it('should set project API key when provided', () => {
-      const client = new BugsnagClient('test-token', 'test-project-key');
+    it("should set project API key when provided", () => {
+      const client = new BugsnagClient("test-token", "test-project-key");
       expect(client).toBeInstanceOf(BugsnagClient);
     });
   });
 
-  describe('getEndpoint method', () => {
+  describe("getEndpoint method", () => {
     let client: BugsnagClient;
 
     beforeEach(() => {
-      client = new BugsnagClient('test-token');
+      client = new BugsnagClient("test-token");
     });
 
-    describe('without custom endpoint', () => {
-      describe('with Hub API key (00000 prefix)', () => {
-        it('should return Hub domain for api subdomain', () => {
-          const result = client.getEndpoint('api', '00000hub-key');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+    describe("without custom endpoint", () => {
+      describe("with Hub API key (00000 prefix)", () => {
+        it("should return Hub domain for api subdomain", () => {
+          const result = client.getEndpoint("api", "00000hub-key");
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
 
-        it('should return Hub domain for app subdomain', () => {
-          const result = client.getEndpoint('app', '00000test-key');
-          expect(result).toBe('https://app.bugsnag.smartbear.com');
+        it("should return Hub domain for app subdomain", () => {
+          const result = client.getEndpoint("app", "00000test-key");
+          expect(result).toBe("https://app.bugsnag.smartbear.com");
         });
 
-        it('should return Hub domain for custom subdomain', () => {
-          const result = client.getEndpoint('custom', '00000key');
-          expect(result).toBe('https://custom.bugsnag.smartbear.com');
+        it("should return Hub domain for custom subdomain", () => {
+          const result = client.getEndpoint("custom", "00000key");
+          expect(result).toBe("https://custom.bugsnag.smartbear.com");
         });
 
-        it('should handle empty string after prefix', () => {
-          const result = client.getEndpoint('api', '00000');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
-        });
-      });
-
-      describe('with regular API key (non-Hub)', () => {
-        it('should return Bugsnag domain for api subdomain', () => {
-          const result = client.getEndpoint('api', 'regular-key');
-          expect(result).toBe('https://api.bugsnag.com');
-        });
-
-        it('should return Bugsnag domain for app subdomain', () => {
-          const result = client.getEndpoint('app', 'abc123def');
-          expect(result).toBe('https://app.bugsnag.com');
-        });
-
-        it('should return Bugsnag domain for custom subdomain', () => {
-          const result = client.getEndpoint('custom', 'test-key-123');
-          expect(result).toBe('https://custom.bugsnag.com');
-        });
-
-        it('should handle API key with 00000 in middle', () => {
-          const result = client.getEndpoint('api', 'key-00000-middle');
-          expect(result).toBe('https://api.bugsnag.com');
+        it("should handle empty string after prefix", () => {
+          const result = client.getEndpoint("api", "00000");
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
       });
 
-      describe('without API key', () => {
-        it('should return Bugsnag domain when API key is undefined', () => {
-          const result = client.getEndpoint('api', undefined);
-          expect(result).toBe('https://api.bugsnag.com');
+      describe("with regular API key (non-Hub)", () => {
+        it("should return Bugsnag domain for api subdomain", () => {
+          const result = client.getEndpoint("api", "regular-key");
+          expect(result).toBe("https://api.bugsnag.com");
         });
 
-        it('should return Bugsnag domain when API key is empty string', () => {
-          const result = client.getEndpoint('api', '');
-          expect(result).toBe('https://api.bugsnag.com');
+        it("should return Bugsnag domain for app subdomain", () => {
+          const result = client.getEndpoint("app", "abc123def");
+          expect(result).toBe("https://app.bugsnag.com");
         });
 
-        it('should return Bugsnag domain when API key is null', () => {
-          const result = client.getEndpoint('api', null as any);
-          expect(result).toBe('https://api.bugsnag.com');
+        it("should return Bugsnag domain for custom subdomain", () => {
+          const result = client.getEndpoint("custom", "test-key-123");
+          expect(result).toBe("https://custom.bugsnag.com");
+        });
+
+        it("should handle API key with 00000 in middle", () => {
+          const result = client.getEndpoint("api", "key-00000-middle");
+          expect(result).toBe("https://api.bugsnag.com");
+        });
+      });
+
+      describe("without API key", () => {
+        it("should return Bugsnag domain when API key is undefined", () => {
+          const result = client.getEndpoint("api", undefined);
+          expect(result).toBe("https://api.bugsnag.com");
+        });
+
+        it("should return Bugsnag domain when API key is empty string", () => {
+          const result = client.getEndpoint("api", "");
+          expect(result).toBe("https://api.bugsnag.com");
+        });
+
+        it("should return Bugsnag domain when API key is null", () => {
+          const result = client.getEndpoint("api", null as any);
+          expect(result).toBe("https://api.bugsnag.com");
         });
       });
     });
 
-    describe('with custom endpoint', () => {
-      describe('Hub domain endpoints (always normalized)', () => {
-        it('should normalize to HTTPS subdomain for exact hub domain match', () => {
-          const result = client.getEndpoint('api', '00000key', 'https://api.bugsnag.smartbear.com');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+    describe("with custom endpoint", () => {
+      describe("Hub domain endpoints (always normalized)", () => {
+        it("should normalize to HTTPS subdomain for exact hub domain match", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "https://api.bugsnag.smartbear.com"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
 
-        it('should normalize to HTTPS subdomain regardless of input protocol', () => {
-          const result = client.getEndpoint('api', '00000key', 'http://app.bugsnag.smartbear.com');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+        it("should normalize to HTTPS subdomain regardless of input protocol", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "http://app.bugsnag.smartbear.com"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
 
-        it('should normalize to HTTPS subdomain regardless of input subdomain', () => {
-          const result = client.getEndpoint('app', '00000key', 'https://api.bugsnag.smartbear.com');
-          expect(result).toBe('https://app.bugsnag.smartbear.com');
+        it("should normalize to HTTPS subdomain regardless of input subdomain", () => {
+          const result = client.getEndpoint(
+            "app",
+            "00000key",
+            "https://api.bugsnag.smartbear.com"
+          );
+          expect(result).toBe("https://app.bugsnag.smartbear.com");
         });
 
-        it('should normalize hub domain with port', () => {
-          const result = client.getEndpoint('api', '00000key', 'https://custom.bugsnag.smartbear.com:8080');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+        it("should normalize hub domain with port", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "https://custom.bugsnag.smartbear.com:8080"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
 
-        it('should normalize hub domain with path', () => {
-          const result = client.getEndpoint('api', '00000key', 'https://custom.bugsnag.smartbear.com/path');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+        it("should normalize hub domain with path", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "https://custom.bugsnag.smartbear.com/path"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
 
-        it('should normalize complex subdomains to standard format', () => {
-          const result = client.getEndpoint('api', '00000key', 'https://staging.app.bugsnag.smartbear.com');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
-        });
-      });
-
-      describe('Bugsnag domain endpoints (always normalized)', () => {
-        it('should normalize to HTTPS subdomain for exact bugsnag domain match', () => {
-          const result = client.getEndpoint('api', 'regular-key', 'https://api.bugsnag.com');
-          expect(result).toBe('https://api.bugsnag.com');
-        });
-
-        it('should normalize to HTTPS subdomain regardless of input protocol', () => {
-          const result = client.getEndpoint('api', 'regular-key', 'http://app.bugsnag.com');
-          expect(result).toBe('https://api.bugsnag.com');
-        });
-
-        it('should normalize bugsnag domain with port', () => {
-          const result = client.getEndpoint('app', 'regular-key', 'https://api.bugsnag.com:9000');
-          expect(result).toBe('https://app.bugsnag.com');
-        });
-
-        it('should normalize bugsnag domain with path', () => {
-          const result = client.getEndpoint('app', 'regular-key', 'https://api.bugsnag.com/v2');
-          expect(result).toBe('https://app.bugsnag.com');
-        });
-      });
-
-      describe('Custom domain endpoints (used as-is)', () => {
-        it('should return custom endpoint exactly as provided', () => {
-          const customEndpoint = 'https://custom.api.com';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
-          expect(result).toBe(customEndpoint);
-        });
-
-        it('should return custom endpoint as-is regardless of API key type', () => {
-          const customEndpoint = 'https://my-custom-domain.com/api';
-          const result = client.getEndpoint('api', 'regular-key', customEndpoint);
-          expect(result).toBe(customEndpoint);
-        });
-
-        it('should preserve HTTP protocol for custom domains', () => {
-          const customEndpoint = 'http://localhost:3000';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
-          expect(result).toBe(customEndpoint);
-        });
-
-        it('should preserve custom domain with ports and paths', () => {
-          const customEndpoint = 'https://192.168.1.100:8080/api/v1';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
-          expect(result).toBe(customEndpoint);
-        });
-
-        it('should preserve custom domain with query parameters', () => {
-          const customEndpoint = 'https://custom.domain.com/api?version=1';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
-          expect(result).toBe(customEndpoint);
-        });
-
-        it('should preserve custom domain with fragments', () => {
-          const customEndpoint = 'https://custom.domain.com/api#section';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
-          expect(result).toBe(customEndpoint);
+        it("should normalize complex subdomains to standard format", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "https://staging.app.bugsnag.smartbear.com"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
       });
 
-      describe('edge cases', () => {
-        it('should handle malformed custom endpoints gracefully', () => {
+      describe("Bugsnag domain endpoints (always normalized)", () => {
+        it("should normalize to HTTPS subdomain for exact bugsnag domain match", () => {
+          const result = client.getEndpoint(
+            "api",
+            "regular-key",
+            "https://api.bugsnag.com"
+          );
+          expect(result).toBe("https://api.bugsnag.com");
+        });
+
+        it("should normalize to HTTPS subdomain regardless of input protocol", () => {
+          const result = client.getEndpoint(
+            "api",
+            "regular-key",
+            "http://app.bugsnag.com"
+          );
+          expect(result).toBe("https://api.bugsnag.com");
+        });
+
+        it("should normalize bugsnag domain with port", () => {
+          const result = client.getEndpoint(
+            "app",
+            "regular-key",
+            "https://api.bugsnag.com:9000"
+          );
+          expect(result).toBe("https://app.bugsnag.com");
+        });
+
+        it("should normalize bugsnag domain with path", () => {
+          const result = client.getEndpoint(
+            "app",
+            "regular-key",
+            "https://api.bugsnag.com/v2"
+          );
+          expect(result).toBe("https://app.bugsnag.com");
+        });
+      });
+
+      describe("Custom domain endpoints (used as-is)", () => {
+        it("should return custom endpoint exactly as provided", () => {
+          const customEndpoint = "https://custom.api.com";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
+          expect(result).toBe(customEndpoint);
+        });
+
+        it("should return custom endpoint as-is regardless of API key type", () => {
+          const customEndpoint = "https://my-custom-domain.com/api";
+          const result = client.getEndpoint(
+            "api",
+            "regular-key",
+            customEndpoint
+          );
+          expect(result).toBe(customEndpoint);
+        });
+
+        it("should preserve HTTP protocol for custom domains", () => {
+          const customEndpoint = "http://localhost:3000";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
+          expect(result).toBe(customEndpoint);
+        });
+
+        it("should preserve custom domain with ports and paths", () => {
+          const customEndpoint = "https://192.168.1.100:8080/api/v1";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
+          expect(result).toBe(customEndpoint);
+        });
+
+        it("should preserve custom domain with query parameters", () => {
+          const customEndpoint = "https://custom.domain.com/api?version=1";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
+          expect(result).toBe(customEndpoint);
+        });
+
+        it("should preserve custom domain with fragments", () => {
+          const customEndpoint = "https://custom.domain.com/api#section";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
+          expect(result).toBe(customEndpoint);
+        });
+      });
+
+      describe("edge cases", () => {
+        it("should handle malformed custom endpoints gracefully", () => {
           // This should throw due to invalid URL, which is expected behavior
           expect(() => {
-            client.getEndpoint('api', '00000key', 'not-a-valid-url');
+            client.getEndpoint("api", "00000key", "not-a-valid-url");
           }).toThrow();
         });
 
-        it('should preserve custom endpoints with userinfo', () => {
-          const customEndpoint = 'https://user:pass@custom.domain.com';
-          const result = client.getEndpoint('api', '00000key', customEndpoint);
+        it("should preserve custom endpoints with userinfo", () => {
+          const customEndpoint = "https://user:pass@custom.domain.com";
+          const result = client.getEndpoint("api", "00000key", customEndpoint);
           expect(result).toBe(customEndpoint);
         });
 
-        it('should normalize known domains even with userinfo', () => {
-          const result = client.getEndpoint('api', '00000key', 'https://user:pass@app.bugsnag.smartbear.com');
-          expect(result).toBe('https://api.bugsnag.smartbear.com');
+        it("should normalize known domains even with userinfo", () => {
+          const result = client.getEndpoint(
+            "api",
+            "00000key",
+            "https://user:pass@app.bugsnag.smartbear.com"
+          );
+          expect(result).toBe("https://api.bugsnag.smartbear.com");
         });
       });
     });
 
-    describe('subdomain validation', () => {
-      it('should handle empty subdomain', () => {
-        const result = client.getEndpoint('', '00000key');
-        expect(result).toBe('https://.bugsnag.smartbear.com');
+    describe("subdomain validation", () => {
+      it("should handle empty subdomain", () => {
+        const result = client.getEndpoint("", "00000key");
+        expect(result).toBe("https://.bugsnag.smartbear.com");
       });
 
-      it('should handle subdomain with special characters', () => {
-        const result = client.getEndpoint('test-api_v2', '00000key');
-        expect(result).toBe('https://test-api_v2.bugsnag.smartbear.com');
+      it("should handle subdomain with special characters", () => {
+        const result = client.getEndpoint("test-api_v2", "00000key");
+        expect(result).toBe("https://test-api_v2.bugsnag.smartbear.com");
       });
 
-      it('should handle numeric subdomain', () => {
-        const result = client.getEndpoint('v1', 'regular-key');
-        expect(result).toBe('https://v1.bugsnag.com');
+      it("should handle numeric subdomain", () => {
+        const result = client.getEndpoint("v1", "regular-key");
+        expect(result).toBe("https://v1.bugsnag.com");
       });
 
-      it('should handle very long subdomains', () => {
-        const longSubdomain = 'very-long-subdomain-name-with-many-characters';
-        const result = client.getEndpoint(longSubdomain, '00000key');
+      it("should handle very long subdomains", () => {
+        const longSubdomain = "very-long-subdomain-name-with-many-characters";
+        const result = client.getEndpoint(longSubdomain, "00000key");
         expect(result).toBe(`https://${longSubdomain}.bugsnag.smartbear.com`);
       });
     });
   });
 
-  describe('static utility methods', () => {
+  describe("static utility methods", () => {
     // Test static methods if they exist in the class
-    it('should have proper class structure', () => {
-      const client = new BugsnagClient('test-token');
+    it("should have proper class structure", () => {
+      const client = new BugsnagClient("test-token");
 
       // Verify the client has expected methods
-      expect(typeof client.initialize).toBe('function');
-      expect(typeof client.registerTools).toBe('function');
-      expect(typeof client.registerResources).toBe('function');
+      expect(typeof client.initialize).toBe("function");
+      expect(typeof client.registerTools).toBe("function");
+      expect(typeof client.registerResources).toBe("function");
     });
   });
 
-  describe('error handling', () => {
-    it('should handle invalid tokens gracefully during construction', () => {
+  describe("error handling", () => {
+    it("should handle invalid tokens gracefully during construction", () => {
       expect(() => {
-        new BugsnagClient('');
+        new BugsnagClient("");
       }).not.toThrow();
 
       expect(() => {
-        new BugsnagClient('   ');
+        new BugsnagClient("   ");
       }).not.toThrow();
     });
 
-    it('should handle special characters in project API key', () => {
+    it("should handle special characters in project API key", () => {
       expect(() => {
-        new BugsnagClient('test-token', '00000-special!@#$%^&*()');
+        new BugsnagClient("test-token", "00000-special!@#$%^&*()");
       }).not.toThrow();
     });
   });
 
-  describe('configuration validation', () => {
-    it('should pass correct authToken to Configuration', async () => {
-      const { Configuration } = await import('../../../bugsnag/client/index.js');
+  describe("configuration validation", () => {
+    it("should pass correct authToken to Configuration", async () => {
+      const { Configuration } = await import(
+        "../../../bugsnag/client/index.js"
+      );
       const MockedConfiguration = vi.mocked(Configuration);
-      const testToken = 'super-secret-token-123';
+      const testToken = "super-secret-token-123";
 
       new BugsnagClient(testToken);
 
       expect(MockedConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
-          authToken: testToken
+          authToken: testToken,
         })
       );
     });
 
-    it('should include all required headers', async () => {
-      const { Configuration } = await import('../../../bugsnag/client/index.js');
+    it("should include all required headers", async () => {
+      const { Configuration } = await import(
+        "../../../bugsnag/client/index.js"
+      );
       const MockedConfiguration = vi.mocked(Configuration);
 
-      new BugsnagClient('test-token');
+      new BugsnagClient("test-token");
 
       const configCall = MockedConfiguration.mock.calls[0][0];
       expect(configCall.headers).toEqual({
@@ -383,10 +437,14 @@ describe('BugsnagClient', () => {
     });
   });
 
-  describe('API client initialization', () => {
-    it('should initialize all required API clients', async () => {
-      const { CurrentUserAPI, ErrorAPI } = await import('../../../bugsnag/client/index.js');
-      const { ProjectAPI } = await import('../../../bugsnag/client/api/Project.js');
+  describe("API client initialization", () => {
+    it("should initialize all required API clients", async () => {
+      const { CurrentUserAPI, ErrorAPI } = await import(
+        "../../../bugsnag/client/index.js"
+      );
+      const { ProjectAPI } = await import(
+        "../../../bugsnag/client/api/Project.js"
+      );
 
       const MockedCurrentUserAPI = vi.mocked(CurrentUserAPI);
       const MockedErrorAPI = vi.mocked(ErrorAPI);
@@ -397,146 +455,201 @@ describe('BugsnagClient', () => {
       MockedErrorAPI.mockClear();
       MockedProjectAPI.mockClear();
 
-      new BugsnagClient('test-token');
+      new BugsnagClient("test-token");
 
       expect(MockedCurrentUserAPI).toHaveBeenCalledOnce();
       expect(MockedErrorAPI).toHaveBeenCalledOnce();
       expect(MockedProjectAPI).toHaveBeenCalledOnce();
     });
 
-    it('should initialize NodeCache', async () => {
-      const NodeCacheModule = await import('node-cache');
+    it("should initialize NodeCache", async () => {
+      const NodeCacheModule = await import("node-cache");
       const MockedNodeCache = vi.mocked(NodeCacheModule.default);
 
       // Clear previous calls from beforeEach
       MockedNodeCache.mockClear();
 
-      new BugsnagClient('test-token');
+      new BugsnagClient("test-token");
 
       expect(MockedNodeCache).toHaveBeenCalledOnce();
     });
   });
 
-  describe('initialization', () => {
-    it('should initialize successfully with organizations and projects', async () => {
-      const mockOrg = { id: 'org-1', name: 'Test Org' };
+  describe("initialization", () => {
+    it("should initialize successfully with organizations and projects", async () => {
+      const mockOrg = { id: "org-1", name: "Test Org" };
       const mockProjects = [
-        { id: 'proj-1', name: 'Project 1', api_key: 'key1' },
-        { id: 'proj-2', name: 'Project 2', api_key: 'key2' }
+        { id: "proj-1", name: "Project 1", api_key: "key1" },
+        { id: "proj-2", name: "Project 2", api_key: "key2" },
       ];
 
-      mockCache.get.mockReturnValueOnce(null) // No current projects
+      mockCache.get
+        .mockReturnValueOnce(null) // No current projects
         .mockReturnValueOnce(null) // No cached projects
         .mockReturnValueOnce(null); // No cached organization
-      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [mockOrg] });
-      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
+      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({
+        body: [mockOrg],
+      });
+      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+        body: mockProjects,
+      });
 
       await client.initialize();
 
       expect(mockCurrentUserAPI.listUserOrganizations).toHaveBeenCalledOnce();
-      expect(mockCurrentUserAPI.getOrganizationProjects).toHaveBeenCalledWith('org-1');
-      expect(mockCache.set).toHaveBeenCalledWith('bugsnag_org', mockOrg);
-      expect(mockCache.set).toHaveBeenCalledWith('bugsnag_projects', mockProjects);
-    });
-
-    it('should initialize with project API key and set up event filters', async () => {
-      const clientWithApiKey = new BugsnagClient('test-token', 'project-api-key');
-      const mockProjects = [
-        { id: 'proj-1', name: 'Project 1', api_key: 'project-api-key' },
-        { id: 'proj-2', name: 'Project 2', api_key: 'other-key' }
-      ];
-      const mockEventFields = [
-        { display_id: 'user.email', custom: false },
-        { display_id: 'error.status', custom: false },
-        { display_id: 'search', custom: false } // This should be filtered out
-      ];
-
-      mockCache.get.mockReturnValueOnce(mockProjects)
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce(mockProjects);
-      mockProjectAPI.listProjectEventFields.mockResolvedValue({ body: mockEventFields });
-
-      await clientWithApiKey.initialize();
-
-      expect(mockCache.set).toHaveBeenCalledWith('bugsnag_current_project', mockProjects[0]);
-      expect(mockProjectAPI.listProjectEventFields).toHaveBeenCalledWith('proj-1');
-
-      // // Verify that 'search' field is filtered out
-      const filteredFields = mockEventFields.filter(field => field.display_id !== 'search');
-      expect(mockCache.set).toHaveBeenCalledWith('bugsnag_current_project_event_filters', filteredFields);
-    });
-
-    it('should throw error when no organizations found', async () => {
-      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [] });
-
-      await expect(client.initialize()).rejects.toThrow('No organizations found for the current user.');
-    });
-
-    it('should throw error when project with API key not found', async () => {
-      const clientWithApiKey = new BugsnagClient('test-token', 'non-existent-key');
-      const mockOrg = { id: 'org-1', name: 'Test Org' };
-      const mockProject = { id: 'proj-1', name: 'Project 1', api_key: 'other-key' };
-
-      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [mockOrg] });
-      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: [mockProject] });
-
-      await expect(clientWithApiKey.initialize()).rejects.toThrow(
-        'Unable to find project with API key non-existent-key in organization.'
+      expect(mockCurrentUserAPI.getOrganizationProjects).toHaveBeenCalledWith(
+        "org-1"
+      );
+      expect(mockCache.set).toHaveBeenCalledWith("bugsnag_org", mockOrg);
+      expect(mockCache.set).toHaveBeenCalledWith(
+        "bugsnag_projects",
+        mockProjects
       );
     });
 
-    it('should throw error when no event fields found for project', async () => {
-      const clientWithApiKey = new BugsnagClient('test-token', 'project-api-key');
-      const mockOrg = { id: 'org-1', name: 'Test Org' };
+    it("should initialize with project API key and set up event filters", async () => {
+      const clientWithApiKey = new BugsnagClient(
+        "test-token",
+        "project-api-key"
+      );
       const mockProjects = [
-        { id: 'proj-1', name: 'Project 1', api_key: 'project-api-key' }
+        { id: "proj-1", name: "Project 1", api_key: "project-api-key" },
+        { id: "proj-2", name: "Project 2", api_key: "other-key" },
+      ];
+      const mockEventFields = [
+        { display_id: "user.email", custom: false },
+        { display_id: "error.status", custom: false },
+        { display_id: "search", custom: false }, // This should be filtered out
       ];
 
-      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [mockOrg] });
-      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
+      mockCache.get
+        .mockReturnValueOnce(mockProjects)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(mockProjects);
+      mockProjectAPI.listProjectEventFields.mockResolvedValue({
+        body: mockEventFields,
+      });
+
+      await clientWithApiKey.initialize();
+
+      expect(mockCache.set).toHaveBeenCalledWith(
+        "bugsnag_current_project",
+        mockProjects[0]
+      );
+      expect(mockProjectAPI.listProjectEventFields).toHaveBeenCalledWith(
+        "proj-1"
+      );
+
+      // // Verify that 'search' field is filtered out
+      const filteredFields = mockEventFields.filter(
+        (field) => field.display_id !== "search"
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        "bugsnag_current_project_event_filters",
+        filteredFields
+      );
+    });
+
+    it("should throw error when no organizations found", async () => {
+      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: [] });
+
+      await expect(client.initialize()).rejects.toThrow(
+        "No organizations found for the current user."
+      );
+    });
+
+    it("should throw error when project with API key not found", async () => {
+      const clientWithApiKey = new BugsnagClient(
+        "test-token",
+        "non-existent-key"
+      );
+      const mockOrg = { id: "org-1", name: "Test Org" };
+      const mockProject = {
+        id: "proj-1",
+        name: "Project 1",
+        api_key: "other-key",
+      };
+
+      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({
+        body: [mockOrg],
+      });
+      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+        body: [mockProject],
+      });
+
+      await expect(clientWithApiKey.initialize()).rejects.toThrow(
+        "Unable to find project with API key non-existent-key in organization."
+      );
+    });
+
+    it("should throw error when no event fields found for project", async () => {
+      const clientWithApiKey = new BugsnagClient(
+        "test-token",
+        "project-api-key"
+      );
+      const mockOrg = { id: "org-1", name: "Test Org" };
+      const mockProjects = [
+        { id: "proj-1", name: "Project 1", api_key: "project-api-key" },
+      ];
+
+      mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({
+        body: [mockOrg],
+      });
+      mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+        body: mockProjects,
+      });
       mockProjectAPI.listProjectEventFields.mockResolvedValue({ body: [] });
 
       await expect(clientWithApiKey.initialize()).rejects.toThrow(
-        'No event fields found for project Project 1.'
+        "No event fields found for project Project 1."
       );
     });
   });
 
-  describe('API methods', () => {
-    describe('getProjects', () => {
-      it('should return cached projects when available', async () => {
-        const mockProjects = [{ id: 'proj-1', name: 'Project 1' }];
+  describe("API methods", () => {
+    describe("getProjects", () => {
+      it("should return cached projects when available", async () => {
+        const mockProjects = [{ id: "proj-1", name: "Project 1" }];
         mockCache.get.mockReturnValue(mockProjects);
 
         const result = await client.getProjects();
 
-        expect(mockCache.get).toHaveBeenCalledWith('bugsnag_projects');
+        expect(mockCache.get).toHaveBeenCalledWith("bugsnag_projects");
         expect(result).toEqual(mockProjects);
       });
 
-      it('should fetch projects from API when not cached', async () => {
-        const mockOrg = { id: 'org-1', name: 'Test Org' };
-        const mockProjects = [{ id: 'proj-1', name: 'Project 1' }];
+      it("should fetch projects from API when not cached", async () => {
+        const mockOrg = { id: "org-1", name: "Test Org" };
+        const mockProjects = [{ id: "proj-1", name: "Project 1" }];
 
         mockCache.get
           .mockReturnValueOnce(null) // First call for projects
           .mockReturnValueOnce(mockOrg); // Second call for org
-        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
+        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+          body: mockProjects,
+        });
 
         const result = await client.getProjects();
 
-        expect(mockCurrentUserAPI.getOrganizationProjects).toHaveBeenCalledWith('org-1');
-        expect(mockCache.set).toHaveBeenCalledWith('bugsnag_projects', mockProjects);
+        expect(mockCurrentUserAPI.getOrganizationProjects).toHaveBeenCalledWith(
+          "org-1"
+        );
+        expect(mockCache.set).toHaveBeenCalledWith(
+          "bugsnag_projects",
+          mockProjects
+        );
         expect(result).toEqual(mockProjects);
       });
 
-      it('should return empty array when no projects found', async () => {
-        const mockOrg = { id: 'org-1', name: 'Test Org' };
+      it("should return empty array when no projects found", async () => {
+        const mockOrg = { id: "org-1", name: "Test Org" };
 
         mockCache.get
           .mockReturnValueOnce(null) // First call for projects
           .mockReturnValueOnce(mockOrg); // Second call for org
-        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: [] });
+        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+          body: [],
+        });
 
         await expect(client.getProjects()).resolves.toEqual([]);
       });
@@ -552,8 +665,7 @@ describe('BugsnagClient', () => {
             release_stage: { name: "production" },
             source_control: {
               service: "github",
-              commit_url:
-                "https://github.com/org/repo/commit/abc123",
+              commit_url: "https://github.com/org/repo/commit/abc123",
             },
             errors_introduced_count: 5,
             errors_seen_count: 10,
@@ -578,29 +690,29 @@ describe('BugsnagClient', () => {
         mockProjectAPI.listBuilds.mockResolvedValue({
           body: mockBuilds,
           headers: new Headers(),
-          status: 200
+          status: 200,
         });
 
         const result = await client.listBuilds("proj-1", {
           release_stage: "production",
         });
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage: "production" }
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
+          release_stage: "production",
+        });
         expect(result).toEqual({ builds: enhancedBuilds, nextUrl: null });
       });
 
       it("should return empty array when no builds found", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({ body: null, headers: new Headers(), status: 200 });
+        mockProjectAPI.listBuilds.mockResolvedValue({
+          body: null,
+          headers: new Headers(),
+          status: 200,
+        });
 
         const result = await client.listBuilds("proj-1", {});
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          {}
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {});
         expect(result).toEqual({ builds: [], nextUrl: null });
       });
 
@@ -608,7 +720,7 @@ describe('BugsnagClient', () => {
         mockProjectAPI.listBuilds.mockImplementation(() => ({
           body: [],
           headers: new Headers(),
-          status: 200
+          status: 200,
         }));
 
         await client.listBuilds("proj-1", {
@@ -616,10 +728,9 @@ describe('BugsnagClient', () => {
         });
 
         // This is testing the implementation detail that the ProjectAPI correctly constructs the URL
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage: "staging" }
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
+          release_stage: "staging",
+        });
       });
 
       it("should handle pagination with next URL", async () => {
@@ -651,37 +762,41 @@ describe('BugsnagClient', () => {
 
         // Create headers with Link for pagination
         const headers = new Headers();
-        headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/releases?offset=30&per_page=30>; rel="next"');
+        headers.append(
+          "Link",
+          '<https://api.bugsnag.com/projects/proj-1/releases?offset=30&per_page=30>; rel="next"'
+        );
 
         mockProjectAPI.listBuilds.mockResolvedValue({
           body: mockBuilds,
           headers,
-          status: 200
+          status: 200,
         });
 
         const result = await client.listBuilds("proj-1", {});
 
         expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {});
         expect(result.builds).toEqual(enhancedBuilds);
-        expect(result.nextUrl).toBe('/projects/proj-1/releases?offset=30&per_page=30');
+        expect(result.nextUrl).toBe(
+          "/projects/proj-1/releases?offset=30&per_page=30"
+        );
       });
 
       it("should pass next_url parameter to ProjectAPI", async () => {
         mockProjectAPI.listBuilds.mockImplementation(() => ({
           body: [],
           headers: new Headers(),
-          status: 200
+          status: 200,
         }));
 
-        const nextUrl = '/projects/proj-1/releases?offset=30&per_page=30';
+        const nextUrl = "/projects/proj-1/releases?offset=30&per_page=30";
         await client.listBuilds("proj-1", {
-          next_url: nextUrl
+          next_url: nextUrl,
         });
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          { next_url: nextUrl }
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
+          next_url: nextUrl,
+        });
       });
     });
 
@@ -726,13 +841,8 @@ describe('BugsnagClient', () => {
 
         const result = await client.getBuild("proj-1", "rel-1");
 
-        expect(mockCache.get).toHaveBeenCalledWith(
-          "bugsnag_build_rel-1"
-        );
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
-          "proj-1",
-          "rel-1"
-        );
+        expect(mockCache.get).toHaveBeenCalledWith("bugsnag_build_rel-1");
+        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_build_rel-1",
           enhancedBuild,
@@ -761,10 +871,7 @@ describe('BugsnagClient', () => {
           body: mockBuild,
         });
 
-        const result = (await client.getBuild(
-          "proj-1",
-          "rel-2"
-        ));
+        const result = await client.getBuild("proj-1", "rel-2");
 
         expect(result.user_stability).toBe(0);
         expect(result.meets_target_stability).toBe(false);
@@ -791,10 +898,7 @@ describe('BugsnagClient', () => {
           body: mockBuild,
         });
 
-        const result = (await client.getBuild(
-          "proj-1",
-          "rel-3"
-        ));
+        const result = await client.getBuild("proj-1", "rel-3");
 
         expect(result.session_stability).toBe(0);
         // Since stability_target_type is "user", user_stability is used for comparison
@@ -818,31 +922,26 @@ describe('BugsnagClient', () => {
         };
 
         // Override the default mockProjectAPI.getProjectStabilityTargets for this test only
-        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce(
-          {
-            target_stability: {
-              value: 0.95,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            critical_stability: {
-              value: 0.9,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            stability_target_type: "session" as const,
-          }
-        );
+        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce({
+          target_stability: {
+            value: 0.95,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          critical_stability: {
+            value: 0.9,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          stability_target_type: "session" as const,
+        });
 
         mockCache.get.mockReturnValueOnce(null);
         mockProjectAPI.getBuild.mockResolvedValue({
           body: mockBuild,
         });
 
-        const result = (await client.getBuild(
-          "proj-1",
-          "rel-4"
-        ));
+        const result = await client.getBuild("proj-1", "rel-4");
 
         expect(result.stability_target_type).toBe("session");
         expect(result.session_stability).toBe(0.95); // (100-5)/100
@@ -868,31 +967,26 @@ describe('BugsnagClient', () => {
         };
 
         // Override the default mockProjectAPI.getProjectStabilityTargets for this test only
-        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce(
-          {
-            target_stability: {
-              value: 0.99,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            critical_stability: {
-              value: 0.95,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            stability_target_type: "user" as const,
-          }
-        );
+        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce({
+          target_stability: {
+            value: 0.99,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          critical_stability: {
+            value: 0.95,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          stability_target_type: "user" as const,
+        });
 
         mockCache.get.mockReturnValueOnce(null);
         mockProjectAPI.getBuild.mockResolvedValue({
           body: mockBuild,
         });
 
-        const result = (await client.getBuild(
-          "proj-1",
-          "rel-5"
-        ));
+        const result = await client.getBuild("proj-1", "rel-5");
 
         expect(result.user_stability).toBe(0.996); // (500-2)/500
         expect(result.meets_target_stability).toBe(true);
@@ -919,10 +1013,7 @@ describe('BugsnagClient', () => {
           body: mockBuild,
         });
 
-        const result = (await client.getBuild(
-          "proj-1",
-          "rel-6"
-        ));
+        const result = await client.getBuild("proj-1", "rel-6");
 
         expect(result.user_stability).toBe(0.8); // (100-20)/100
         expect(result.meets_target_stability).toBe(false); // 0.8 < 0.995
@@ -944,9 +1035,7 @@ describe('BugsnagClient', () => {
 
         const result = await client.getBuild("proj-1", "rel-1");
 
-        expect(mockCache.get).toHaveBeenCalledWith(
-          "bugsnag_build_rel-1"
-        );
+        expect(mockCache.get).toHaveBeenCalledWith("bugsnag_build_rel-1");
         expect(mockProjectAPI.getBuild).not.toHaveBeenCalled();
         expect(result).toEqual(mockBuild);
       });
@@ -958,9 +1047,7 @@ describe('BugsnagClient', () => {
 
         await expect(
           client.getBuild("proj-1", "non-existent-build-id")
-        ).rejects.toThrow(
-          "No build for non-existent-build-id found."
-        );
+        ).rejects.toThrow("No build for non-existent-build-id found.");
 
         expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
           "proj-1",
@@ -1002,7 +1089,7 @@ describe('BugsnagClient', () => {
         mockProjectAPI.listReleases.mockResolvedValue({
           body: mockReleases,
           headers: new Headers(),
-          status: 200
+          status: 200,
         });
 
         const result = await client.listReleases("proj-1", {
@@ -1010,25 +1097,29 @@ describe('BugsnagClient', () => {
           visible_only: true,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "production", visible_only: true }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "production",
+          visible_only: true,
+        });
         expect(result).toEqual({ releases: enhancedReleases, nextUrl: null });
       });
 
       it("should return empty array when no releases found", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({ body: null, headers: new Headers(), status: 200 });
+        mockProjectAPI.listReleases.mockResolvedValue({
+          body: null,
+          headers: new Headers(),
+          status: 200,
+        });
 
         const result = await client.listReleases("proj-1", {
           release_stage_name: "production",
-          visible_only: true
+          visible_only: true,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "production", visible_only: true }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "production",
+          visible_only: true,
+        });
         expect(result).toEqual({ releases: [], nextUrl: null });
       });
 
@@ -1036,18 +1127,18 @@ describe('BugsnagClient', () => {
         mockProjectAPI.listReleases.mockImplementation(() => ({
           body: [],
           headers: new Headers(),
-          status: 200
+          status: 200,
         }));
 
         await client.listReleases("proj-1", {
           release_stage_name: "staging",
-          visible_only: false
+          visible_only: false,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "staging", visible_only: false }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "staging",
+          visible_only: false,
+        });
       });
 
       it("should handle pagination with next URL in listReleases", async () => {
@@ -1081,41 +1172,47 @@ describe('BugsnagClient', () => {
 
         // Create headers with Link for pagination
         const headers = new Headers();
-        headers.append('Link', '<https://api.bugsnag.com/projects/proj-1/release_groups?offset=30&per_page=30>; rel="next"');
+        headers.append(
+          "Link",
+          '<https://api.bugsnag.com/projects/proj-1/release_groups?offset=30&per_page=30>; rel="next"'
+        );
 
         mockProjectAPI.listReleases.mockResolvedValue({
           body: mockReleases,
           headers,
-          status: 200
+          status: 200,
         });
 
         const result = await client.listReleases("proj-1", {
           release_stage_name: "production",
-          visible_only: true
+          visible_only: true,
         });
 
         expect(result.releases).toEqual(enhancedReleases);
-        expect(result.nextUrl).toBe('/projects/proj-1/release_groups?offset=30&per_page=30');
+        expect(result.nextUrl).toBe(
+          "/projects/proj-1/release_groups?offset=30&per_page=30"
+        );
       });
 
       it("should pass next_url parameter to ProjectAPI in listReleases", async () => {
         mockProjectAPI.listReleases.mockImplementation(() => ({
           body: [],
           headers: new Headers(),
-          status: 200
+          status: 200,
         }));
 
-        const nextUrl = '/projects/proj-1/release_groups?offset=30&per_page=30';
+        const nextUrl = "/projects/proj-1/release_groups?offset=30&per_page=30";
         await client.listReleases("proj-1", {
           release_stage_name: "production",
           visible_only: true,
-          next_url: nextUrl
+          next_url: nextUrl,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "production", visible_only: true, next_url: nextUrl }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "production",
+          visible_only: true,
+          next_url: nextUrl,
+        });
       });
     });
 
@@ -1136,7 +1233,8 @@ describe('BugsnagClient', () => {
             service: "github",
             commit_url: "https://github.com/org/repo/commit/abc123",
             revision: "abc123",
-            diff_url_to_previous: "https://github.com/org/repo/compare/previous...abc123",
+            diff_url_to_previous:
+              "https://github.com/org/repo/compare/previous...abc123",
           },
           top_release_group: true,
           visible: true,
@@ -1169,9 +1267,7 @@ describe('BugsnagClient', () => {
         expect(mockCache.get).toHaveBeenCalledWith(
           "bugsnag_release_rel-group-1"
         );
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
-          "rel-group-1"
-        );
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith("rel-group-1");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_release_rel-group-1",
           enhancedRelease,
@@ -1199,10 +1295,7 @@ describe('BugsnagClient', () => {
           body: mockRelease,
         });
 
-        const result = (await client.getRelease(
-          "proj-1",
-          "rel-group-2"
-        ));
+        const result = await client.getRelease("proj-1", "rel-group-2");
 
         expect(result.user_stability).toBe(0);
         expect(result.meets_target_stability).toBe(false);
@@ -1224,31 +1317,26 @@ describe('BugsnagClient', () => {
         };
 
         // Override the default mockProjectAPI.getProjectStabilityTargets for this test only
-        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce(
-          {
-            target_stability: {
-              value: 0.95,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            critical_stability: {
-              value: 0.9,
-              updated_at: "2023-01-01",
-              updated_by_id: "user-1",
-            },
-            stability_target_type: "session" as const,
-          }
-        );
+        mockProjectAPI.getProjectStabilityTargets.mockResolvedValueOnce({
+          target_stability: {
+            value: 0.95,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          critical_stability: {
+            value: 0.9,
+            updated_at: "2023-01-01",
+            updated_by_id: "user-1",
+          },
+          stability_target_type: "session" as const,
+        });
 
         mockCache.get.mockReturnValueOnce(null);
         mockProjectAPI.getRelease.mockResolvedValue({
           body: mockRelease,
         });
 
-        const result = (await client.getRelease(
-          "proj-1",
-          "rel-group-3"
-        ));
+        const result = await client.getRelease("proj-1", "rel-group-3");
 
         expect(result.stability_target_type).toBe("session");
         expect(result.session_stability).toBe(0.95); // (100-5)/100
@@ -1287,9 +1375,7 @@ describe('BugsnagClient', () => {
 
         await expect(
           client.getRelease("proj-1", "non-existent-release-id")
-        ).rejects.toThrow(
-          "No release for non-existent-release-id found."
-        );
+        ).rejects.toThrow("No release for non-existent-release-id found.");
 
         expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
           "non-existent-release-id"
@@ -1309,7 +1395,7 @@ describe('BugsnagClient', () => {
             id: "build-2",
             release_time: "2023-01-02T00:00:00Z",
             app_version: "1.0.0",
-          }
+          },
         ];
 
         // Mock cache to return null first to simulate no cached data
@@ -1317,7 +1403,7 @@ describe('BugsnagClient', () => {
         mockProjectAPI.listBuildsInRelease.mockResolvedValue({
           body: mockBuildsInRelease,
           headers: new Headers(),
-          status: 200
+          status: 200,
         });
 
         const result = await client.listBuildsInRelease("rel-group-1");
@@ -1342,7 +1428,7 @@ describe('BugsnagClient', () => {
             id: "build-1",
             release_time: "2023-01-01T00:00:00Z",
             app_version: "1.0.0",
-          }
+          },
         ];
 
         // Mock cache to return builds
@@ -1360,7 +1446,11 @@ describe('BugsnagClient', () => {
       it("should return empty array when no builds in release found", async () => {
         // Mock cache to return null to simulate no cached data
         mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.listBuildsInRelease.mockResolvedValue({ body: null, headers: new Headers(), status: 200 });
+        mockProjectAPI.listBuildsInRelease.mockResolvedValue({
+          body: null,
+          headers: new Headers(),
+          status: 200,
+        });
 
         const result = await client.listBuildsInRelease("rel-group-1");
 
@@ -1376,45 +1466,57 @@ describe('BugsnagClient', () => {
       });
     });
 
-    describe('getEventById', () => {
-      it('should find event across multiple projects', async () => {
-        const mockOrgs = [{ id: 'org-1', name: 'Test Org' }];
+    describe("getEventById", () => {
+      it("should find event across multiple projects", async () => {
+        const mockOrgs = [{ id: "org-1", name: "Test Org" }];
         const mockProjects = [
-          { id: 'proj-1', name: 'Project 1' },
-          { id: 'proj-2', name: 'Project 2' }
+          { id: "proj-1", name: "Project 1" },
+          { id: "proj-2", name: "Project 2" },
         ];
-        const mockEvent = { id: 'event-1', project_id: 'proj-2' };
+        const mockEvent = { id: "event-1", project_id: "proj-2" };
 
         mockCache.get.mockReturnValueOnce(mockProjects);
         mockCache.get.mockReturnValueOnce(mockOrgs);
-        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
+        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+          body: mockProjects,
+        });
         mockErrorAPI.viewEventById
-          .mockRejectedValueOnce(new Error('Not found')) // proj-1
+          .mockRejectedValueOnce(new Error("Not found")) // proj-1
           .mockResolvedValueOnce({ body: mockEvent }); // proj-2
 
-        const result = await client.getEvent('event-1');
+        const result = await client.getEvent("event-1");
 
-        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith('proj-1', 'event-1');
-        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith('proj-2', 'event-1');
+        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith(
+          "proj-1",
+          "event-1"
+        );
+        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith(
+          "proj-2",
+          "event-1"
+        );
         expect(result).toEqual(mockEvent);
       });
 
-      it('should return null when event not found in any project', async () => {
-        const mockOrgs = [{ id: 'org-1', name: 'Test Org' }];
-        const mockProjects = [{ id: 'proj-1', name: 'Project 1' }];
+      it("should return null when event not found in any project", async () => {
+        const mockOrgs = [{ id: "org-1", name: "Test Org" }];
+        const mockProjects = [{ id: "proj-1", name: "Project 1" }];
 
-        mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({ body: mockOrgs });
-        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({ body: mockProjects });
-        mockErrorAPI.viewEventById.mockRejectedValue(new Error('Not found'));
+        mockCurrentUserAPI.listUserOrganizations.mockResolvedValue({
+          body: mockOrgs,
+        });
+        mockCurrentUserAPI.getOrganizationProjects.mockResolvedValue({
+          body: mockProjects,
+        });
+        mockErrorAPI.viewEventById.mockRejectedValue(new Error("Not found"));
 
-        const result = await client.getEvent('event-1');
+        const result = await client.getEvent("event-1");
 
         expect(result).toBeNull();
       });
     });
   });
 
-  describe('tool registration', () => {
+  describe("tool registration", () => {
     let registerToolsSpy: any;
     let getInputFunctionSpy: any;
 
@@ -1423,7 +1525,7 @@ describe('BugsnagClient', () => {
       getInputFunctionSpy = vi.fn();
     });
 
-    it('should register list_projects tool when no project API key', () => {
+    it("should register list_projects tool when no project API key", () => {
       client.registerTools(registerToolsSpy, getInputFunctionSpy);
 
       expect(registerToolsSpy).toBeCalledWith(
@@ -1432,51 +1534,57 @@ describe('BugsnagClient', () => {
       );
     });
 
-    it('should not register list_projects tool when project API key is provided', () => {
-      const clientWithApiKey = new BugsnagClient('test-token', 'project-api-key');
+    it("should not register list_projects tool when project API key is provided", () => {
+      const clientWithApiKey = new BugsnagClient(
+        "test-token",
+        "project-api-key"
+      );
       clientWithApiKey.registerTools(registerToolsSpy, getInputFunctionSpy);
 
-      const registeredTools = registerToolsSpy.mock.calls.map((call: any) => call[0].title);
-      expect(registeredTools).not.toContain('List Projects');
+      const registeredTools = registerToolsSpy.mock.calls.map(
+        (call: any) => call[0].title
+      );
+      expect(registeredTools).not.toContain("List Projects");
     });
 
-    it('should register common tools regardless of project API key', () => {
+    it("should register common tools regardless of project API key", () => {
       client.registerTools(registerToolsSpy, getInputFunctionSpy);
 
-      const registeredTools = registerToolsSpy.mock.calls.map((call: any) => call[0].title);
-      expect(registeredTools).toContain('Get Error');
-      expect(registeredTools).toContain('Get Event Details');
-      expect(registeredTools).toContain('List Project Errors');
-      expect(registeredTools).toContain('List Project Event Filters');
-      expect(registeredTools).toContain('Update Error');
-      expect(registeredTools).toContain('List Builds');
-      expect(registeredTools).toContain('Get Build');
-      expect(registeredTools).toContain('List Releases');
-      expect(registeredTools).toContain('Get Release');
-      expect(registeredTools).toContain('List Builds in Release');
+      const registeredTools = registerToolsSpy.mock.calls.map(
+        (call: any) => call[0].title
+      );
+      expect(registeredTools).toContain("Get Error");
+      expect(registeredTools).toContain("Get Event Details");
+      expect(registeredTools).toContain("List Project Errors");
+      expect(registeredTools).toContain("List Project Event Filters");
+      expect(registeredTools).toContain("Update Error");
+      expect(registeredTools).toContain("List Builds");
+      expect(registeredTools).toContain("Get Build");
+      expect(registeredTools).toContain("List Releases");
+      expect(registeredTools).toContain("Get Release");
+      expect(registeredTools).toContain("List Builds in Release");
     });
   });
 
-  describe('resource registration', () => {
+  describe("resource registration", () => {
     let registerResourcesSpy: any;
 
     beforeEach(() => {
       registerResourcesSpy = vi.fn();
     });
 
-    it('should register event resource', () => {
+    it("should register event resource", () => {
       client.registerResources(registerResourcesSpy);
 
       expect(registerResourcesSpy).toHaveBeenCalledWith(
-        'event',
-        '{id}',
+        "event",
+        "{id}",
         expect.any(Function)
       );
     });
   });
 
-  describe('tool handlers', () => {
-
+  describe("tool handlers", () => {
     let registerToolsSpy: any;
     let getInputFunctionSpy: any;
 
@@ -1485,215 +1593,261 @@ describe('BugsnagClient', () => {
       getInputFunctionSpy = vi.fn();
     });
 
-    describe('list_projects tool handler', () => {
-      it('should return projects with pagination', async () => {
+    describe("list_projects tool handler", () => {
+      it("should return projects with pagination", async () => {
         const mockProjects = [
-          { id: 'proj-1', name: 'Project 1' },
-          { id: 'proj-2', name: 'Project 2' },
-          { id: 'proj-3', name: 'Project 3' }
+          { id: "proj-1", name: "Project 1" },
+          { id: "proj-2", name: "Project 2" },
+          { id: "proj-3", name: "Project 3" },
         ];
         mockCache.get.mockReturnValue(mockProjects);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Projects')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Projects"
+        )[1];
 
         const result = await toolHandler({ page_size: 2, page: 1 });
 
         const expectedResult = {
           data: mockProjects.slice(0, 2),
-          count: 2
+          count: 2,
         };
         expect(result.content[0].text).toBe(JSON.stringify(expectedResult));
       });
 
-      it('should return all projects when no pagination specified', async () => {
-        const mockProjects = [{ id: 'proj-1', name: 'Project 1' }];
+      it("should return all projects when no pagination specified", async () => {
+        const mockProjects = [{ id: "proj-1", name: "Project 1" }];
         mockCache.get.mockReturnValue(mockProjects);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Projects')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Projects"
+        )[1];
 
         const result = await toolHandler({});
 
         const expectedResult = {
           data: mockProjects,
-          count: 1
+          count: 1,
         };
         expect(result.content[0].text).toBe(JSON.stringify(expectedResult));
       });
 
-      it('should handle no projects found', async () => {
+      it("should handle no projects found", async () => {
         mockCache.get.mockReturnValue([]);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Projects')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Projects"
+        )[1];
 
         const result = await toolHandler({});
 
-        expect(result.content[0].text).toBe('No projects found.');
+        expect(result.content[0].text).toBe("No projects found.");
       });
 
-      it('should handle pagination with only page_size', async () => {
+      it("should handle pagination with only page_size", async () => {
         const mockProjects = [
-          { id: 'proj-1', name: 'Project 1' },
-          { id: 'proj-2', name: 'Project 2' },
-          { id: 'proj-3', name: 'Project 3' }
+          { id: "proj-1", name: "Project 1" },
+          { id: "proj-2", name: "Project 2" },
+          { id: "proj-3", name: "Project 3" },
         ];
         mockCache.get.mockReturnValue(mockProjects);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Projects')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Projects"
+        )[1];
 
         const result = await toolHandler({ page_size: 2 });
 
         const expectedResult = {
           data: mockProjects.slice(0, 2),
-          count: 2
+          count: 2,
         };
         expect(result.content[0].text).toBe(JSON.stringify(expectedResult));
       });
 
-      it('should handle pagination with only page', async () => {
+      it("should handle pagination with only page", async () => {
         const mockProjects = Array.from({ length: 25 }, (_, i) => ({
           id: `proj-${i + 1}`,
-          name: `Project ${i + 1}`
+          name: `Project ${i + 1}`,
         }));
         mockCache.get.mockReturnValue(mockProjects);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Projects')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Projects"
+        )[1];
 
         const result = await toolHandler({ page: 2 });
 
         // Default page_size is 10, so page 2 should return projects 10-19
         const expectedResult = {
           data: mockProjects.slice(10, 20),
-          count: 10
+          count: 10,
         };
         expect(result.content[0].text).toBe(JSON.stringify(expectedResult));
       });
     });
 
-    describe('get_error tool handler', () => {
-      it('should get error details with project from cache', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1', slug: 'my-project' };
-        const mockError = { id: 'error-1', message: 'Test error' };
-        const mockOrg = { id: 'org-1', name: 'Test Org', slug: 'test-org' };
-        const mockEvents = [{ id: 'event-1', timestamp: '2023-01-01' }];
-        const mockPivots = [{ id: 'pivot-1', name: 'test-pivot' }];
+    describe("get_error tool handler", () => {
+      it("should get error details with project from cache", async () => {
+        const mockProject = {
+          id: "proj-1",
+          name: "Project 1",
+          slug: "my-project",
+        };
+        const mockError = { id: "error-1", message: "Test error" };
+        const mockOrg = { id: "org-1", name: "Test Org", slug: "test-org" };
+        const mockEvents = [{ id: "event-1", timestamp: "2023-01-01" }];
+        const mockPivots = [{ id: "pivot-1", name: "test-pivot" }];
 
-        mockCache.get.mockReturnValueOnce(mockProject)
+        mockCache.get
+          .mockReturnValueOnce(mockProject)
           .mockReturnValueOnce(mockOrg);
         mockErrorAPI.viewErrorOnProject.mockResolvedValue({ body: mockError });
-        mockErrorAPI.listEventsOnProject.mockResolvedValue({ body: mockEvents });
+        mockErrorAPI.listEventsOnProject.mockResolvedValue({
+          body: mockEvents,
+        });
         mockErrorAPI.listErrorPivots.mockResolvedValue({ body: mockPivots });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Error"
+        )[1];
 
-        const result = await toolHandler({ errorId: 'error-1' });
+        const result = await toolHandler({ errorId: "error-1" });
 
-        const queryString = '?filters[error][][type]=eq&filters[error][][value]=error-1'
+        const queryString =
+          "?filters[error][][type]=eq&filters[error][][value]=error-1";
         const encodedQueryString = encodeURI(queryString);
-        expect(mockErrorAPI.viewErrorOnProject).toHaveBeenCalledWith('proj-1', 'error-1');
-        expect(result.content[0].text).toBe(JSON.stringify({
-          error_details: mockError,
-          latest_event: mockEvents[0],
-          pivots: mockPivots,
-          url: `https://app.bugsnag.com/${mockOrg.slug}/${mockProject.slug}/errors/error-1${encodedQueryString}`
-        }));
+        expect(mockErrorAPI.viewErrorOnProject).toHaveBeenCalledWith(
+          "proj-1",
+          "error-1"
+        );
+        expect(result.content[0].text).toBe(
+          JSON.stringify({
+            error_details: mockError,
+            latest_event: mockEvents[0],
+            pivots: mockPivots,
+            url: `https://app.bugsnag.com/${mockOrg.slug}/${mockProject.slug}/errors/error-1${encodedQueryString}`,
+          })
+        );
       });
 
-      it('should throw error when projectId is not set', async () => {
+      it("should throw error when projectId is not set", async () => {
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Error"
+        )[1];
 
-        await expect(toolHandler({})).rejects.toThrow('No current project found. Please provide a projectId or configure a project API key.');
+        await expect(toolHandler({})).rejects.toThrow(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
       });
 
-      it('should throw error when error ID is not set', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1', slug: 'my-project' };
+      it("should throw error when error ID is not set", async () => {
+        const mockProject = {
+          id: "proj-1",
+          name: "Project 1",
+          slug: "my-project",
+        };
         mockCache.get.mockReturnValueOnce(mockProject);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Error"
+        )[1];
 
-        await expect(toolHandler({})).rejects.toThrow('Both projectId and errorId arguments are required');
+        await expect(toolHandler({})).rejects.toThrow(
+          "Both projectId and errorId arguments are required"
+        );
       });
     });
 
-    describe('get_bugsnag_event_details tool handler', () => {
-      it('should get event details from dashboard URL', async () => {
-        const mockProjects = [{ id: 'proj-1', slug: 'my-project', name: 'My Project' }];
-        const mockEvent = { id: 'event-1', project_id: 'proj-1' };
+    describe("get_bugsnag_event_details tool handler", () => {
+      it("should get event details from dashboard URL", async () => {
+        const mockProjects = [
+          { id: "proj-1", slug: "my-project", name: "My Project" },
+        ];
+        const mockEvent = { id: "event-1", project_id: "proj-1" };
 
         mockCache.get.mockReturnValue(mockProjects);
 
         mockErrorAPI.viewEventById.mockResolvedValue({ body: mockEvent });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Event Details')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Event Details"
+        )[1];
 
         const result = await toolHandler({
-          link: 'https://app.bugsnag.com/my-org/my-project/errors/error-123?event_id=event-1'
+          link: "https://app.bugsnag.com/my-org/my-project/errors/error-123?event_id=event-1",
         });
 
-        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith('proj-1', 'event-1');
+        expect(mockErrorAPI.viewEventById).toHaveBeenCalledWith(
+          "proj-1",
+          "event-1"
+        );
         expect(result.content[0].text).toBe(JSON.stringify(mockEvent));
       });
 
-      it('should throw error when link is invalid', async () => {
+      it("should throw error when link is invalid", async () => {
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Event Details')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Event Details"
+        )[1];
 
-        await expect(toolHandler({ link: 'invalid-url' })).rejects.toThrow();
+        await expect(toolHandler({ link: "invalid-url" })).rejects.toThrow();
       });
 
-      it('should throw error when project not found', async () => {
-        mockCache.get.mockReturnValue([{ id: 'proj-1', slug: 'other-project', name: 'Other Project' }]);
+      it("should throw error when project not found", async () => {
+        mockCache.get.mockReturnValue([
+          { id: "proj-1", slug: "other-project", name: "Other Project" },
+        ]);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Event Details')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Event Details"
+        )[1];
 
-        await expect(toolHandler({
-          link: 'https://app.bugsnag.com/my-org/my-project/errors/error-123?event_id=event-1'
-        })).rejects.toThrow('Project with the specified slug not found.');
+        await expect(
+          toolHandler({
+            link: "https://app.bugsnag.com/my-org/my-project/errors/error-123?event_id=event-1",
+          })
+        ).rejects.toThrow("Project with the specified slug not found.");
       });
 
-      it('should throw error when URL is missing required parameters', async () => {
+      it("should throw error when URL is missing required parameters", async () => {
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Get Event Details')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Event Details"
+        )[1];
 
-        await expect(toolHandler({
-          link: 'https://app.bugsnag.com/my-org/my-project/errors/error-123' // Missing event_id
-        })).rejects.toThrow('Both projectSlug and eventId must be present in the link');
+        await expect(
+          toolHandler({
+            link: "https://app.bugsnag.com/my-org/my-project/errors/error-123", // Missing event_id
+          })
+        ).rejects.toThrow(
+          "Both projectSlug and eventId must be present in the link"
+        );
       });
     });
 
-    describe('list_project_errors tool handler', () => {
-      it('should list project errors with supplied parameters', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+    describe("list_project_errors tool handler", () => {
+      it("should list project errors with supplied parameters", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
         const mockEventFields = [
-          { display_id: 'error.status', custom: false },
-          { display_id: 'user.email', custom: false },
-          { display_id: 'event.since', custom: false }
+          { display_id: "error.status", custom: false },
+          { display_id: "user.email", custom: false },
+          { display_id: "event.since", custom: false },
         ];
-        const mockErrors = [{ id: 'error-1', message: 'Test error' }];
+        const mockErrors = [{ id: "error-1", message: "Test error" }];
         const filters = {
-          'error.status': [{ type: 'eq' as const, value: 'for_review' }],
-          'event.since': [{ type: 'eq', value: '7d' }]
+          "error.status": [{ type: "eq" as const, value: "for_review" }],
+          "event.since": [{ type: "eq", value: "7d" }],
         };
 
         mockCache.get
@@ -1701,35 +1855,46 @@ describe('BugsnagClient', () => {
           .mockReturnValueOnce(mockEventFields); // event fields
         mockErrorAPI.listProjectErrors.mockResolvedValue({
           body: mockErrors,
-          headers: new Headers({ 'X-Total-Count': '1' })
+          headers: new Headers({ "X-Total-Count": "1" }),
         });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Errors')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Errors"
+        )[1];
 
-        const result = await toolHandler({ filters, sort: 'last_seen', direction: 'desc', per_page: 50 });
+        const result = await toolHandler({
+          filters,
+          sort: "last_seen",
+          direction: "desc",
+          per_page: 50,
+        });
 
-        expect(mockErrorAPI.listProjectErrors).toHaveBeenCalledWith('proj-1', { filters, sort: 'last_seen', direction: 'desc', per_page: 50 });
+        expect(mockErrorAPI.listProjectErrors).toHaveBeenCalledWith("proj-1", {
+          filters,
+          sort: "last_seen",
+          direction: "desc",
+          per_page: 50,
+        });
         const expectedResult = {
           data: mockErrors,
           count: 1,
-          total: 1
+          total: 1,
         };
         expect(result.content[0].text).toBe(JSON.stringify(expectedResult));
       });
 
-      it('should use default filters when not specified', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+      it("should use default filters when not specified", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
         const mockEventFields = [
-          { display_id: 'error.status', custom: false },
-          { display_id: 'user.email', custom: false },
-          { display_id: 'event.since', custom: false }
+          { display_id: "error.status", custom: false },
+          { display_id: "user.email", custom: false },
+          { display_id: "event.since", custom: false },
         ];
-        const mockErrors = [{ id: 'error-1', message: 'Test error' }];
+        const mockErrors = [{ id: "error-1", message: "Test error" }];
         const defaultFilters = {
-          'error.status': [{ type: 'eq' as const, value: 'open' }],
-          'event.since': [{ type: 'eq', value: '30d' }]
+          "error.status": [{ type: "eq" as const, value: "open" }],
+          "event.since": [{ type: "eq", value: "30d" }],
         };
 
         mockCache.get
@@ -1737,76 +1902,100 @@ describe('BugsnagClient', () => {
           .mockReturnValueOnce(mockEventFields); // event fields
         mockErrorAPI.listProjectErrors.mockResolvedValue({
           body: mockErrors,
-          headers: new Headers({ 'X-Total-Count': '1' })
+          headers: new Headers({ "X-Total-Count": "1" }),
         });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Errors')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Errors"
+        )[1];
 
-        const defaultFilterResult = await toolHandler({ sort: 'last_seen', direction: 'desc', per_page: 50 });
+        const defaultFilterResult = await toolHandler({
+          sort: "last_seen",
+          direction: "desc",
+          per_page: 50,
+        });
 
-        expect(mockErrorAPI.listProjectErrors).toHaveBeenCalledWith('proj-1', { filters: defaultFilters, sort: 'last_seen', direction: 'desc', per_page: 50 });
+        expect(mockErrorAPI.listProjectErrors).toHaveBeenCalledWith("proj-1", {
+          filters: defaultFilters,
+          sort: "last_seen",
+          direction: "desc",
+          per_page: 50,
+        });
         const expectedResult = {
           data: mockErrors,
           count: 1,
-          total: 1
+          total: 1,
         };
-        expect(defaultFilterResult.content[0].text).toBe(JSON.stringify(expectedResult));
+        expect(defaultFilterResult.content[0].text).toBe(
+          JSON.stringify(expectedResult)
+        );
       });
 
-      it('should validate filter keys against cached event fields', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
-        const mockEventFields = [{ display_id: 'error.status', custom: false }];
-        const filters = { 'invalid.field': [{ type: 'eq' as const, value: 'test' }] };
+      it("should validate filter keys against cached event fields", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
+        const mockEventFields = [{ display_id: "error.status", custom: false }];
+        const filters = {
+          "invalid.field": [{ type: "eq" as const, value: "test" }],
+        };
 
         mockCache.get
           .mockReturnValueOnce(mockProject)
           .mockReturnValueOnce(mockEventFields);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Errors')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Errors"
+        )[1];
 
-        await expect(toolHandler({ filters })).rejects.toThrow('Invalid filter key: invalid.field');
+        await expect(toolHandler({ filters })).rejects.toThrow(
+          "Invalid filter key: invalid.field"
+        );
       });
 
-      it('should throw error when no project ID available', async () => {
+      it("should throw error when no project ID available", async () => {
         mockCache.get.mockReturnValue(null);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Errors')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Errors"
+        )[1];
 
-        await expect(toolHandler({})).rejects.toThrow('No current project found. Please provide a projectId or configure a project API key.');
+        await expect(toolHandler({})).rejects.toThrow(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
       });
     });
 
-    describe('get_project_event_filters tool handler', () => {
-      it('should return cached event fields', async () => {
+    describe("get_project_event_filters tool handler", () => {
+      it("should return cached event fields", async () => {
         const mockEventFields = [
-          { display_id: 'error.status', custom: false },
-          { display_id: 'user.email', custom: false }
+          { display_id: "error.status", custom: false },
+          { display_id: "user.email", custom: false },
         ];
         mockCache.get.mockReturnValue(mockEventFields);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Event Filters')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Event Filters"
+        )[1];
 
         const result = await toolHandler({});
 
         expect(result.content[0].text).toBe(JSON.stringify(mockEventFields));
       });
 
-      it('should throw error when no event filters in cache', async () => {
+      it("should throw error when no event filters in cache", async () => {
         mockCache.get.mockReturnValue(null);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'List Project Event Filters')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "List Project Event Filters"
+        )[1];
 
-        await expect(toolHandler({})).rejects.toThrow('No event filters found in cache.');
+        await expect(toolHandler({})).rejects.toThrow(
+          "No event filters found in cache."
+        );
       });
     });
 
@@ -1821,8 +2010,7 @@ describe('BugsnagClient', () => {
             release_stage: { name: "production" },
             source_control: {
               service: "github",
-              commit_url:
-                "https://github.com/org/repo/commit/abc123",
+              commit_url: "https://github.com/org/repo/commit/abc123",
             },
             errors_introduced_count: 5,
             errors_seen_count: 10,
@@ -1859,10 +2047,9 @@ describe('BugsnagClient', () => {
           releaseStage: "production",
         });
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage: "production" }
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
+          release_stage: "production",
+        });
         expect(result.content[0].text).toBe(
           JSON.stringify({ builds: enhancedBuilds, next: null })
         );
@@ -1913,12 +2100,11 @@ describe('BugsnagClient', () => {
           releaseStage: "staging",
         });
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage: "staging" }
-        );
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
+          release_stage: "staging",
+        });
         expect(result.content[0].text).toBe(
-          JSON.stringify({ builds: enhancedBuilds, next: null})
+          JSON.stringify({ builds: enhancedBuilds, next: null })
         );
       });
 
@@ -1936,11 +2122,10 @@ describe('BugsnagClient', () => {
 
         const result = await toolHandler({});
 
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith(
-          "proj-1",
-          {}
+        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {});
+        expect(result.content[0].text).toBe(
+          JSON.stringify({ builds: [], next: null })
         );
-        expect(result.content[0].text).toBe(JSON.stringify({ builds: [], next: null }));
       });
 
       it("should throw error when no project ID available", async () => {
@@ -1978,7 +2163,7 @@ describe('BugsnagClient', () => {
           unhandled_sessions_count: 10,
           accumulative_daily_users_seen: 50,
           accumulative_daily_users_with_unhandled: 5,
-        }
+        };
         const enhancedBuild = {
           ...mockBuild,
           user_stability: 0.9,
@@ -2004,25 +2189,21 @@ describe('BugsnagClient', () => {
 
         const result = await toolHandler({ buildId: "rel-1" });
 
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
-          "proj-1",
-          "rel-1"
-        );
+        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_build_rel-1",
           enhancedBuild,
           300
         );
-        expect(result.content[0].text).toBe(
-          JSON.stringify(enhancedBuild)
-        );
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedBuild));
       });
 
       it("should get build with explicit project ID", async () => {
         const mockProjects = [
           { id: "proj-1", name: "Project 1" },
           { id: "proj-2", name: "Project 2" },
-        ];        const mockBuild = {
+        ];
+        const mockBuild = {
           id: "rel-1",
           release_time: "2023-01-01T00:00:00Z",
           app_version: "1.0.0",
@@ -2062,18 +2243,13 @@ describe('BugsnagClient', () => {
           buildId: "rel-1",
         });
 
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
-          "proj-1",
-          "rel-1"
-        );
+        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_build_rel-1",
           enhancedBuild,
           300
         );
-        expect(result.content[0].text).toBe(
-          JSON.stringify(enhancedBuild)
-        );
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedBuild));
       });
 
       it("should throw error when build not found", async () => {
@@ -2091,9 +2267,7 @@ describe('BugsnagClient', () => {
 
         await expect(
           toolHandler({ buildId: "non-existent-release-id" })
-        ).rejects.toThrow(
-          "No build for non-existent-release-id found."
-        );
+        ).rejects.toThrow("No build for non-existent-release-id found.");
       });
 
       it("should throw error when buildId argument is missing", async () => {
@@ -2112,17 +2286,16 @@ describe('BugsnagClient', () => {
       });
 
       it("should throw error when no project ID available", async () => {
-        mockCache.get
-          .mockReturnValue(null);
+        mockCache.get.mockReturnValue(null);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
           (call: any) => call[0].title === "Get Build"
         )[1];
 
-        await expect(
-          toolHandler({ buildId: "rel-1" })
-        ).rejects.toThrow("No current project found. Please provide a projectId or configure a project API key.");
+        await expect(toolHandler({ buildId: "rel-1" })).rejects.toThrow(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
       });
     });
 
@@ -2169,10 +2342,11 @@ describe('BugsnagClient', () => {
           visibleOnly: true,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "production", visible_only: true,next_url: null }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "production",
+          visible_only: true,
+          next_url: null,
+        });
         expect(result.content[0].text).toBe(
           JSON.stringify({ releases: enhancedReleases, next: null })
         );
@@ -2223,10 +2397,11 @@ describe('BugsnagClient', () => {
           visibleOnly: false,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-2",
-          { release_stage_name: "staging", visible_only: false, next_url: null }
-        );
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-2", {
+          release_stage_name: "staging",
+          visible_only: false,
+          next_url: null,
+        });
         expect(result.content[0].text).toBe(
           JSON.stringify({ releases: enhancedReleases, next: null })
         );
@@ -2249,11 +2424,14 @@ describe('BugsnagClient', () => {
           visibleOnly: true,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith(
-          "proj-1",
-          { release_stage_name: "production", visible_only: true, next_url: null }
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+          release_stage_name: "production",
+          visible_only: true,
+          next_url: null,
+        });
+        expect(result.content[0].text).toBe(
+          JSON.stringify({ releases: [], next: null })
         );
-        expect(result.content[0].text).toBe(JSON.stringify({ releases: [], next: null }));
       });
 
       it("should throw error when no project ID available", async () => {
@@ -2311,17 +2489,13 @@ describe('BugsnagClient', () => {
 
         const result = await toolHandler({ releaseId: "rel-group-1" });
 
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
-          "rel-group-1"
-        );
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith("rel-group-1");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_release_rel-group-1",
           enhancedRelease,
           300
         );
-        expect(result.content[0].text).toBe(
-          JSON.stringify(enhancedRelease)
-        );
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedRelease));
       });
 
       it("should get release with explicit project ID", async () => {
@@ -2370,17 +2544,13 @@ describe('BugsnagClient', () => {
           releaseId: "rel-group-2",
         });
 
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
-          "rel-group-2"
-        );
+        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith("rel-group-2");
         expect(mockCache.set).toHaveBeenCalledWith(
           "bugsnag_release_rel-group-2",
           enhancedRelease,
           300
         );
-        expect(result.content[0].text).toBe(
-          JSON.stringify(enhancedRelease)
-        );
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedRelease));
       });
 
       it("should throw error when release not found", async () => {
@@ -2398,13 +2568,10 @@ describe('BugsnagClient', () => {
 
         await expect(
           toolHandler({ releaseId: "non-existent-release-id" })
-        ).rejects.toThrow(
-          "No release for non-existent-release-id found."
-        );
+        ).rejects.toThrow("No release for non-existent-release-id found.");
       });
 
       it("should throw error when releaseId argument is missing", async () => {
-
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
           (call: any) => call[0].title === "Get Release"
@@ -2422,17 +2589,16 @@ describe('BugsnagClient', () => {
           {
             id: "build-1",
             release_time: "2023-01-01T00:00:00Z",
-            app_version: "1.0.0"
+            app_version: "1.0.0",
           },
           {
             id: "build-2",
             release_time: "2023-01-02T00:00:00Z",
-            app_version: "1.0.0"
-          }
+            app_version: "1.0.0",
+          },
         ];
 
-        mockCache.get
-          .mockReturnValueOnce(mockBuildsInRelease);
+        mockCache.get.mockReturnValueOnce(mockBuildsInRelease);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
@@ -2440,7 +2606,7 @@ describe('BugsnagClient', () => {
         )[1];
 
         const result = await toolHandler({
-          releaseId: "rel-group-1"
+          releaseId: "rel-group-1",
         });
 
         expect(mockCache.get).toHaveBeenCalledWith(
@@ -2459,12 +2625,11 @@ describe('BugsnagClient', () => {
           {
             id: "build-1",
             release_time: "2023-01-01T00:00:00Z",
-            app_version: "1.0.0"
-          }
+            app_version: "1.0.0",
+          },
         ];
 
-        mockCache.get
-          .mockReturnValueOnce(null);
+        mockCache.get.mockReturnValueOnce(null);
         mockProjectAPI.listBuildsInRelease.mockResolvedValue({
           body: mockBuildsInRelease,
         });
@@ -2475,7 +2640,7 @@ describe('BugsnagClient', () => {
         )[1];
 
         const result = await toolHandler({
-          releaseId: "rel-group-2"
+          releaseId: "rel-group-2",
         });
 
         expect(mockCache.get).toHaveBeenCalledWith(
@@ -2495,9 +2660,7 @@ describe('BugsnagClient', () => {
       });
 
       it("should handle empty builds in release list", async () => {
-
-        mockCache.get
-          .mockReturnValueOnce(null);
+        mockCache.get.mockReturnValueOnce(null);
         mockProjectAPI.listBuildsInRelease.mockResolvedValue({ body: [] });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2506,7 +2669,7 @@ describe('BugsnagClient', () => {
         )[1];
 
         const result = await toolHandler({
-          releaseId: "rel-group-1"
+          releaseId: "rel-group-1",
         });
 
         expect(mockProjectAPI.listBuildsInRelease).toHaveBeenCalledWith(
@@ -2536,31 +2699,32 @@ describe('BugsnagClient', () => {
       });
     });
 
-    describe('update_error tool handler', () => {
-      it('should update error successfully with project from cache', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+    describe("update_error tool handler", () => {
+      it("should update error successfully with project from cache", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
 
         mockCache.get.mockReturnValue(mockProject);
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         const result = await toolHandler({
-          errorId: 'error-1',
-          operation: 'fix'
+          errorId: "error-1",
+          operation: "fix",
         });
 
         expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledWith(
-          'proj-1',
-          'error-1',
-          { operation: 'fix' }
+          "proj-1",
+          "error-1",
+          { operation: "fix" }
         );
         expect(result.content[0].text).toBe(JSON.stringify({ success: true }));
       });
 
-      it('should update error successfully with explicit project ID', async () => {
+      it("should update error successfully with explicit project ID", async () => {
         const mockProjects = [
           { id: "proj-1", name: "Project 1" },
           { id: "proj-2", name: "Project 2" },
@@ -2569,181 +2733,197 @@ describe('BugsnagClient', () => {
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 204 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         const result = await toolHandler({
-          projectId: 'proj-1',
-          errorId: 'error-1',
-          operation: 'ignore'
+          projectId: "proj-1",
+          errorId: "error-1",
+          operation: "ignore",
         });
 
         expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledWith(
-          'proj-1',
-          'error-1',
-          { operation: 'ignore' }
+          "proj-1",
+          "error-1",
+          { operation: "ignore" }
         );
         expect(result.content[0].text).toBe(JSON.stringify({ success: true }));
       });
 
-      it('should handle all permitted operations', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+      it("should handle all permitted operations", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
         // Test all operations except override_severity which requires special elicitInput handling
-        const operations = ['open', 'fix', 'ignore', 'discard', 'undiscard'];
+        const operations = ["open", "fix", "ignore", "discard", "undiscard"];
 
         mockCache.get.mockReturnValue(mockProject);
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         for (const operation of operations) {
           await toolHandler({
-            errorId: 'error-1',
-            operation: operation as any
+            errorId: "error-1",
+            operation: operation as any,
           });
 
           expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledWith(
-            'proj-1',
-            'error-1',
+            "proj-1",
+            "error-1",
             { operation, severity: undefined }
           );
         }
 
-        expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledTimes(operations.length);
+        expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledTimes(
+          operations.length
+        );
       });
 
-      it('should handle override_severity operation with elicitInput', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+      it("should handle override_severity operation with elicitInput", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
 
         getInputFunctionSpy.mockResolvedValue({
-              action: 'accept',
-              content: { severity: 'warning' }
-            });
+          action: "accept",
+          content: { severity: "warning" },
+        });
 
         mockCache.get.mockReturnValue(mockProject);
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         const result = await toolHandler({
-          errorId: 'error-1',
-          operation: 'override_severity'
+          errorId: "error-1",
+          operation: "override_severity",
         });
 
         expect(getInputFunctionSpy).toHaveBeenCalledWith({
-          message: "Please provide the new severity for the error (e.g. 'info', 'warning', 'error', 'critical')",
+          message:
+            "Please provide the new severity for the error (e.g. 'info', 'warning', 'error', 'critical')",
           requestedSchema: {
             type: "object",
             properties: {
               severity: {
                 type: "string",
-                enum: ['info', 'warning', 'error'],
-                description: "The new severity level for the error"
-              }
-            }
+                enum: ["info", "warning", "error"],
+                description: "The new severity level for the error",
+              },
+            },
           },
-          required: ["severity"]
+          required: ["severity"],
         });
 
         expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledWith(
-          'proj-1',
-          'error-1',
-          { operation: 'override_severity', severity: 'warning' }
+          "proj-1",
+          "error-1",
+          { operation: "override_severity", severity: "warning" }
         );
         expect(result.content[0].text).toBe(JSON.stringify({ success: true }));
       });
 
-      it('should handle override_severity operation when elicitInput is rejected', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+      it("should handle override_severity operation when elicitInput is rejected", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
 
         getInputFunctionSpy.mockResolvedValue({
-              action: 'reject'
-            });
+          action: "reject",
+        });
 
         mockCache.get.mockReturnValue(mockProject);
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         const result = await toolHandler({
-          errorId: 'error-1',
-          operation: 'override_severity'
+          errorId: "error-1",
+          operation: "override_severity",
         });
 
         expect(mockErrorAPI.updateErrorOnProject).toHaveBeenCalledWith(
-          'proj-1',
-          'error-1',
-          { operation: 'override_severity', severity: undefined }
+          "proj-1",
+          "error-1",
+          { operation: "override_severity", severity: undefined }
         );
         expect(result.content[0].text).toBe(JSON.stringify({ success: true }));
       });
 
-      it('should return false when API returns non-success status', async () => {
-        const mockProject = { id: 'proj-1', name: 'Project 1' };
+      it("should return false when API returns non-success status", async () => {
+        const mockProject = { id: "proj-1", name: "Project 1" };
 
         mockCache.get.mockReturnValue(mockProject);
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 400 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
         const result = await toolHandler({
-          errorId: 'error-1',
-          operation: 'fix'
+          errorId: "error-1",
+          operation: "fix",
         });
 
         expect(result.content[0].text).toBe(JSON.stringify({ success: false }));
       });
 
-      it('should throw error when no project found', async () => {
+      it("should throw error when no project found", async () => {
         mockCache.get.mockReturnValue(null);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
-        await expect(toolHandler({
-          errorId: 'error-1',
-          operation: 'fix'
-        })).rejects.toThrow('No current project found. Please provide a projectId or configure a project API key.');
+        await expect(
+          toolHandler({
+            errorId: "error-1",
+            operation: "fix",
+          })
+        ).rejects.toThrow(
+          "No current project found. Please provide a projectId or configure a project API key."
+        );
       });
 
-      it('should throw error when project ID not found', async () => {
-        const mockOrg = { id: 'org-1', name: 'Org 1', slug: 'org-1' };
+      it("should throw error when project ID not found", async () => {
+        const mockOrg = { id: "org-1", name: "Org 1", slug: "org-1" };
 
-        mockCache.get.mockReturnValueOnce(null).mockReturnValueOnce(mockOrg)
+        mockCache.get.mockReturnValueOnce(null).mockReturnValueOnce(mockOrg);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
-        const toolHandler = registerToolsSpy.mock.calls
-          .find((call: any) => call[0].title === 'Update Error')[1];
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Update Error"
+        )[1];
 
-        await expect(toolHandler({
-          projectId: 'non-existent-project',
-          errorId: 'error-1',
-          operation: 'fix'
-        })).rejects.toThrow('Project with ID non-existent-project not found.');
+        await expect(
+          toolHandler({
+            projectId: "non-existent-project",
+            errorId: "error-1",
+            operation: "fix",
+          })
+        ).rejects.toThrow("Project with ID non-existent-project not found.");
       });
     });
   });
 
-  describe('resource handlers', () => {
+  describe("resource handlers", () => {
     let registerResourcesSpy: any;
 
     beforeEach(() => {
       registerResourcesSpy = vi.fn();
     });
 
-    describe('bugsnag_event resource handler', () => {
-      it('should find event by ID across projects', async () => {
-        const mockEvent = { id: 'event-1', project_id: 'proj-1' };
-        const mockProjects = [{ id: 'proj-1', name: 'Project 1' }];
+    describe("bugsnag_event resource handler", () => {
+      it("should find event by ID across projects", async () => {
+        const mockEvent = { id: "event-1", project_id: "proj-1" };
+        const mockProjects = [{ id: "proj-1", name: "Project 1" }];
 
         mockCache.get.mockReturnValueOnce(mockProjects);
         mockErrorAPI.viewEventById.mockResolvedValue({ body: mockEvent });
@@ -2752,11 +2932,11 @@ describe('BugsnagClient', () => {
         const resourceHandler = registerResourcesSpy.mock.calls[0][2];
 
         const result = await resourceHandler(
-          { href: 'bugsnag://event/event-1' },
-          { id: 'event-1' }
+          { href: "bugsnag://event/event-1" },
+          { id: "event-1" }
         );
 
-        expect(result.contents[0].uri).toBe('bugsnag://event/event-1');
+        expect(result.contents[0].uri).toBe("bugsnag://event/event-1");
         expect(result.contents[0].text).toBe(JSON.stringify(mockEvent));
       });
     });

--- a/src/tests/unit/bugsnag/filters.test.ts
+++ b/src/tests/unit/bugsnag/filters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   equals,
   notEquals,
@@ -6,115 +6,119 @@ import {
   relativeTime,
   isoTime,
   toUrlSearchParams,
-  FilterObject
-} from '../../../bugsnag/client/api/filters.js';
+  FilterObject,
+} from "../../../bugsnag/client/api/filters.js";
 
-describe('Filter Utilities', () => {
-  describe('equals', () => {
-    it('should create eq filter for string value', () => {
-      const result = equals('test-value');
-      expect(result).toEqual({ type: 'eq', value: 'test-value' });
+describe("Filter Utilities", () => {
+  describe("equals", () => {
+    it("should create eq filter for string value", () => {
+      const result = equals("test-value");
+      expect(result).toEqual({ type: "eq", value: "test-value" });
     });
 
-    it('should create eq filter for number value', () => {
+    it("should create eq filter for number value", () => {
       const result = equals(42);
-      expect(result).toEqual({ type: 'eq', value: 42 });
+      expect(result).toEqual({ type: "eq", value: 42 });
     });
   });
 
-  describe('notEquals', () => {
-    it('should create ne filter for string value', () => {
-      const result = notEquals('test-value');
-      expect(result).toEqual({ type: 'ne', value: 'test-value' });
+  describe("notEquals", () => {
+    it("should create ne filter for string value", () => {
+      const result = notEquals("test-value");
+      expect(result).toEqual({ type: "ne", value: "test-value" });
     });
 
-    it('should create ne filter for number value', () => {
+    it("should create ne filter for number value", () => {
       const result = notEquals(42);
-      expect(result).toEqual({ type: 'ne', value: 42 });
+      expect(result).toEqual({ type: "ne", value: 42 });
     });
   });
 
-  describe('empty', () => {
-    it('should create empty filter for true', () => {
+  describe("empty", () => {
+    it("should create empty filter for true", () => {
       const result = empty(true);
-      expect(result).toEqual({ type: 'empty', value: 'true' });
+      expect(result).toEqual({ type: "empty", value: "true" });
     });
 
-    it('should create empty filter for false', () => {
+    it("should create empty filter for false", () => {
       const result = empty(false);
-      expect(result).toEqual({ type: 'empty', value: 'false' });
+      expect(result).toEqual({ type: "empty", value: "false" });
     });
   });
 
-  describe('relativeTime', () => {
-    it('should create relative time filter with hours', () => {
-      const result = relativeTime(24, 'h');
-      expect(result).toEqual({ type: 'eq', value: '24h' });
+  describe("relativeTime", () => {
+    it("should create relative time filter with hours", () => {
+      const result = relativeTime(24, "h");
+      expect(result).toEqual({ type: "eq", value: "24h" });
     });
 
-    it('should create relative time filter with days', () => {
-      const result = relativeTime(7, 'd');
-      expect(result).toEqual({ type: 'eq', value: '7d' });
+    it("should create relative time filter with days", () => {
+      const result = relativeTime(7, "d");
+      expect(result).toEqual({ type: "eq", value: "7d" });
     });
   });
 
-  describe('isoTime', () => {
-    it('should create ISO time filter from date', () => {
-      const date = new Date('2023-01-01T12:00:00.000Z');
+  describe("isoTime", () => {
+    it("should create ISO time filter from date", () => {
+      const date = new Date("2023-01-01T12:00:00.000Z");
       const result = isoTime(date);
-      expect(result).toEqual({ type: 'eq', value: '2023-01-01T12:00:00.000Z' });
+      expect(result).toEqual({ type: "eq", value: "2023-01-01T12:00:00.000Z" });
     });
   });
 
-  describe('toUrlSearchParams', () => {
-    it('should convert simple filter object to URL params', () => {
+  describe("toUrlSearchParams", () => {
+    it("should convert simple filter object to URL params", () => {
       const filters: FilterObject = {
-        'error.status': [{ type: 'eq', value: 'open' }],
-        'user.email': [{ type: 'ne', value: 'test@example.com' }]
+        "error.status": [{ type: "eq", value: "open" }],
+        "user.email": [{ type: "ne", value: "test@example.com" }],
       };
 
       const result = toUrlSearchParams(filters);
 
-      expect(result.get('filters[error.status][][type]')).toBe('eq');
-      expect(result.get('filters[error.status][][value]')).toBe('open');
-      expect(result.get('filters[user.email][][type]')).toBe('ne');
-      expect(result.get('filters[user.email][][value]')).toBe('test@example.com');
+      expect(result.get("filters[error.status][][type]")).toBe("eq");
+      expect(result.get("filters[error.status][][value]")).toBe("open");
+      expect(result.get("filters[user.email][][type]")).toBe("ne");
+      expect(result.get("filters[user.email][][value]")).toBe(
+        "test@example.com"
+      );
     });
 
-    it('should handle multiple filters for same field', () => {
+    it("should handle multiple filters for same field", () => {
       const filters: FilterObject = {
-        'error.status': [
-          { type: 'eq', value: 'open' },
-          { type: 'eq', value: 'in_progress' }
-        ]
+        "error.status": [
+          { type: "eq", value: "open" },
+          { type: "eq", value: "in_progress" },
+        ],
       };
 
       const result = toUrlSearchParams(filters);
       const allEntries = Array.from(result.entries());
 
       // Should have entries for both filter values
-      const statusFilters = allEntries.filter(([key]) => key.includes('error.status'));
+      const statusFilters = allEntries.filter(([key]) =>
+        key.includes("error.status")
+      );
       expect(statusFilters.length).toBeGreaterThan(2); // type and value for each filter
     });
 
-    it('should handle empty filter object', () => {
+    it("should handle empty filter object", () => {
       const filters: FilterObject = {};
       const result = toUrlSearchParams(filters);
-      expect(result.toString()).toBe('');
+      expect(result.toString()).toBe("");
     });
 
-    it('should handle complex filter scenarios', () => {
+    it("should handle complex filter scenarios", () => {
       const filters: FilterObject = {
-        'event.since': [{ type: 'eq', value: '7d' }],
-        'error.status': [{ type: 'ne', value: 'resolved' }],
-        'user.id': [{ type: 'empty', value: 'false' }]
+        "event.since": [{ type: "eq", value: "7d" }],
+        "error.status": [{ type: "ne", value: "resolved" }],
+        "user.id": [{ type: "empty", value: "false" }],
       };
 
       const result = toUrlSearchParams(filters);
 
-      expect(result.get('filters[event.since][][value]')).toBe('7d');
-      expect(result.get('filters[error.status][][value]')).toBe('resolved');
-      expect(result.get('filters[user.id][][value]')).toBe('false');
+      expect(result.get("filters[event.since][][value]")).toBe("7d");
+      expect(result.get("filters[error.status][][value]")).toBe("resolved");
+      expect(result.get("filters[user.id][][value]")).toBe("false");
     });
   });
 });

--- a/src/tests/unit/pactflow/ai.test.ts
+++ b/src/tests/unit/pactflow/ai.test.ts
@@ -2,21 +2,21 @@ import { describe, it, expect } from "vitest";
 import { RefineInputSchema } from "../../../pactflow/client/ai.js";
 
 describe("AI zod schemas validation tests", () => {
-    it("Parses RefineInputSchema with partial input", () => {
-        const result = RefineInputSchema.safeParse({
-            pactTests: {
-                filename: "test.js",
-                language: "javascript",
-                body: "describe('API', () => { it('works', () => { }); });"
-            }
-        });
-        expect(result.success).toBe(true);
-        expect(result.data).toEqual({
-            pactTests: {
-                filename: "test.js",
-                language: "javascript",
-                body: "describe('API', () => { it('works', () => { }); });"
-            }
-        });
+  it("Parses RefineInputSchema with partial input", () => {
+    const result = RefineInputSchema.safeParse({
+      pactTests: {
+        filename: "test.js",
+        language: "javascript",
+        body: "describe('API', () => { it('works', () => { }); });",
+      },
     });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      pactTests: {
+        filename: "test.js",
+        language: "javascript",
+        body: "describe('API', () => { it('works', () => { }); });",
+      },
+    });
+  });
 });

--- a/src/tests/unit/pactflow/client.test.ts
+++ b/src/tests/unit/pactflow/client.test.ts
@@ -20,14 +20,22 @@ describe("PactFlowClient", () => {
 
   describe("constructor", () => {
     it("should initialize with correct parameters", () => {
-      client = new PactflowClient("test-token", "https://example.com", "pactflow");
+      client = new PactflowClient(
+        "test-token",
+        "https://example.com",
+        "pactflow"
+      );
       expect(client).toBeInstanceOf(PactflowClient);
       expect(client["baseUrl"]).toBe("https://example.com");
       expect(client["clientType"]).toBe("pactflow");
     });
 
     it("sets correct headers when client is pactflow", () => {
-      client = new PactflowClient("my-token", "https://example.com", "pactflow");
+      client = new PactflowClient(
+        "my-token",
+        "https://example.com",
+        "pactflow"
+      );
 
       expect(client["headers"]).toEqual(
         expect.objectContaining({
@@ -81,7 +89,11 @@ describe("PactFlowClient", () => {
       ];
       vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
 
-      const client = new PactflowClient("token", "https://example.com", "pactflow");
+      const client = new PactflowClient(
+        "token",
+        "https://example.com",
+        "pactflow"
+      );
       client.registerTools(mockRegister, mockGetInput);
 
       expect(mockRegister).toHaveBeenCalledTimes(1);
@@ -102,7 +114,11 @@ describe("PactFlowClient", () => {
       ];
       vi.spyOn(toolsModule, "TOOLS", "get").mockReturnValue(fakeTools as any);
 
-      const client = new PactflowClient("token", "https://example.com", "pactflow");
+      const client = new PactflowClient(
+        "token",
+        "https://example.com",
+        "pactflow"
+      );
       client.registerTools(mockRegister, mockGetInput);
 
       expect(mockRegister).not.toHaveBeenCalled();
@@ -111,7 +127,11 @@ describe("PactFlowClient", () => {
 
   describe("API Methods", () => {
     beforeEach(() => {
-      client = new PactflowClient("test-token", "https://example.com", "pactflow");
+      client = new PactflowClient(
+        "test-token",
+        "https://example.com",
+        "pactflow"
+      );
     });
 
     describe("canIDeploy", () => {
@@ -156,7 +176,7 @@ describe("PactFlowClient", () => {
         const errorText = "Pacticipant not found";
         fetchMock.mockResponseOnce(errorText, {
           status: 404,
-          statusText: "Not Found"
+          statusText: "Not Found",
         });
 
         await expect(client.canIDeploy(mockInput)).rejects.toThrow(
@@ -171,7 +191,9 @@ describe("PactFlowClient", () => {
           environment: "test/staging",
         };
 
-        fetchMock.mockResponseOnce(JSON.stringify({ summary: { deployable: true } }));
+        fetchMock.mockResponseOnce(
+          JSON.stringify({ summary: { deployable: true } })
+        );
 
         await client.canIDeploy(inputWithSpecialChars);
 
@@ -204,7 +226,10 @@ describe("PactFlowClient", () => {
             consumer: { name: "Consumer App", version: { number: "1.0.0" } },
             provider: { name: "Example API", version: { number: "1.0.0" } },
             pact: { createdAt: "2024-01-01T00:00:00Z" },
-            verificationResult: { success: true, verifiedAt: "2024-01-01T01:00:00Z" },
+            verificationResult: {
+              success: true,
+              verifiedAt: "2024-01-01T01:00:00Z",
+            },
           },
         ],
         notices: [
@@ -349,7 +374,7 @@ describe("PactFlowClient", () => {
         const errorText = "Invalid query parameters";
         fetchMock.mockResponseOnce(errorText, {
           status: 400,
-          statusText: "Bad Request"
+          statusText: "Bad Request",
         });
 
         await expect(client.getMatrix(mockMatrixInput)).rejects.toThrow(
@@ -361,14 +386,13 @@ describe("PactFlowClient", () => {
         const errorText = "Pacticipant not found";
         fetchMock.mockResponseOnce(errorText, {
           status: 404,
-          statusText: "Not Found"
+          statusText: "Not Found",
         });
 
         await expect(client.getMatrix(mockMatrixInput)).rejects.toThrow(
           "Matrix Request Failed - status: 404 Not Found - Pacticipant not found"
         );
       });
-
     });
   });
 });

--- a/src/tests/unit/pactflow/tools.test.ts
+++ b/src/tests/unit/pactflow/tools.test.ts
@@ -1,7 +1,7 @@
 // tools.test.ts
 import { ZodObject, ZodTypeAny } from "zod";
 import { TOOLS } from "../../../pactflow/client/tools.js";
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
 describe("TOOLS definition for 'Generate Pact Tests'", () => {
   it("defines the generate pact tests tool with correct metadata", () => {
@@ -27,7 +27,9 @@ describe("TOOLS definition for 'Generate Pact Tests'", () => {
       },
     };
 
-    expect(() => openapiSchema?.parse(invalidOpenapi.openapi)).toThrow(/matcher/);
+    expect(() => openapiSchema?.parse(invalidOpenapi.openapi)).toThrow(
+      /matcher/
+    );
   });
 
   it("rejects unsupported language values in the language field", () => {
@@ -37,6 +39,8 @@ describe("TOOLS definition for 'Generate Pact Tests'", () => {
     expect(languageSchema).toBeDefined();
 
     const invalidData = "ruby"; // not in enum
-    expect(() => languageSchema?.parse(invalidData)).toThrow(/Invalid enum value/);
+    expect(() => languageSchema?.parse(invalidData)).toThrow(
+      /Invalid enum value/
+    );
   });
 });


### PR DESCRIPTION
## Goal

Currently, the repository lacks standardization in terms of the code style. Adding a formatter aids to keep the style consistent.

## Design

Prettier was used due to being the most popular JS formatter. The configuration was selected to roughly match the current state of the repository, so the changes aren't that substantial. 
`.editorconfig` was added as a backup for people not using Prettier.

## Changeset

- Added `.editorconfig`
- Added and applied Prettier

## Testing

Tests still pass after formatting code. 
