### PR TITLE
test(bugsnag): add types to mocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test Suite
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, integration/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, integration/* ]
   workflow_dispatch:
 
 permissions:

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -1,10 +1,8 @@
-import { get } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ErrorApiView,
   EventApiView,
   EventField,
-  PerformanceFilter,
   PivotApiView,
   ProjectApiView,
   ReleaseApiView,
@@ -13,7 +11,6 @@ import type {
 } from "../../../bugsnag/client/api/api.js";
 import type { BaseAPI } from "../../../bugsnag/client/api/base.js";
 import type {
-  Build,
   CurrentUserAPI,
   ErrorAPI,
   Organization,


### PR DESCRIPTION
## Goal

The untyped mock objects hid some incorrect field names and made debugging tricky - this adds types to the mocks to ensure we spot breaking changes

## Changeset

* Added type annotations to objects used for mocks
* Added two helper functions to return mocked projects and orgs for convenience
* Corrected occurrences where the types were incorrect in the test

## Testing

All unit tests.
