### PR TITLE
TM4J-13482: Mention newly introduced Zephyr tools to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- [Zephyr] Added a tool for retrieving statuses [#212](https://github.com/SmartBear/smartbear-mcp/pull/212)
+- [Zephyr] Added a tool for retrieving Test Cases [#230](https://github.com/SmartBear/smartbear-mcp/pull/230)
+
 ## [0.10.0] - 2025-11-11
 
 ### Added


### PR DESCRIPTION
## Goal

The goal of this PR is to add a missing information to the Changelog, mentioning recently added tools in Zephyr

## Design

Followed the design of the Changelog file, with an **Unreleased** section instead of a released version

## Changeset

Just the `CHANGELOG.md` file

## Testing

Doesn't require testing.
