### PR TITLE
feat(bugsnag): add Get Event and trim threads from Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BugSnag] Added tools for querying performance data and managing network grouping rules: List/Get Span Groups, List Spans, Get Trace, List Trace Fields, Get/Set Network Endpoint Groupings [#253](https://github.com/SmartBear/smartbear-mcp/pull/253)
 - Added --version command line argument to display the current version [#258](https://github.com/SmartBear/smartbear-mcp/pull/258)
 
+### Changed
+- [BugSnag] Removed event threads from Get Error response and introduced Get Event (by ID) [#263](https://github.com/SmartBear/smartbear-mcp/pull/263)
+
 ## [0.11.0] - 2025-11-20
 
 ### Added

--- a/docs/products/SmartBear MCP Server/bugsnag-integration.md
+++ b/docs/products/SmartBear MCP Server/bugsnag-integration.md
@@ -27,6 +27,11 @@ If you wish to interact with only one BugSnag project, we also recommend setting
 
 ### Get Event Details
 
+-   Retrieve event (occurrence) details of a specific event by ID.
+-   This includes all the information about the event, including any thread traces which are trimmed in the Get Error tool.
+
+### Get Event Details From Dashboard URL
+
 -   Retrieve event (occurrence) details from a dashboard URL.
 -   This is useful if you are copying the link from your dashboard to your IDE.
 

--- a/src/bugsnag/client/api/Error.ts
+++ b/src/bugsnag/client/api/Error.ts
@@ -40,7 +40,7 @@ export class ErrorAPI extends BaseAPI {
     perPage?: number,
     filters?: FilterObject,
     fullReports?: boolean,
-  ): Promise<ApiResponse<ErrorApiView[]>> {
+  ): Promise<ApiResponse<EventApiView[]>> {
     const localVarFetchArgs = ErrorsApiFetchParamCreator(
       this.configuration,
     ).listEventsOnProject(
@@ -53,7 +53,7 @@ export class ErrorAPI extends BaseAPI {
       fullReports,
       { query: filters },
     );
-    return await this.requestArray<ErrorApiView>(
+    return await this.requestArray<EventApiView>(
       localVarFetchArgs.url,
       localVarFetchArgs.options,
       false, // Paginate results

--- a/src/bugsnag/input-schemas.ts
+++ b/src/bugsnag/input-schemas.ts
@@ -13,15 +13,16 @@ const filtersSchema = z.record(z.array(filterValueSchema));
  */
 export const toolInputParameters = {
   empty: z.object({}).describe("No parameters are required for this tool"),
+  buildId: z.string().describe("Unique identifier of the app build"),
+  errorId: z.string().describe("Unique identifier of the error"),
+  eventId: z.string().describe("Unique identifier of the event"),
   projectId: z
     .string()
     .optional()
     .describe(
-      "ID of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.",
+      "Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.",
     ),
-  errorId: z.string().describe("Unique identifier of the error"),
-  releaseId: z.string().describe("ID of the release"),
-  buildId: z.string().describe("ID of the build"),
+  releaseId: z.string().describe("Unique identifier of the app release"),
   direction: z
     .enum(["asc", "desc"])
     .describe("Sort direction for ordering results")


### PR DESCRIPTION
## Goal

Some customers have many threads running in their apps and so the `event.threads` part of the payload can dominate the response without adding much value.

## Design

We have removed threads when `Get Error` is called as this doesn't seem worthwhile. However it's been added to `Get Event` so that the full details can be retrieved if required.

## Changeset

I also noticed that `listEventsOnProject` had the incorrect type, so fixed this.

## Testing

Expanded unit tests and confirmed that the LLM will ask for event details if explicitly asked.
