### PR TITLE
feat: introduced ToolError to improve error handling/reporting

### DIFF
--- a/src/api-hub/client/api.ts
+++ b/src/api-hub/client/api.ts
@@ -1,3 +1,4 @@
+import { ToolError } from "../../common/types.js";
 import type { ApiHubConfiguration } from "./configuration.js";
 import type {
   CreatePortalArgs,
@@ -107,7 +108,7 @@ export class ApiHubAPI {
     defaultReturn: T | Record<string, never> = {} as T,
   ): Promise<T | FallbackResponse> {
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw new ToolError(`HTTP ${response.status}: ${response.statusText}`);
     }
 
     return this.parseResponse<T, T | Record<string, never>>(
@@ -151,7 +152,7 @@ export class ApiHubAPI {
     );
     const result = await this.handleResponse<Portal>(response);
     if (!("id" in (result as any))) {
-      throw new Error("Portal not found or empty response");
+      throw new ToolError("Portal not found or empty response");
     }
     return result as Portal;
   }
@@ -166,7 +167,7 @@ export class ApiHubAPI {
     );
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
-      throw new Error(
+      throw new ToolError(
         `API Hub deletePortal failed - status: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
       );
     }
@@ -232,7 +233,7 @@ export class ApiHubAPI {
     );
     const result = await this.handleResponse<Product>(response);
     if (!("id" in (result as any))) {
-      throw new Error("Product not found or empty response");
+      throw new ToolError("Product not found or empty response");
     }
     return result as Product;
   }
@@ -307,7 +308,7 @@ export class ApiHubAPI {
     });
 
     if (!response.ok) {
-      throw new Error(
+      throw new ToolError(
         `SwaggerHub Registry API searchApis failed - status: ${response.status} ${response.statusText}`,
       );
     }
@@ -376,7 +377,7 @@ export class ApiHubAPI {
     });
 
     if (!response.ok) {
-      throw new Error(
+      throw new ToolError(
         `SwaggerHub Registry API getApiDefinition failed - status: ${response.status} ${response.statusText}`,
       );
     }
@@ -413,7 +414,7 @@ export class ApiHubAPI {
         const parsedDefinition = JSON.parse(params.definition);
         requestBody = JSON.stringify(parsedDefinition);
       } catch (error) {
-        throw new Error(
+        throw new ToolError(
           `Invalid JSON format in definition: ${
             error instanceof Error ? error.message : "Unknown error"
           }`,
@@ -442,7 +443,7 @@ export class ApiHubAPI {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
-      throw new Error(
+      throw new ToolError(
         `SwaggerHub Registry API createOrUpdateApi failed - status: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}. URL: ${url}`,
       );
     }
@@ -487,7 +488,7 @@ export class ApiHubAPI {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
-      throw new Error(
+      throw new ToolError(
         `SwaggerHub Registry API createApiFromTemplate failed - status: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}. URL: ${url}`,
       );
     }
@@ -513,7 +514,7 @@ export class ApiHubAPI {
   private detectDefinitionFormat(definition: string): "json" | "yaml" {
     const trimmed = definition.trim();
     if (!trimmed) {
-      throw new Error("Empty definition content provided");
+      throw new ToolError("Empty definition content provided");
     }
 
     try {

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -1,3 +1,4 @@
+import { ToolError } from "../../../common/types.js";
 import type { Configuration } from "./configuration.js";
 
 export interface ApiResponse<T> {
@@ -166,9 +167,6 @@ export class BaseAPI {
     let nextUrl: string | null = url;
     let apiResponse: ApiResponse<T[]>;
     do {
-      if (!this.configuration.basePath) {
-        throw new Error("Base path is not configured for API requests");
-      }
       nextUrl = ensureFullUrl(nextUrl, this.configuration.basePath);
       const response: Response = await fetch(nextUrl, {
         ...options,
@@ -179,7 +177,7 @@ export class BaseAPI {
       });
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(
+        throw new ToolError(
           `Request failed with status ${response.status}: ${errorText}`,
         );
       }

--- a/src/bugsnag/client/api/configuration.ts
+++ b/src/bugsnag/client/api/configuration.ts
@@ -1,6 +1,6 @@
 interface ConfigurationParameters {
   apiKey?: string | ((name: string) => string);
-  basePath?: string;
+  basePath: string;
   headers?: Record<string, string>; // Additional headers for API requests
 }
 
@@ -17,7 +17,7 @@ export class Configuration {
    * @type {string}
    * @memberof Configuration
    */
-  basePath?: string;
+  basePath: string;
   /**
    * Additional headers for API requests
    * @type {Record<string, string>}
@@ -25,7 +25,7 @@ export class Configuration {
    */
   headers?: Record<string, string>;
 
-  constructor(param: ConfigurationParameters = {}) {
+  constructor(param: ConfigurationParameters) {
     this.apiKey = param.apiKey;
     this.basePath = param.basePath;
     this.headers = param.headers;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -33,6 +33,12 @@ export interface ToolParams {
   openWorld?: boolean;
 }
 
+/**
+ * Error class for tool-specific errors – these result in a response to the LLM with `isError: true`
+ * and are not reported to BugSnag
+ */
+export class ToolError extends Error {}
+
 export interface PromptParams {
   name: string;
   callback: any;

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -1,10 +1,11 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
-import type {
-  Client,
-  GetInputFunction,
-  RegisterPromptFunction,
-  RegisterToolsFunction,
+import {
+  type Client,
+  type GetInputFunction,
+  type RegisterPromptFunction,
+  type RegisterToolsFunction,
+  ToolError,
 } from "../common/types.js";
 import type {
   Entitlement,
@@ -116,7 +117,7 @@ export class PactflowClient implements Client {
     });
 
     if (!response.ok) {
-      throw new Error(
+      throw new ToolError(
         `HTTP error! status: ${response.status} - ${await response.text()}`,
       );
     }
@@ -164,7 +165,7 @@ export class PactflowClient implements Client {
     });
 
     if (!response.ok) {
-      throw new Error(
+      throw new ToolError(
         `HTTP error! status: ${response.status} - ${await response.text()}`,
       );
     }
@@ -196,7 +197,7 @@ export class PactflowClient implements Client {
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => "");
-        throw new Error(
+        throw new ToolError(
           `PactFlow AI Entitlements Request Failed - status: ${response.status} ${response.statusText}${
             errorText ? ` - ${errorText}` : ""
           }`,
@@ -237,7 +238,7 @@ export class PactflowClient implements Client {
     });
     // Check if the response is OK (status 200)
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      throw new ToolError(`HTTP error! status: ${response.status}`);
     }
 
     return response.json();
@@ -261,7 +262,7 @@ export class PactflowClient implements Client {
       }
 
       if (statusCheck.status !== 202) {
-        throw new Error(
+        throw new ToolError(
           `${operationName} failed with status: ${statusCheck.status}`,
         );
       }
@@ -270,7 +271,7 @@ export class PactflowClient implements Client {
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 
-    throw new Error(
+    throw new ToolError(
       `${operationName} timed out after ${timeout / 1000} seconds`,
     );
   }
@@ -292,7 +293,7 @@ export class PactflowClient implements Client {
     );
 
     if (!response.ok) {
-      throw new Error(
+      throw new ToolError(
         `HTTP error! status: ${response.status} - ${await response.text()}`,
       );
     }
@@ -328,7 +329,7 @@ export class PactflowClient implements Client {
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => "");
-        throw new Error(
+        throw new ToolError(
           `Can-I-Deploy Request Failed - status: ${response.status} ${response.statusText}${
             errorText ? ` - ${errorText}` : ""
           }`,
@@ -404,7 +405,7 @@ export class PactflowClient implements Client {
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => "");
-        throw new Error(
+        throw new ToolError(
           `Matrix Request Failed - status: ${response.status} ${response.statusText}${
             errorText ? ` - ${errorText}` : ""
           }`,

--- a/src/pactflow/client/prompt-utils.ts
+++ b/src/pactflow/client/prompt-utils.ts
@@ -1,5 +1,5 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import type { GetInputFunction } from "../../common/types.js";
+import { type GetInputFunction, ToolError } from "../../common/types.js";
 import {
   type EndpointMatcher,
   EndpointMatcherSchema,
@@ -44,7 +44,7 @@ export async function getOADMatcherRecommendations(
       MatcherRecommendationInputSchema.parse(parsed);
     return matcherRecommendations;
   } else {
-    throw new Error(
+    throw new ToolError(
       "Unable to parse recommendations please provide OpenAPI matchers manually.",
     );
   }

--- a/src/pactflow/client/utils.ts
+++ b/src/pactflow/client/utils.ts
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 // @ts-expect-error missing type declarations
 import Swagger from "swagger-client";
+import { ToolError } from "../../common/types.js";
 import {
   type OpenAPI,
   type RemoteOpenAPIDocument,
@@ -21,7 +22,7 @@ export async function resolveOpenAPISpec(
     remoteOpenAPIDocument,
   );
   if (openAPISchema.error || !remoteOpenAPIDocument) {
-    throw new Error(
+    throw new ToolError(
       `Invalid RemoteOpenAPIDocument: ${JSON.stringify(
         openAPISchema.error?.issues,
       )}`,
@@ -32,7 +33,7 @@ export async function resolveOpenAPISpec(
   const resolvedSpec = await Swagger.resolve({ spec: unresolvedSpec });
 
   if (resolvedSpec.errors?.length) {
-    throw new Error(
+    throw new ToolError(
       `Failed to resolve OpenAPI document: ${resolvedSpec.errors?.join(", ")}`,
     );
   }
@@ -51,7 +52,7 @@ export async function getRemoteSpecContents(
   openAPISchema: RemoteOpenAPIDocument,
 ): Promise<any> {
   if (!openAPISchema.url) {
-    throw new Error("'url' must be provided.");
+    throw new ToolError("'url' must be provided.");
   }
 
   let headers = {};
@@ -76,7 +77,7 @@ export async function getRemoteSpecContents(
     try {
       return yaml.load(specRawBody);
     } catch (yamlError) {
-      throw new Error(
+      throw new ToolError(
         `Unsupported Content-Type: ${remoteSpec.headers.get(
           "Content-Type",
         )} for remote OpenAPI document. Found following parse errors:-\nJSON parse error: ${jsonError}\nYAML parse error: ${yamlError}`,

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info.js";
-import type {
-  Client,
-  GetInputFunction,
-  RegisterToolsFunction,
+import {
+  type Client,
+  type GetInputFunction,
+  type RegisterToolsFunction,
+  ToolError,
 } from "../common/types.js";
 
 // Type definitions for tool arguments
@@ -174,7 +175,7 @@ export class ReflectClient implements Client {
         ],
       },
       async (args, _extra) => {
-        if (!args.suiteId) throw new Error("suiteId argument is required");
+        if (!args.suiteId) throw new ToolError("suiteId argument is required");
         const response = await this.listSuiteExecutions(args.suiteId);
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
@@ -202,7 +203,7 @@ export class ReflectClient implements Client {
       },
       async (args, _extra) => {
         if (!args.suiteId || !args.executionId)
-          throw new Error(
+          throw new ToolError(
             "Both suiteId and executionId arguments are required",
           );
         const response = await this.getSuiteExecutionStatus(
@@ -228,7 +229,7 @@ export class ReflectClient implements Client {
         ],
       },
       async (args, _extra) => {
-        if (!args.suiteId) throw new Error("suiteId argument is required");
+        if (!args.suiteId) throw new ToolError("suiteId argument is required");
         const response = await this.executeSuite(args.suiteId);
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
@@ -256,7 +257,7 @@ export class ReflectClient implements Client {
       },
       async (args, _extra) => {
         if (!args.suiteId || !args.executionId)
-          throw new Error(
+          throw new ToolError(
             "Both suiteId and executionId arguments are required",
           );
         const response = await this.cancelSuiteExecution(
@@ -295,7 +296,7 @@ export class ReflectClient implements Client {
         ],
       },
       async (args, _extra) => {
-        if (!args.testId) throw new Error("testId argument is required");
+        if (!args.testId) throw new ToolError("testId argument is required");
         const response = await this.runReflectTest(args.testId);
         return {
           content: [{ type: "text", text: JSON.stringify(response) }],
@@ -323,7 +324,9 @@ export class ReflectClient implements Client {
       },
       async (args, _extra) => {
         if (!args.testId || !args.executionId)
-          throw new Error("Both testId and executionId arguments are required");
+          throw new ToolError(
+            "Both testId and executionId arguments are required",
+          );
         const response = await this.getReflectTestStatus(
           args.testId,
           args.executionId,

--- a/src/tests/unit/bugsnag/api/base.test.ts
+++ b/src/tests/unit/bugsnag/api/base.test.ts
@@ -425,15 +425,6 @@ describe("base.ts", () => {
         });
       });
 
-      it("should throw error when basePath is not configured", async () => {
-        const noBasePathConfig = new Configuration({ apiKey: "test" });
-        const api = new BaseAPI(noBasePathConfig);
-
-        await expect(
-          api.requestObject("/test", { method: "GET" }),
-        ).rejects.toThrow("Base path is not configured for API requests");
-      });
-
       it("should throw error on failed request", async () => {
         const mockResponse = {
           ok: false,
@@ -654,15 +645,6 @@ describe("base.ts", () => {
         await expect(
           baseApi.requestArray("/test", { method: "GET" }),
         ).rejects.toThrow("Expected response to be an array");
-      });
-
-      it("should throw error when basePath is not configured", async () => {
-        const noBasePathConfig = new Configuration({ apiKey: "test" });
-        const api = new BaseAPI(noBasePathConfig);
-
-        await expect(
-          api.requestArray("/test", { method: "GET" }),
-        ).rejects.toThrow("Base path is not configured for API requests");
       });
 
       it("should filter fields from array items when specified", async () => {


### PR DESCRIPTION
## Goal

Standardise error handling by differentiating between errors in the tools that are passed back to the LLM/user and unexpected errors, that are also reported to BugSnag.

The MCP Node framework already converts thrown errors to a standard response with `isError` set to `true`, but this change allows us to catch this earlier and report accordingly.

## Design

Created `ToolError` to be thrown for any error that should just be sent back to the user/LLM and not reported as unexpected.

## Testing

Unit tests updated accordingly and confirmed Bugsnags get reported for unexpected errors.
