### PR TITLE
fix(docs): relative URL in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,13 @@ npm run test:coverage
 
 ## Documentation
 
-Documentation lives in the `/docs` directory of this repo. Changes to the documentation will be automatically deployed to the docs site when merged to `main` and to an internal staging site when merged to `next`. For full information please see the [SwaggerHub Portal Management](https://github.com/frankkilcommins/SwaggerHub-Portal-Management) docs.
+Documentation lives in the `/docs` directory of this repo. Changes to the documentation will be automatically deployed to the docs site when merged to `main` and to a SmartBear-internal staging site when merged to `next`. For full information on the markdown syntax allowed in these docs, please see the [SwaggerHub Portal Management](https://github.com/frankkilcommins/SwaggerHub-Portal-Management) docs.
+
+### Previewing docs
+
+SmartBear team members wishing to preview docs changes before a change is merged to `next`, run the "Publish Portal Content" GitHub Action manually from the "Actions" tab in this repository, selecting your branch as the workflow input. Changes will be visible in the [preview site](https://smartbear-internal.portal.swaggerhub.com/smartbear-mcp) on completion.
+
+Please note – there is only one preview site, shared with `next` merges.
 
 ## Releases
 

--- a/docs/products/SmartBear MCP Server/mcp-server.md
+++ b/docs/products/SmartBear MCP Server/mcp-server.md
@@ -12,7 +12,7 @@ Here's a quick example of the power we're bringing to your AI development experi
 
 [![MCP-Demo](https://img.youtube.com/vi/NbKnK3rbcFE/0.jpg)](https://www.youtube.com/watch?v=NbKnK3rbcFE)
 
-See our full capabilities [here](./mcp-server-capabilities).
+See our full capabilities [here](./../mcp-server-capabilities).
 
 ## What is the Model Context Protocol?
 


### PR DESCRIPTION
## Goal

It seems to require the syntax `./../page` to avoid having to hard code the absolute URL.

Also added some instructions on how to test docs changes.

## Testing

Manually ran workflow to preview site: https://github.com/SmartBear/smartbear-mcp/actions/runs/18034571684
