### PR TITLE
docs: Adjust Zephyr logo reference

### DIFF
--- a/docs/products/SmartBear MCP Server/zephyr-integration.md
+++ b/docs/products/SmartBear MCP Server/zephyr-integration.md
@@ -1,4 +1,4 @@
-![zephyr.svg](images/embedded/zephyr.svg)
+![zephyr.svg](./images/embedded/zephyr.svg)
 
 The Zephyr client provides test management and execution capabilities within Zephyr as listed on [Available Tools](#Available-Tools).
 


### PR DESCRIPTION
## Goal

Adjusted a typo on Zephyr's logo reference.