### PR TITLE
chore(ci): fix prek caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,26 +163,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8    # v5.0.0
 
       - name: Cache prek
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809    # v4.2.4
         with:
-          path: |
-            $HOME/.cache/prek
-          key: ${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+          path: |-
+            ~/.cache/prek
+          key: >-
+            ${{ runner.os }}-prek-${{
+              hashFiles(
+                '**/.pre-commit-config.yaml',
+                '**/.pre-commit-config.yml'
+              ) }}
+          restore-keys: |-
+            ${{ runner.os }}-prek-
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.6.1
+        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6    # v6.6.1
         with:
           enable-cache: true
           cache-suffix: prek
-          cache-dependency-glob: ''
+          cache-dependency-glob: |-
+            **/.pre-commit-config.yaml
+            **/.pre-commit-config.yml
 
       - name: Install prek
         run: uv tool install prek


### PR DESCRIPTION
The previous caching did not work as expected. And removing the installation of Rust toolchains (accidentally copy-pasted).
