### PR TITLE
[bugsnag] call api classes directly for build and release

### DIFF
--- a/src/bugsnag/client/api/Project.ts
+++ b/src/bugsnag/client/api/Project.ts
@@ -343,7 +343,10 @@ export class ProjectAPI extends BaseAPI {
    * @param opts Options for listing releases, including filtering by release stage.
    * @returns A promise that resolves to an array of `ListReleasesResponse` objects.
    */
-  async listBuilds(projectId: string, opts: ListBuildsOptions) {
+  async listBuilds(
+    projectId: string,
+    opts: ListBuildsOptions,
+  ): Promise<ApiResponse<BuildSummaryResponse[]>> {
     const url =
       opts.next_url ??
       `/projects/${projectId}/releases${opts.release_stage ? `?release_stage=${opts.release_stage}` : ""}`;
@@ -370,7 +373,10 @@ export class ProjectAPI extends BaseAPI {
    * @param buildId The ID of the release to retrieve.
    * @returns A promise that resolves to the release data.
    */
-  async getBuild(projectId: string, buildId: string) {
+  async getBuild(
+    projectId: string,
+    buildId: string,
+  ): Promise<ApiResponse<BuildResponse>> {
     const url = `/projects/${projectId}/releases/${buildId}`;
     return await this.request<BuildResponse>({
       method: "GET",
@@ -385,7 +391,10 @@ export class ProjectAPI extends BaseAPI {
    * @param opts Options for listing releases, including filtering by release stage and visibility.
    * @returns A promise that resolves to an array of `ReleaseSummaryResponse` objects.
    */
-  async listReleases(projectId: string, opts: ListReleasesOptions) {
+  async listReleases(
+    projectId: string,
+    opts: ListReleasesOptions,
+  ): Promise<ApiResponse<ReleaseSummaryResponse[]>> {
     const url =
       opts.next_url ??
       `/projects/${projectId}/release_groups?` +
@@ -415,7 +424,7 @@ export class ProjectAPI extends BaseAPI {
    * @param releaseId The ID of the release to retrieve.
    * @returns A promise that resolves to the release data.
    */
-  async getRelease(releaseId: string) {
+  async getRelease(releaseId: string): Promise<ApiResponse<ReleaseResponse>> {
     const url = `/release_groups/${releaseId}`;
     return await this.request<ReleaseResponse>({
       method: "GET",
@@ -429,7 +438,9 @@ export class ProjectAPI extends BaseAPI {
    * @param releaseId The ID of the release group.
    * @return A promise that resolves to an array of `BuildResponse` objects.
    */
-  async listBuildsInRelease(releaseId: string) {
+  async listBuildsInRelease(
+    releaseId: string,
+  ): Promise<ApiResponse<BuildResponse[]>> {
     const url = `/release_groups/${releaseId}/releases`;
     return await this.request<BuildResponse[]>(
       {

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -692,669 +692,6 @@ describe("BugsnagClient", () => {
       });
     });
 
-    describe("listBuilds", () => {
-      const build = {
-        id: "rel-1",
-        release_time: "2023-01-01T00:00:00Z",
-        app_version: "1.0.0",
-        release_stage: { name: "production" },
-        source_control: {
-          service: "github",
-          commit_url: "https://github.com/org/repo/commit/abc123",
-          revision: "abc123",
-          diff_url_to_previous:
-            "https://github.com/org/repo/compare/previous...abc123",
-        },
-        total_sessions_count: 100,
-        unhandled_sessions_count: 10,
-        accumulative_daily_users_seen: 5,
-        accumulative_daily_users_with_unhandled: 1,
-      };
-
-      it("should return builds at stability target", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({
-          body: [build],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.75,
-          },
-          critical_stability: {
-            value: 0.5,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listBuilds("proj-1", {
-          release_stage: "production",
-        });
-
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
-          release_stage: "production",
-        });
-
-        expect(result?.body?.[0]).toEqual({
-          ...build,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.75,
-          critical_stability: 0.5,
-          meets_target_stability: true,
-          meets_critical_stability: true,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return builds under stability target", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({
-          body: [build],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.9,
-          },
-          critical_stability: {
-            value: 0.5,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listBuilds("proj-1", {
-          release_stage: "production",
-        });
-
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
-          release_stage: "production",
-        });
-        expect(result?.body?.[0]).toEqual({
-          ...build,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.9,
-          critical_stability: 0.5,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return builds under critical stability", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({
-          body: [build],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.9,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listBuilds("proj-1", {
-          release_stage: "production",
-        });
-
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {
-          release_stage: "production",
-        });
-
-        expect(result?.body?.[0]).toEqual({
-          ...build,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.9,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: false,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return empty array when no builds found", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({
-          body: null,
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const result = await client.listBuilds("proj-1", {});
-
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {});
-        expect(result.body).toEqual([]);
-      });
-
-      it("should throw error when project not found", async () => {
-        mockProjectAPI.listBuilds.mockResolvedValue({
-          body: [build],
-          headers: new Headers(),
-          status: 200,
-        });
-        client.getProject = vi.fn().mockResolvedValue(null);
-
-        await expect(client.listBuilds("proj-1", {})).rejects.toThrowError(
-          "Project with ID proj-1 not found.",
-        );
-
-        expect(mockProjectAPI.listBuilds).toHaveBeenCalledWith("proj-1", {});
-      });
-    });
-
-    describe("getBuild", () => {
-      const build = {
-        id: "rel-1",
-        release_time: "2023-01-01T00:00:00Z",
-        app_version: "1.0.0",
-        release_stage: { name: "production" },
-        source_control: {
-          service: "github",
-          commit_url: "https://github.com/org/repo/commit/abc123",
-          revision: "abc123",
-          diff_url_to_previous:
-            "https://github.com/org/repo/compare/previous...abc123",
-        },
-        total_sessions_count: 100,
-        unhandled_sessions_count: 10,
-        accumulative_daily_users_seen: 5,
-        accumulative_daily_users_with_unhandled: 1,
-      };
-
-      it("should return build from API", async () => {
-        mockProjectAPI.getBuild.mockResolvedValue({
-          body: build,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.95,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "session" as const,
-        };
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.getBuild("proj-1", "rel-1");
-
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
-        expect(result.body).toEqual({
-          ...build,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.95,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "session",
-        });
-      });
-
-      // Test for division by zero case for user stability
-      it("should handle zero accumulative_daily_users_seen", async () => {
-        const zeroBuild = {
-          ...build,
-          accumulative_daily_users_seen: 0,
-          accumulative_daily_users_with_unhandled: 0,
-        };
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.95,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "user" as const,
-        };
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getBuild.mockResolvedValue({
-          body: zeroBuild,
-        });
-
-        const result = await client.getBuild("proj-1", "rel-2");
-
-        expect(result?.body?.user_stability).toBe(0);
-        expect(result?.body?.meets_target_stability).toBe(false);
-        expect(result?.body?.meets_critical_stability).toBe(false);
-      });
-
-      // Test for division by zero case for session stability
-      it("should handle zero total_sessions_count", async () => {
-        const zeroBuild = {
-          ...build,
-          total_sessions_count: 0,
-        };
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.95,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "session" as const,
-        };
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getBuild.mockResolvedValue({
-          body: zeroBuild,
-        });
-
-        const result = await client.getBuild("proj-1", "rel-2");
-
-        expect(result?.body?.session_stability).toBe(0);
-        expect(result?.body?.meets_target_stability).toBe(false);
-        expect(result?.body?.meets_critical_stability).toBe(false);
-      });
-
-      it("should return null when build not found", async () => {
-        // Mock cache to return null to simulate no cached data
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getBuild.mockResolvedValue({ body: null });
-
-        await expect(
-          client.getBuild("proj-1", "non-existent-build-id"),
-        ).rejects.toThrow("No build for non-existent-build-id found.");
-
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
-          "proj-1",
-          "non-existent-build-id",
-        );
-      });
-
-      it("should throw error when project not found", async () => {
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getBuild.mockResolvedValue({ body: build });
-        client.getProject = vi.fn().mockResolvedValue(null);
-
-        await expect(
-          client.getBuild("proj-1", "non-existent-build-id"),
-        ).rejects.toThrow("Project with ID proj-1 not found.");
-
-        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith(
-          "proj-1",
-          "non-existent-build-id",
-        );
-      });
-    });
-
-    describe("listReleases", () => {
-      const release = {
-        id: "rel-group-1",
-        release_stage_name: "production",
-        app_version: "1.0.0",
-        first_released_at: "2023-01-01T00:00:00Z",
-        first_release_id: "build-1",
-        releases_count: 2,
-        visible: true,
-        sessions_count_in_last_24h: 20,
-        total_sessions_count: 100,
-        unhandled_sessions_count: 10,
-        accumulative_daily_users_seen: 5,
-        accumulative_daily_users_with_unhandled: 1,
-      };
-
-      it("should return builds at stability target", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({
-          body: [release],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.75,
-          },
-          critical_stability: {
-            value: 0.5,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listReleases("proj-1", {
-          release_stage_name: "production",
-          visible_only: true,
-        });
-
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
-          release_stage_name: "production",
-          visible_only: true,
-        });
-        expect(result?.body?.[0]).toEqual({
-          ...release,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.75,
-          critical_stability: 0.5,
-          meets_target_stability: true,
-          meets_critical_stability: true,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return releases under stability target", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({
-          body: [release],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.9,
-          },
-          critical_stability: {
-            value: 0.5,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listReleases("proj-1", {
-          release_stage_name: "testing",
-          visible_only: false,
-        });
-
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
-          release_stage_name: "testing",
-          visible_only: false,
-        });
-
-        expect(result?.body?.[0]).toEqual({
-          ...release,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.9,
-          critical_stability: 0.5,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return releases under critical stability", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({
-          body: [release],
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.9,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "user" as const,
-        };
-
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listReleases("proj-1", {});
-
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {});
-        expect(result?.body?.[0]).toEqual({
-          ...release,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.9,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: false,
-          stability_target_type: "user",
-        });
-      });
-
-      it("should return empty array when no releases found", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({
-          body: null,
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const result = await client.listReleases("proj-1", {});
-
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {});
-        expect(result.body).toEqual([]);
-      });
-
-      it("should throw error when project not found", async () => {
-        mockProjectAPI.listReleases.mockResolvedValue({
-          body: [release],
-          headers: new Headers(),
-          status: 200,
-        });
-        client.getProject = vi.fn().mockResolvedValue(null);
-
-        await expect(client.listReleases("proj-1", {})).rejects.toThrowError(
-          "Project with ID proj-1 not found.",
-        );
-
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {});
-      });
-    });
-
-    describe("getRelease", () => {
-      const release = {
-        id: "rel-group-1",
-        project_id: "proj-1",
-        release_stage_name: "production",
-        app_version: "1.0.0",
-        first_released_at: "2023-01-01T00:00:00Z",
-        first_release_id: "build-1",
-        releases_count: 2,
-        has_secondary_versions: false,
-        build_tool: "gradle",
-        builder_name: "CI",
-        source_control: {
-          service: "github",
-          commit_url: "https://github.com/org/repo/commit/abc123",
-          revision: "abc123",
-          diff_url_to_previous:
-            "https://github.com/org/repo/compare/previous...abc123",
-        },
-        top_release_group: true,
-        visible: true,
-        total_sessions_count: 100,
-        unhandled_sessions_count: 10,
-        sessions_count_in_last_24h: 20,
-        accumulative_daily_users_seen: 5,
-        accumulative_daily_users_with_unhandled: 1,
-      };
-
-      it("should return release from API", async () => {
-        mockProjectAPI.getRelease.mockResolvedValue({
-          body: release,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.95,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "session" as const,
-        };
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.getRelease("proj-1", "rel-1");
-
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith("rel-1");
-        expect(result.body).toEqual({
-          ...release,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.95,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "session",
-        });
-      });
-
-      it("should return null when release not found", async () => {
-        // Mock cache to return null to simulate no cached data
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getRelease.mockResolvedValue({ body: null });
-
-        await expect(
-          client.getRelease("proj-1", "non-existent-release-id"),
-        ).rejects.toThrow("No release for non-existent-release-id found.");
-
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
-          "non-existent-release-id",
-        );
-      });
-
-      it("should throw error when project not found", async () => {
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.getRelease.mockResolvedValue({ body: release });
-        client.getProject = vi.fn().mockResolvedValue(null);
-
-        await expect(
-          client.getRelease("proj-1", "non-existent-release-id"),
-        ).rejects.toThrow("Project with ID proj-1 not found.");
-
-        expect(mockProjectAPI.getRelease).toHaveBeenCalledWith(
-          "non-existent-release-id",
-        );
-      });
-    });
-
-    describe("listBuildsInRelease", () => {
-      const mockBuildsInRelease = [
-        {
-          id: "build-1",
-          release_time: "2023-01-01T00:00:00Z",
-          app_version: "1.0.0",
-          total_sessions_count: 100,
-          unhandled_sessions_count: 10,
-          accumulative_daily_users_seen: 5,
-          accumulative_daily_users_with_unhandled: 1,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.95,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "session",
-        },
-        {
-          id: "build-2",
-          release_time: "2023-01-02T00:00:00Z",
-          app_version: "1.0.0",
-          total_sessions_count: 100,
-          unhandled_sessions_count: 10,
-          accumulative_daily_users_seen: 5,
-          accumulative_daily_users_with_unhandled: 1,
-          session_stability: 0.9,
-          user_stability: 0.8,
-          target_stability: 0.95,
-          critical_stability: 0.85,
-          meets_target_stability: false,
-          meets_critical_stability: true,
-          stability_target_type: "session",
-        },
-      ];
-      it("should return builds in release from API when not cached", async () => {
-        mockCache.get.mockReturnValueOnce(null);
-        mockProjectAPI.listBuildsInRelease.mockResolvedValue({
-          body: mockBuildsInRelease,
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const mockProject = {
-          id: "proj-1",
-          target_stability: {
-            value: 0.95,
-          },
-          critical_stability: {
-            value: 0.85,
-          },
-          stability_target_type: "session" as const,
-        };
-        client.getProject = vi.fn().mockResolvedValue(mockProject);
-
-        const result = await client.listBuildsInRelease(
-          "proj-1",
-          "rel-group-1",
-        );
-
-        expect(mockProjectAPI.listBuildsInRelease).toHaveBeenCalledWith(
-          "rel-group-1",
-        );
-        expect(result.body).toEqual(mockBuildsInRelease);
-      });
-
-      it("should return empty array when no builds in release found", async () => {
-        mockProjectAPI.listBuildsInRelease.mockResolvedValue({
-          body: null,
-          headers: new Headers(),
-          status: 200,
-        });
-
-        const result = await client.listBuildsInRelease(
-          "proj-1",
-          "rel-group-1",
-        );
-
-        expect(mockProjectAPI.listBuildsInRelease).toHaveBeenCalledWith(
-          "rel-group-1",
-        );
-        expect(result.body).toEqual([]);
-      });
-
-      it("should throw error when project not found", async () => {
-        mockProjectAPI.listBuildsInRelease.mockResolvedValue({
-          body: mockBuildsInRelease,
-          headers: new Headers(),
-          status: 200,
-        });
-
-        client.getProject = vi.fn().mockResolvedValue(null);
-
-        await expect(
-          client.listBuildsInRelease("proj-1", "rel-group-1"),
-        ).rejects.toThrow("Project with ID proj-1 not found.");
-      });
-    });
-
     describe("getEventById", () => {
       it("should find event across multiple projects", async () => {
         const mockOrgs = [{ id: "org-1", name: "Test Org" }];
@@ -1887,8 +1224,8 @@ describe("BugsnagClient", () => {
     });
 
     describe("get_build tool handler", () => {
-      it("should get build details", async () => {
-        const mockProject = {
+      const mockProjects = [
+        {
           id: "proj-1",
           name: "Project 1",
           target_stability: {
@@ -1898,19 +1235,31 @@ describe("BugsnagClient", () => {
             value: 0.85,
           },
           stability_target_type: "user" as const,
-        };
-        const mockBuild = {
-          id: "rel-1",
-          release_time: "2023-01-01T00:00:00Z",
-          app_version: "1.0.0",
-          release_stage: { name: "production" },
-          source_control: {
-            service: "github",
-            commit_url: "https://github.com/org/repo/commit/abc123",
-            revision: "abc123",
-            diff_url_to_previous:
-              "https://github.com/org/repo/compare/previous...abc123",
-          },
+        },
+        { id: "proj-2", name: "Project 2" },
+      ];
+      const mockBuild = {
+        id: "rel-1",
+        release_time: "2023-01-01T00:00:00Z",
+        app_version: "1.0.0",
+        release_stage: { name: "production" },
+        source_control: {
+          service: "github",
+          commit_url: "https://github.com/org/repo/commit/abc123",
+          revision: "abc123",
+          diff_url_to_previous:
+            "https://github.com/org/repo/compare/previous...abc123",
+        },
+        errors_introduced_count: 5,
+        errors_seen_count: 10,
+        total_sessions_count: 100,
+        unhandled_sessions_count: 10,
+        accumulative_daily_users_seen: 50,
+        accumulative_daily_users_with_unhandled: 5,
+      };
+      it("should get build details", async () => {
+        const basicBuild = {
+          ...mockBuild,
           errors_introduced_count: 5,
           errors_seen_count: 10,
           total_sessions_count: 100,
@@ -1919,7 +1268,7 @@ describe("BugsnagClient", () => {
           accumulative_daily_users_with_unhandled: 5,
         };
         const enhancedBuild = {
-          ...mockBuild,
+          ...basicBuild,
           user_stability: 0.9,
           session_stability: 0.9,
           stability_target_type: "user",
@@ -1931,10 +1280,82 @@ describe("BugsnagClient", () => {
 
         // First get for the project, second for cached build (return null to call API)
         mockCache.get
-          .mockReturnValueOnce(mockProject)
-          .mockReturnValueOnce([mockProject]);
+          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce([mockProjects[0]]);
         mockProjectAPI.getBuild.mockResolvedValue({
-          body: mockBuild,
+          body: basicBuild,
+        });
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Build",
+        )[1];
+
+        const result = await toolHandler({ buildId: "rel-1" });
+
+        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedBuild));
+      });
+
+      it("should handle 0 daily users", async () => {
+        const basicBuild = {
+          ...mockBuild,
+          accumulative_daily_users_seen: 0,
+        };
+        const enhancedBuild = {
+          ...basicBuild,
+          user_stability: 0,
+          session_stability: 0.9,
+          stability_target_type: "user",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: false,
+        };
+
+        // First get for the project, second for cached build (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce([mockProjects[0]]);
+        mockProjectAPI.getBuild.mockResolvedValue({
+          body: basicBuild,
+        });
+        client.registerTools(registerToolsSpy, getInputFunctionSpy);
+        const toolHandler = registerToolsSpy.mock.calls.find(
+          (call: any) => call[0].title === "Get Build",
+        )[1];
+
+        const result = await toolHandler({ buildId: "rel-1" });
+
+        expect(mockProjectAPI.getBuild).toHaveBeenCalledWith("proj-1", "rel-1");
+        expect(result.content[0].text).toBe(JSON.stringify(enhancedBuild));
+      });
+
+      it("should handle 0 sessions", async () => {
+        const mockProjectSessionStability = {
+          ...mockProjects[0],
+          stability_target_type: "session" as const,
+        };
+        const basicBuild = {
+          ...mockBuild,
+          total_sessions_count: 0,
+        };
+        const enhancedBuild = {
+          ...basicBuild,
+          user_stability: 0.9,
+          session_stability: 0,
+          stability_target_type: "session",
+          target_stability: 0.995,
+          critical_stability: 0.85,
+          meets_target_stability: false,
+          meets_critical_stability: false,
+        };
+
+        // First get for the project, second for cached build (return null to call API)
+        mockCache.get
+          .mockReturnValueOnce(mockProjectSessionStability)
+          .mockReturnValueOnce([mockProjectSessionStability]);
+        mockProjectAPI.getBuild.mockResolvedValue({
+          body: basicBuild,
         });
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
@@ -1948,25 +1369,8 @@ describe("BugsnagClient", () => {
       });
 
       it("should get build with explicit project ID", async () => {
-        const mockProjects = [
-          {
-            id: "proj-1",
-            name: "Project 1",
-            target_stability: {
-              value: 0.995,
-            },
-            critical_stability: {
-              value: 0.85,
-            },
-            stability_target_type: "user" as const,
-          },
-          { id: "proj-2", name: "Project 2" },
-        ];
-        const mockBuild = {
-          id: "rel-1",
-          release_time: "2023-01-01T00:00:00Z",
-          app_version: "1.0.0",
-          release_stage: { name: "production" },
+        const basicBuild = {
+          ...mockBuild,
           total_sessions_count: 50,
           unhandled_sessions_count: 5,
           accumulative_daily_users_seen: 30,
@@ -1974,7 +1378,7 @@ describe("BugsnagClient", () => {
         };
 
         const enhancedBuild = {
-          ...mockBuild,
+          ...basicBuild,
           user_stability: 0.9,
           session_stability: 0.9,
           stability_target_type: "user",
@@ -1988,7 +1392,7 @@ describe("BugsnagClient", () => {
           .mockReturnValueOnce(mockProjects)
           .mockReturnValueOnce(mockProjects);
         mockProjectAPI.getBuild.mockResolvedValue({
-          body: mockBuild,
+          body: basicBuild,
         });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2006,11 +1410,9 @@ describe("BugsnagClient", () => {
       });
 
       it("should throw error when build not found", async () => {
-        const mockProject = { id: "proj-1", name: "Project 1" };
-
         mockCache.get
-          .mockReturnValueOnce(mockProject)
-          .mockReturnValueOnce([mockProject]);
+          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce([mockProjects[0]]);
         mockProjectAPI.getBuild.mockResolvedValue({ body: null });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2024,9 +1426,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should throw error when buildId argument is missing", async () => {
-        const mockProject = { id: "proj-1", name: "Project 1" };
-
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(mockProjects[0]);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
@@ -2053,10 +1453,11 @@ describe("BugsnagClient", () => {
     });
 
     describe("list_releases tool handler", () => {
-      it("should list releases with project from cache", async () => {
-        const mockProject = {
-          id: "proj-1",
-          name: "Project 1",
+      const mockProjects = [
+        { id: "proj-1", name: "Project 1" },
+        {
+          id: "proj-2",
+          name: "Project 2",
           target_stability: {
             value: 0.995,
           },
@@ -2064,7 +1465,9 @@ describe("BugsnagClient", () => {
             value: 0.85,
           },
           stability_target_type: "user" as const,
-        };
+        },
+      ];
+      it("should list releases with project from cache", async () => {
         const mockReleases = [
           {
             id: "rel-group-1",
@@ -2091,8 +1494,8 @@ describe("BugsnagClient", () => {
 
         // Mock project cache to return the project
         mockCache.get
-          .mockReturnValueOnce(mockProject)
-          .mockReturnValueOnce([mockProject]);
+          .mockReturnValueOnce(mockProjects[1])
+          .mockReturnValueOnce([mockProjects[1]]);
         mockProjectAPI.listReleases.mockResolvedValue({
           body: mockReleases,
         });
@@ -2107,7 +1510,7 @@ describe("BugsnagClient", () => {
           visibleOnly: true,
         });
 
-        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-1", {
+        expect(mockProjectAPI.listReleases).toHaveBeenCalledWith("proj-2", {
           release_stage_name: "production",
           visible_only: true,
         });
@@ -2117,20 +1520,6 @@ describe("BugsnagClient", () => {
       });
 
       it("should list releases with explicit project ID", async () => {
-        const mockProjects = [
-          { id: "proj-1", name: "Project 1" },
-          {
-            id: "proj-2",
-            name: "Project 2",
-            target_stability: {
-              value: 0.995,
-            },
-            critical_stability: {
-              value: 0.85,
-            },
-            stability_target_type: "user" as const,
-          },
-        ];
         const mockReleases = [
           {
             id: "rel-group-2",
@@ -2183,10 +1572,8 @@ describe("BugsnagClient", () => {
       });
 
       it("should handle empty releases list", async () => {
-        const mockProject = { id: "proj-1", name: "Project 1" };
-
         // Mock project cache to return the project
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(mockProjects[0]);
         mockProjectAPI.listReleases.mockResolvedValue({ body: [] });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2223,21 +1610,21 @@ describe("BugsnagClient", () => {
     });
 
     describe("get_release tool handler", () => {
-      it("should get release with explicit project ID", async () => {
-        const mockProjects = [
-          { id: "proj-1", name: "Project 1" },
-          {
-            id: "proj-2",
-            name: "Project 2",
-            target_stability: {
-              value: 0.995,
-            },
-            critical_stability: {
-              value: 0.85,
-            },
-            stability_target_type: "user" as const,
+      const mockProjects = [
+        { id: "proj-1", name: "Project 1" },
+        {
+          id: "proj-2",
+          name: "Project 2",
+          target_stability: {
+            value: 0.995,
           },
-        ];
+          critical_stability: {
+            value: 0.85,
+          },
+          stability_target_type: "user" as const,
+        },
+      ];
+      it("should get release with explicit project ID", async () => {
         const mockRelease = {
           id: "rel-group-2",
           project_id: "proj-2",
@@ -2318,10 +1705,8 @@ describe("BugsnagClient", () => {
       });
 
       it("should throw error when release not found", async () => {
-        const mockProject = { id: "proj-1", name: "Project 1" };
-
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(mockProjects[0])
           .mockReturnValueOnce(null);
         mockProjectAPI.getRelease.mockResolvedValue({ body: null });
 


### PR DESCRIPTION
## Goal

Continuation of work towards having one tool per file – this removes the intermediate methods between the tool handler and the API classes.

## Testing

Unit tests consolidated to cover the same scenarios.