### PR TITLE
fix: shorten tool name for API creation prompt

### DIFF
--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -183,7 +183,7 @@ export const TOOLS: SwaggerToolParams[] = [
     handler: "scanStandardization",
   },
   {
-    title: "Create API from Prompt using SmartBear AI",
+    title: "Create API from Prompt",
     summary:
       "Generate and save an API definition based on a prompt using SmartBear AI. This tool automatically applies organization governance and standardization rules during API generation. The specType parameter determines the format of the generated definition. Use: 'openapi20' for OpenAPI 2.0, 'openapi30x' for OpenAPI 3.0.x, 'openapi31x' for OpenAPI 3.1.x, 'asyncapi2xx' for AsyncAPI 2.x, 'asyncapi30x' for AsyncAPI 3.0.x. Use this tool when creating APIs that comply with governance policies or when generating APIs from natural language descriptions. Use this tool when users ask to create, generate, or design APIs with governance or standardization requirements. Returns HTTP 201 for creation, HTTP 200 for update. Response includes 'operation' field indicating whether it was a 'create' or 'update' operation along with API details and SwaggerHub URL.",
     inputSchema: CreateApiFromPromptParamsSchema,


### PR DESCRIPTION
This pull request makes a minor update to the `TOOLS` array in `src/swagger/client/tools.ts`, specifically clarifying the title of one of the API generation tools. The change improves the clarity of the tool's purpose without altering its functionality.

* Changed the `title` of the "Create API from Prompt using SmartBear AI" tool to "Create API from Prompt" for improved clarity.