### PR TITLE
fix: add pollyfills for elicitation and sampling

### DIFF
--- a/src/common/pollyfills.ts
+++ b/src/common/pollyfills.ts
@@ -1,0 +1,165 @@
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  ElicitRequest,
+  ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { SmartBearMcpServer } from "./server";
+import { ToolError } from "./tools";
+
+export interface SamplingPolyfillResult {
+  requiresPromptExecution: true;
+  prompt: string;
+  instructions: string;
+}
+
+export interface ElicitationPolyfillResult {
+  requiresInputCollection: true;
+  inputRequest: ElicitRequest["params"];
+  instructions: string;
+}
+
+/**
+ * Attempts to execute a sampling request. If sampling is not available,
+ * returns a polyfill result instructing the host to execute the prompt
+ * and re-request the tool.
+ *
+ * @param server - The MCP server instance
+ * @param prompt - The prompt to execute
+ * @param maxTokens - Maximum tokens for the response
+ * @returns Either the sampling response text or a polyfill result
+ * @throws ToolError if sampling fails or response format is unexpected
+ */
+export async function executeSamplingOrPolyfill(
+  server: SmartBearMcpServer,
+  prompt: string,
+  maxTokens = 1000,
+): Promise<string | SamplingPolyfillResult> {
+  if (!server.isSamplingSupported()) {
+    return createPolyfillResult(prompt);
+  }
+
+  try {
+    const response = await server.server.createMessage({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: prompt,
+          },
+        },
+      ],
+      maxTokens,
+    });
+
+    const content = response.content;
+    if (content.type !== "text") {
+      throw new ToolError(
+        `Received unexpected response type from sampling: ${content.type}`,
+      );
+    }
+
+    return content.text;
+  } catch (error) {
+    console.error(error);
+    return createPolyfillResult(prompt);
+  }
+}
+
+/**
+ * Creates a polyfill result that instructs the host AI application to
+ * execute the prompt and re-request the tool.
+ *
+ * @param prompt - The prompt to be executed
+ * @returns A polyfill result object
+ */
+function createPolyfillResult(prompt: string): SamplingPolyfillResult {
+  return {
+    requiresPromptExecution: true,
+    prompt,
+    instructions:
+      "Please execute the above prompt using your AI capabilities and re-request this tool with the result. " +
+      "Include the prompt result in your next request to continue the operation.",
+  };
+}
+
+/**
+ * Checks if a value is a sampling polyfill result.
+ *
+ * @param value - The value to check
+ * @returns true if the value is a SamplingPolyfillResult
+ */
+export function isSamplingPolyfillResult(
+  value: unknown,
+): value is SamplingPolyfillResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "requiresPromptExecution" in value &&
+    (value as SamplingPolyfillResult).requiresPromptExecution === true
+  );
+}
+
+/**
+ * Attempts to execute an elicitation request. If elicitation is not available,
+ * returns a polyfill result instructing the host to collect the input
+ * and re-request the tool.
+ *
+ * @param server - The MCP server instance
+ * @param params - The elicitation request parameters
+ * @param options - Optional request options
+ * @returns Either the elicitation result or a polyfill result
+ * @throws ToolError if elicitation fails unexpectedly
+ */
+export async function executeElicitationOrPolyfill(
+  server: SmartBearMcpServer,
+  params: ElicitRequest["params"],
+  options?: RequestOptions,
+): Promise<ElicitResult | ElicitationPolyfillResult> {
+  if (!server.isElicitationSupported()) {
+    return createElicitationPolyfillResult(params);
+  }
+
+  try {
+    return await server.server.elicitInput(params, options);
+  } catch (error) {
+    console.error(error);
+    return createElicitationPolyfillResult(params);
+  }
+}
+
+/**
+ * Creates a polyfill result that instructs the host AI application to
+ * collect the requested input and re-request the tool.
+ *
+ * @param params - The elicitation request parameters
+ * @returns A polyfill result object
+ */
+function createElicitationPolyfillResult(
+  params: ElicitRequest["params"],
+): ElicitationPolyfillResult {
+  return {
+    requiresInputCollection: true,
+    inputRequest: params,
+    instructions:
+      "Please collect the requested input from the user and re-request this tool with the collected values. " +
+      "Include the input results in your next request to continue the operation.",
+  };
+}
+
+/**
+ * Checks if a value is an elicitation polyfill result.
+ *
+ * @param value - The value to check
+ * @returns true if the value is an ElicitationPolyfillResult
+ */
+export function isElicitationPolyfillResult(
+  value: unknown,
+): value is ElicitationPolyfillResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "requiresInputCollection" in value &&
+    (value as ElicitationPolyfillResult).requiresInputCollection === true
+  );
+}

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -214,6 +214,27 @@ async function createNewTransport(
       transports.set(newSessionId, { server, transport });
     },
   });
