### PR TITLE
fix(docs): correct URL to capabilities page

### DIFF
--- a/docs/products/SmartBear MCP Server/mcp-server.md
+++ b/docs/products/SmartBear MCP Server/mcp-server.md
@@ -12,7 +12,7 @@ Here's a quick example of the power we're bringing to your AI development experi
 
 [![MCP-Demo](https://img.youtube.com/vi/NbKnK3rbcFE/0.jpg)](https://www.youtube.com/watch?v=NbKnK3rbcFE)
 
-See our full capabilities [here](./mcp-server-capabilities.md).
+See our full capabilities [here](./mcp-server-capabilities).
 
 ## What is the Model Context Protocol?
 


### PR DESCRIPTION
## Goal

Fixes broken link in docs landing page: https://developer.smartbear.com/smartbear-mcp/docs/mcp-server
