### PR TITLE
fix: ensure that buildx doesnt push image as manifest list

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,6 +96,7 @@ jobs:
             --platform ${{ matrix.platform }} \
             --tag "$DEST" \
             --cache-from type=gha,scope=${{ matrix.arch }} \
+            --provenance=false \
             --push \
             .
 


### PR DESCRIPTION
## Goal

By default when doing a `buildx build` it will create a manifest list rather than a singular image and since we stitch the different architecture images into one later setting provenance to false fixes the error we get when creating the manifest `***:0.11.0-amd64 is a manifest list`  https://github.com/SmartBear/smartbear-mcp/actions/runs/19536875934/job/55936992911

## Design

To fix issue with publishing images to ECR

## Changeset

Changes flags passed to buildx build command

## Testing

Tested locally
