### PR TITLE
feat(api): extract version from X-Version header and update response 

### DIFF
--- a/docs/products/SmartBear MCP Server/swagger-studio-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-studio-integration.md
@@ -41,7 +41,7 @@ The Swagger Studio client provides comprehensive API and Domain management capab
 #### `create_or_update_api`
 
 -   Purpose: Create a new API or update an existing API in SwaggerHub Registry for Swagger Studio. The API specification type (OpenAPI, AsyncAPI) is automatically detected from the definition content. If an API with the same owner and name already exists, it will be updated; otherwise, a new API will be created.
--   Returns: API metadata including owner, name, version (always 1.0.0), SwaggerHub URL, and operation type ('create' or 'update'). HTTP 201 indicates creation, HTTP 200 indicates update.
+-   Returns: API metadata including owner, name, version, SwaggerHub URL, and operation type ('create' or 'update'). HTTP 201 indicates creation, HTTP 200 indicates update.
 -   Use case: Programmatically create new APIs from OpenAPI/AsyncAPI specifications, update existing API definitions with new versions of the specification, or migrate APIs into Swagger Studio.
 -   Parameters:
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -722,13 +722,15 @@ export class SwaggerAPI {
     // Determine operation type based on HTTP status code
     const operation = response.status === 201 ? "create" : "update";
 
+    // Extract version from X-Version header
+    const version = response.headers.get("X-Version") || "1.0.0";
+
     // Return formatted response with the required fields
-    // Fixed version is always 1.0.0
     return {
       owner: params.owner,
       apiName: params.apiName,
-      version: "1.0.0",
-      url: `${this.config.uiBasePath}/apis/${params.owner}/${params.apiName}/1.0.0`,
+      version: version,
+      url: `${this.config.uiBasePath}/apis/${params.owner}/${params.apiName}/${version}`,
       operation,
     };
   }
@@ -767,12 +769,16 @@ export class SwaggerAPI {
     // Determine operation type based on HTTP status code
     const operation = response.status === 201 ? "create" : "update";
 
+    // Extract version from X-Version header
+    const version = response.headers.get("X-Version") || "1.0.0";
+
     // Return formatted response with the required fields
     return {
       owner: params.owner,
       apiName: params.apiName,
       template: params.template,
-      url: `${this.config.uiBasePath}/apis/${params.owner}/${params.apiName}`,
+      version: version,
+      url: `${this.config.uiBasePath}/apis/${params.owner}/${params.apiName}/${version}`,
       operation,
     };
   }

--- a/src/swagger/client/registry-types.ts
+++ b/src/swagger/client/registry-types.ts
@@ -199,6 +199,7 @@ export interface CreateApiFromTemplateResponse {
   owner: string;
   apiName: string;
   template: string;
+  version: string;
   url: string;
   operation: "create" | "update";
 }


### PR DESCRIPTION
This pull request updates how API version information is handled and returned when creating or updating APIs through the Swagger Studio integration. The main change is to dynamically extract the API version from the response header instead of always defaulting to "1.0.0", ensuring that the correct version is reflected in both the API metadata and URLs. Documentation and type definitions are also updated to support this improvement.
