### PR TITLE
fix: update userManagementBasePath to use registryBasePath

### DIFF
--- a/src/swagger/client/configuration.ts
+++ b/src/swagger/client/configuration.ts
@@ -23,7 +23,8 @@ export class SwaggerConfiguration {
       param.registryBasePath || "https://api.swaggerhub.com"; // Default for registry API
     this.uiBasePath = param.uiBasePath || "https://app.swaggerhub.com"; // Default for UI
     this.userManagementBasePath =
-      param.userManagementBasePath || `${this.registryBasePath}/user-management/v1`;
+      param.userManagementBasePath ||
+      `${this.registryBasePath}/user-management/v1`;
     // Use Bearer token format consistently across all APIs
     this.headers = {
       Authorization: `Bearer ${this.token}`,


### PR DESCRIPTION
This pull request updates the default base path for the user management API in the `SwaggerConfiguration` class to use the registry API's base URL instead of the UI base URL. This ensures consistency in API endpoint usage.