+  transport.onmessage = (message) => {
+    if ("method" in message && message.method === "initialize") {
+      if (message.params?.protocolVersion === "2025-11-25") {
+        const clientCapabilities = message.params?.capabilities as Record<
+          string,
+          unknown
+        >;
+
+        if (Object.hasOwn(clientCapabilities, "sampling")) {
+          server.setSamplingSupported(true);
+        }
+
+        if (Object.hasOwn(clientCapabilities, "elicitation")) {
+          server.setElicitationSupported(true);
+        }
+      }
+
+      // Other protocolVersion handling can be added below
+      // to maintain backwards compatibility.
+    }
+  };
 
   // Clean up session on close
   transport.onclose = () => {

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -59,6 +59,27 @@ export async function runStdioMode() {
   }
 
   const transport = new StdioServerTransport();
+  transport.onmessage = (message) => {
+    if ("method" in message && message.method === "initialize") {
+      if (message.params?.protocolVersion === "2025-11-25") {
+        const clientCapabilities = message.params?.capabilities as Record<
+          string,
+          unknown
+        >;
+
+        if (Object.hasOwn(clientCapabilities, "sampling")) {
+          server.setSamplingSupported(true);
+        }
+
+        if (Object.hasOwn(clientCapabilities, "elicitation")) {
+          server.setElicitationSupported(true);
+        }
+      }
+
+      // Other protocolVersion handling can be added below
+      // to maintain backwards compatibility.
+    }
+  };
   await server.connect(transport);
 }
 

