### PR TITLE
fix(bugsnag): catch initialization errors so the tools are still registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PactFlow] Add tool for fetching AI entitlement [#129](https://github.com/SmartBear/smartbear-mcp/pull/129)
 - [PactFlow] Add matcher recommendation in generate and review tool [#130](https://github.com/SmartBear/smartbear-mcp/pull/130)
 
+### Changed
+
+- [BugSnag] Catch initialization errors to allow tools to remain discoverable [#139](https://github.com/SmartBear/smartbear-mcp/pull/139)
+
 ## [0.5.0] - 2025-09-08
 
 ### Added


### PR DESCRIPTION
## Goal

This is required for the Docker registry to allow it to extract tool information without valid credentials.

I've also renamed the tool prefix as "Bugsnag" is inconsistent.

## Design

* If the auth token is invalid, an error is printed to the console
* If the API key is invalid, we clear the value to allow the tools to work in multi-project mode

## Testing

Manual testing of these scenarios.
