### PR TITLE
Add a source header on api calls to track they come from MCP

### DIFF
--- a/src/tests/unit/zephyr/common/auth-service.test.ts
+++ b/src/tests/unit/zephyr/common/auth-service.test.ts
@@ -16,6 +16,7 @@ describe("AuthService", () => {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "zscale-source": "smartbear-mcp",
     });
   });
 });

--- a/src/zephyr/common/auth-service.ts
+++ b/src/zephyr/common/auth-service.ts
@@ -12,6 +12,7 @@ export class AuthService {
       Authorization: `Bearer ${this.bearerToken}`,
       "Content-Type": "application/json",
       "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "zscale-source": "smartbear-mcp",
     };
   }
 }


### PR DESCRIPTION
## Goal

Add an extra header to identify requests coming from `smartbear-mcp`

## Changeset

Requests going to Zephyr will not have an additional header.

## Testing

Added unit tests and tested the changes with the tool `get-project` locally with GitHub Copilot