### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.12.1] - 2025-12-09
+
 ### Changed
 
 - [Swagger] Removed delete document functionality as this operation is not supported by the Portal API

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: ghcr.io/smartbear/smartbear-mcp:v0.12.0
+          image: ghcr.io/smartbear/smartbear-mcp:v0.12.1
           env:
             - name: MCP_TRANSPORT
               value: "http"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
## [0.12.1] - 2025-12-09

### Changed

- [Swagger] Removed delete document functionality as this operation is not supported by the Portal API
- [Swagger] Removed delete portal functionality as this operation is not allowed via MCP

### Fixed

- [BugSnag] Fixed an issue with filter query formatting [#277](https://github.com/SmartBear/smartbear-mcp/pull/277)