### PR TITLE
chore: add typos to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     rev: v2.2.4
     hooks:
     - id: biome-check
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.37.1
+    hooks:
+      - id: typos

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+# Configuration for Typos
+#
+# See <https://github.com/crate-ci/typos/blob/master/docs/reference.md>
+[default]
+extend-ignore-re = [
+  # Ignore spelling on a specific line
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  # Ignore spelling in a specific block
+  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+]


### PR DESCRIPTION
The [typos](https://github.com/crate-ci/typos) CLI is a great spell checker for the source code. For example, catching misspellings of function or variable names, or comments.
