### PR TITLE
fix(bugsnag): avoid a warning message for no project found if no API key is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [BugSnag] Remove misleading warning for event fields if no API is provided in configuration [#284](https://github.com/SmartBear/smartbear-mcp/pull/284)
+
 ## [0.12.1] - 2025-12-09
 
 ### Changed


### PR DESCRIPTION
## Goal

A recent change to the startup logic resulted in a console error message about not finding the configured project, if one is provided as configuration.

## Changeset

Moved the check inside the if-block conditioned on this configuration option being present.

## Testing

Satisfied existing unit tests.