--- a/src/tests/unit/common/pollyfills.test.ts
+++ b/src/tests/unit/common/pollyfills.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type ElicitationPolyfillResult,
+  executeElicitationOrPolyfill,
+  executeSamplingOrPolyfill,
+  isElicitationPolyfillResult,
+  isSamplingPolyfillResult,
+  type SamplingPolyfillResult,
+} from "../../../common/pollyfills";
+import type { SmartBearMcpServer } from "../../../common/server";
+
+describe("Polyfills", () => {
+  describe("executeSamplingOrPolyfill", () => {
+    let mockServer: SmartBearMcpServer;
+
+    beforeEach(() => {
+      mockServer = {
+        isSamplingSupported: vi.fn(),
+        server: {
+          createMessage: vi.fn(),
+        },
+      } as unknown as SmartBearMcpServer;
+    });
+
+    it("should return polyfill result when sampling is not supported", async () => {
+      vi.mocked(mockServer.isSamplingSupported).mockReturnValue(false);
+
+      const prompt = "Test prompt";
+      const result = await executeSamplingOrPolyfill(mockServer, prompt);
+
+      expect(isSamplingPolyfillResult(result)).toBe(true);
+      if (isSamplingPolyfillResult(result)) {
+        expect(result.requiresPromptExecution).toBe(true);
+        expect(result.prompt).toBe(prompt);
+        expect(result.instructions).toContain(
+          "Please execute the above prompt using your AI capabilities",
+        );
+      }
+      expect(mockServer.server.createMessage).not.toHaveBeenCalled();
+    });
+
+    it("should return text response when sampling succeeds", async () => {
+      vi.mocked(mockServer.isSamplingSupported).mockReturnValue(true);
+      const expectedText = "Sampled response";
+      vi.mocked(mockServer.server.createMessage).mockResolvedValue({
+        model: "test-model",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: expectedText,
+        },
+      });
+
+      const prompt = "Test prompt";
+      const result = await executeSamplingOrPolyfill(mockServer, prompt);
+
+      expect(result).toBe(expectedText);
+      expect(mockServer.server.createMessage).toHaveBeenCalledWith({
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: prompt,
+            },
+          },
+        ],
+        maxTokens: 1000,
+      });
+    });
+
+    it("should use custom maxTokens when provided", async () => {
+      vi.mocked(mockServer.isSamplingSupported).mockReturnValue(true);
+      vi.mocked(mockServer.server.createMessage).mockResolvedValue({
+        model: "test-model",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Response",
+        },
+      });
+
+      const customMaxTokens = 2000;
+      await executeSamplingOrPolyfill(
+        mockServer,
+        "Test prompt",
+        customMaxTokens,
+      );
+
+      expect(mockServer.server.createMessage).toHaveBeenCalledWith({
+        messages: expect.any(Array),
+        maxTokens: customMaxTokens,
+      });
+    });
+
+    it("should return polyfill result when response type is not text", async () => {
+      vi.mocked(mockServer.isSamplingSupported).mockReturnValue(true);
+      vi.mocked(mockServer.server.createMessage).mockResolvedValue({
+        model: "test-model",
+        role: "assistant",
+        content: {
+          type: "image",
+          data: "...",
+        },
+      } as any);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const prompt = "Test prompt";
+      const result = await executeSamplingOrPolyfill(mockServer, prompt);
+
+      // Should fall back to polyfill when response type is unexpected
+      expect(isSamplingPolyfillResult(result)).toBe(true);
+      if (isSamplingPolyfillResult(result)) {
+        expect(result.prompt).toBe(prompt);
+      }
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("should return polyfill result when sampling throws error", async () => {
+      vi.mocked(mockServer.isSamplingSupported).mockReturnValue(true);
+      vi.mocked(mockServer.server.createMessage).mockRejectedValue(
+        new Error("Sampling failed"),
+      );
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const prompt = "Test prompt";
+      const result = await executeSamplingOrPolyfill(mockServer, prompt);
+
+      expect(isSamplingPolyfillResult(result)).toBe(true);
+      if (isSamplingPolyfillResult(result)) {
+        expect(result.prompt).toBe(prompt);
+      }
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("isSamplingPolyfillResult", () => {
+    it("should return true for valid SamplingPolyfillResult", () => {
+      const result: SamplingPolyfillResult = {
+        requiresPromptExecution: true,
+        prompt: "Test prompt",
+        instructions: "Instructions",
+      };
+
+      expect(isSamplingPolyfillResult(result)).toBe(true);
+    });
+
+    it("should return false for null", () => {
+      expect(isSamplingPolyfillResult(null)).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isSamplingPolyfillResult(undefined)).toBe(false);
+    });
+
+    it("should return false for non-object values", () => {
+      expect(isSamplingPolyfillResult("string")).toBe(false);
+      expect(isSamplingPolyfillResult(123)).toBe(false);
+      expect(isSamplingPolyfillResult(true)).toBe(false);
+    });
+
+    it("should return false for object without requiresPromptExecution", () => {
+      expect(
+        isSamplingPolyfillResult({
+          prompt: "Test",
+          instructions: "Test",
+        }),
+      ).toBe(false);
+    });
+
+    it("should return false when requiresPromptExecution is false", () => {
+      expect(
+        isSamplingPolyfillResult({
+          requiresPromptExecution: false,
+          prompt: "Test",
+          instructions: "Test",
+        }),
+      ).toBe(false);
+    });
+
+    it("should return false for ElicitationPolyfillResult", () => {
+      const result: ElicitationPolyfillResult = {
+        requiresInputCollection: true,
+        inputRequest: { message: "Test", requestedSchema: {} as any },
+        instructions: "Instructions",
+      };
+
+      expect(isSamplingPolyfillResult(result)).toBe(false);
+    });
+  });
+
+  describe("executeElicitationOrPolyfill", () => {
+    let mockServer: SmartBearMcpServer;
+
+    beforeEach(() => {
+      mockServer = {
+        isElicitationSupported: vi.fn(),
+        server: {
+          elicitInput: vi.fn(),
+        },
+      } as unknown as SmartBearMcpServer;
+    });
+
+    it("should return polyfill result when elicitation is not supported", async () => {
+      vi.mocked(mockServer.isElicitationSupported).mockReturnValue(false);
+
+      const params = {
+        message: "Enter your name",
+        requestedSchema: {
+          type: "object" as const,
+          properties: {
+            name: { type: "string" as const },
+          },
+        },
+      };
+
+      const result = await executeElicitationOrPolyfill(mockServer, params);
+
+      expect(isElicitationPolyfillResult(result)).toBe(true);
+      if (isElicitationPolyfillResult(result)) {
+        expect(result.requiresInputCollection).toBe(true);
+        expect(result.inputRequest).toBe(params);
+        expect(result.instructions).toContain(
+          "Please collect the requested input from the user",
+        );
+      }
+      expect(mockServer.server.elicitInput).not.toHaveBeenCalled();
+    });
+
+    it("should return elicit result when elicitation succeeds", async () => {
+      vi.mocked(mockServer.isElicitationSupported).mockReturnValue(true);
+
+      const params = {
+        message: "Enter your name",
+        requestedSchema: {
+          type: "object" as const,
+          properties: {
+            name: { type: "string" as const },
+          },
+        },
+      };
+
+      const expectedResult = {
+        action: "accept" as const,
+        content: { name: "John Doe" },
+      };
+
+      vi.mocked(mockServer.server.elicitInput).mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await executeElicitationOrPolyfill(mockServer, params);
+
+      expect(result).toBe(expectedResult);
+      expect(mockServer.server.elicitInput).toHaveBeenCalledWith(
+        params,
+        undefined,
+      );
+    });
+
+    it("should pass options to elicitInput when provided", async () => {
+      vi.mocked(mockServer.isElicitationSupported).mockReturnValue(true);
+
+      const params = {
+        message: "Enter your name",
+        requestedSchema: {
+          type: "object" as const,
+          properties: {
+            name: { type: "string" as const },
+          },
+        },
+      };
+
+      const options = { timeout: 5000 };
+
+      vi.mocked(mockServer.server.elicitInput).mockResolvedValue({
+        action: "accept" as const,
+        content: {},
+      });
+
+      await executeElicitationOrPolyfill(mockServer, params, options);
+
+      expect(mockServer.server.elicitInput).toHaveBeenCalledWith(
+        params,
+        options,
+      );
+    });
+
+    it("should return polyfill result when elicitation throws error", async () => {
+      vi.mocked(mockServer.isElicitationSupported).mockReturnValue(true);
+      vi.mocked(mockServer.server.elicitInput).mockRejectedValue(
+        new Error("Elicitation failed"),
+      );
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const params = {
+        message: "Enter your name",
+        requestedSchema: {
+          type: "object" as const,
+          properties: {
+            name: { type: "string" as const },
+          },
+        },
+      };
+
+      const result = await executeElicitationOrPolyfill(mockServer, params);
+
+      expect(isElicitationPolyfillResult(result)).toBe(true);
+      if (isElicitationPolyfillResult(result)) {
+        expect(result.inputRequest).toBe(params);
+      }
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("isElicitationPolyfillResult", () => {
+    it("should return true for valid ElicitationPolyfillResult", () => {
+      const result: ElicitationPolyfillResult = {
+        requiresInputCollection: true,
+        inputRequest: {
+          message: "Test",
+          requestedSchema: {
+            type: "object" as const,
+            properties: {},
+          },
+        },
+        instructions: "Instructions",
+      };
+
+      expect(isElicitationPolyfillResult(result)).toBe(true);
+    });
+
+    it("should return false for null", () => {
+      expect(isElicitationPolyfillResult(null)).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isElicitationPolyfillResult(undefined)).toBe(false);
+    });
+
+    it("should return false for non-object values", () => {
+      expect(isElicitationPolyfillResult("string")).toBe(false);
+      expect(isElicitationPolyfillResult(123)).toBe(false);
+      expect(isElicitationPolyfillResult(true)).toBe(false);
+    });
+
+    it("should return false for object without requiresInputCollection", () => {
+      expect(
+        isElicitationPolyfillResult({
+          inputRequest: {},
+          instructions: "Test",
+        }),
+      ).toBe(false);
+    });
+
+    it("should return false when requiresInputCollection is false", () => {
+      expect(
+        isElicitationPolyfillResult({
+          requiresInputCollection: false,
+          inputRequest: {},
+          instructions: "Test",
+        }),
+      ).toBe(false);
+    });
+
+    it("should return false for SamplingPolyfillResult", () => {
+      const result: SamplingPolyfillResult = {
+        requiresPromptExecution: true,
+        prompt: "Test prompt",
+        instructions: "Instructions",
+      };
+
+      expect(isElicitationPolyfillResult(result)).toBe(false);
+    });
+  });
+});

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -33,6 +33,8 @@ describe("SmartBearMcpServer", () => {
       )
       .mockImplementation(vi.fn());
     server.server.elicitInput = vi.fn().mockResolvedValue("mocked input");
+    // Mock elicitation support
+    server.setElicitationSupported(true);
 
     // Reset the Bugsnag mock
     vi.mocked(Bugsnag.notify).mockClear();
@@ -366,8 +368,9 @@ describe("SmartBearMcpServer", () => {
       const getInputFn = mockClient.registerTools.mock.calls[0][1];
       const params = vi.mockObject({});
       const options = vi.mockObject({});
-      getInputFn(params, options);
+      await getInputFn(params, options);
 
+      // Since elicitation is supported, the wrapper should call elicitInput
       expect(server.server.elicitInput).toHaveBeenCalledExactlyOnceWith(
         params,
         options,


### PR DESCRIPTION
## Goal

This PR adds pollyfills for sampling and elicitations during the stdio & http transport init to enable use of pactflow tools with advanced features in tools which dont support these features. Other features like prompts, resources don't need to be disabled as they are handled by capability negotiation see - https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#capability-negotiation.

## Testing

Tested the changes in vscode copilot, cursor, windsurf and claude code.
