### PR TITLE
[BugSnag] PLAT-14898: Added the ability to add comments to BugSnag errors

### DIFF
--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1092,6 +1092,82 @@ export class BugsnagClient implements Client {
       },
     );
 
+    const createCommentOnErrorInputSchema = z.object({
+      projectId: toolInputParameters.projectId,
+      errorId: toolInputParameters.errorId,
+      message: z.string().describe("The comment message to add to the error"),
+    });
+
+    register(
+      {
+        title: "Create Comment on Error",
+        summary:
+          "Add a comment to an error for collaboration and documentation",
+        purpose:
+          "Create a comment on a specific error to provide context, updates, or notes for team collaboration",
+        useCases: [
+          "Document investigation findings on an error",
+          "Add notes about workarounds or fixes in progress",
+          "Communicate with team members about error status",
+          "Record decisions made regarding error handling",
+        ],
+        inputSchema: createCommentOnErrorInputSchema,
+        examples: [
+          {
+            description: "Add a comment to document a temporary fix",
+            parameters: {
+              errorId: "6863e2af8c857c0a5023b411",
+              message:
+                "Applied temporary fix in hotfix branch. Monitoring for 24 hours before marking as resolved.",
+            },
+            expectedOutput:
+              "Success response confirming the comment was created",
+          },
+          {
+            description: "Add a comment with investigation details",
+            parameters: {
+              errorId: "6863e2af8c857c0a5023b411",
+              message:
+                "Root cause identified: API timeout due to database query performance. Working on optimization.",
+            },
+            expectedOutput:
+              "Success response confirming the comment was created",
+          },
+        ],
+        hints: [
+          "Comments are visible to all team members with access to the project",
+          "Use comments to maintain a history of actions taken on an error",
+          "Comments can include technical details, links to PRs, or status updates",
+        ],
+        readOnly: false,
+        idempotent: false,
+      },
+      async (args, _extra) => {
+        const params = createCommentOnErrorInputSchema.parse(args);
+        const project = await this.getInputProject(params.projectId);
+
+        const result = await this.errorsApi.createCommentOnError(
+          project.id,
+          params.errorId,
+          params.message,
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                success: result.status === 200 || result.status === 201,
+                errorId: params.errorId,
+                projectId: project.id,
+                message: params.message,
+              }),
+            },
+          ],
+        };
+      },
+    );
+
     const listReleasesInputSchema = z.object({
       projectId: toolInputParameters.projectId,
       releaseStage: toolInputParameters.releaseStage,

--- a/src/bugsnag/client/api/Error.ts
+++ b/src/bugsnag/client/api/Error.ts
@@ -211,4 +211,31 @@ export class ErrorAPI extends BaseAPI {
       false, // Paginate results
     );
   }
+
+  /**
+   * Create a comment on an Error
+   * POST /projects/{project_id}/errors/{error_id}/comments
+   */
+  async createCommentOnError(
+    projectId: string,
+    errorId: string,
+    message: string,
+  ): Promise<ApiResponse<any>> {
+    const url = new URL(
+      `/projects/${projectId}/errors/${errorId}/comments`,
+      this.configuration.basePath,
+    );
+
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Bugsnag-Api": "true",
+        Authorization: this.configuration.apiKey,
+      },
+      body: JSON.stringify({ message }),
+    };
+
+    return await this.requestObject<any>(url.toString(), options);
+  }
 }

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -42,6 +42,7 @@ const mockErrorAPI = {
   listProjectErrors: vi.fn(),
   updateErrorOnProject: vi.fn(),
   getPivotValuesOnAnError: vi.fn(),
+  createCommentOnError: vi.fn(),
 } satisfies Omit<ErrorAPI, keyof BaseAPI>;
 
 const mockProjectAPI = {
@@ -901,7 +902,7 @@ describe("BugsnagClient", () => {
       expect(registeredTools).toContain("List Trace Fields");
       expect(registeredTools).toContain("Get Network Endpoint Groupings");
       expect(registeredTools).toContain("Set Network Endpoint Groupings");
-      expect(registeredTools.length).toBe(18);
+      expect(registeredTools.length).toBe(19);
     });
   });
 
@@ -3038,6 +3039,41 @@ describe("BugsnagClient", () => {
 
         expect(result.contents[0].uri).toBe("bugsnag://event/event-1");
         expect(result.contents[0].text).toBe(JSON.stringify(mockEvent));
+      });
+    });
+  });
+
+  describe("Create a comment on an error", () => {
+    it("should call createCommentOnError with correct params and return success", async () => {
+      const projectId = "test-project-id";
+      const errorId = "test-error-id";
+      const message = "test comment";
+      // Mock the implementation to resolve with a success response
+      mockErrorAPI.createCommentOnError = vi.fn().mockResolvedValue({
+        success: true,
+        errorId,
+        projectId,
+        message,
+      });
+
+      // Call the method
+      const result = await mockErrorAPI.createCommentOnError(
+        projectId,
+        errorId,
+        message,
+      );
+
+      // Assert
+      expect(mockErrorAPI.createCommentOnError).toHaveBeenCalledWith(
+        projectId,
+        errorId,
+        message,
+      );
+      expect(result).toEqual({
+        success: true,
+        errorId,
+        projectId,
+        message,
       });
     });
   });


### PR DESCRIPTION
## Goal

Adds the ability for comments to be added to errors in BugSnag.

## Design

This coincides with how comments are normally created via the dashboard. Only with this, we're exposing it for being called via MCP instead.

## Changeset

- createCommentOnError exposes the `/comments` endpoint and manages the necessary query parameter and header logic.
- `createCommentOnErrorInputSchema` contains the Zod logic for defining how interactions should be structured when making calls to the `/comments `endpoint.

## Testing

<img width="782" height="427" alt="image" src="https://github.com/user-attachments/assets/6e859095-e84d-452b-8ee6-4c4be62bb234" />
<img width="476" height="87" alt="image" src="https://github.com/user-attachments/assets/2575fc0c-6d64-4856-94be-01de553208ea" />