### PR TITLE
build: allow manual run of the tests pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, next ]
   pull_request:
     branches: [ main, next ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Goal

The sync action from `main` to `next` is not triggering the test pipeline (possibly due to [this](https://github.com/orgs/community/discussions/65321)) and so not fulfilling the check requirements. For now, we're going to allow this manually before working out if this can be triggered automatically in future.