### PR TITLE
fix: adjustments in publish-portal-content.sh (PROVCON-4978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- [Portal] Adjusted internal script to recent changes in Portal's API [#404](https://github.com/SmartBear/smartbear-mcp/pull/404)
 ## [0.17.1] - 2026-04-09
 
 ### Added
 
 - [Pactflow] Added tools for CRUD over BDCT, Pacticipants, Environments, Permissions management [#414](https://github.com/SmartBear/smartbear-mcp/pull/414)
+
 
 ## [0.17.0] - 2026-04-07
 

--- a/docs/scripts/publish-portal-content.sh
+++ b/docs/scripts/publish-portal-content.sh
@@ -706,21 +706,39 @@ function portal_product_toc_markdown_post() {
     local source=$7
 
     log_message $INFO "Creating markdown TOC: $markdown_title in product $product_id with parent $parent_toc_id ..."
-    local response=$(curl -s --request POST \
-        --url "$PORTAL_URL/sections/$product_section_id/table-of-contents" \
-        --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{
-            \"type\": \"new\",
-            \"title\": \"$markdown_title\",
-            \"slug\": \"$markdown_slug\",
-            \"order\": $content_order,
-            \"parentId\": \"$parent_toc_id\",
-            \"content\": {
-                \"type\": \"$type\",
-                \"source\": \"$source\"
-            }
-        }")
+
+    if [ -z "$source" ] || [ "$source" = "" ]; then
+      local response=$(curl -s --request POST \
+          --url "$PORTAL_URL/sections/$product_section_id/table-of-contents" \
+          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data "{
+              \"type\": \"new\",
+              \"title\": \"$markdown_title\",
+              \"slug\": \"$markdown_slug\",
+              \"order\": $content_order,
+              \"parentId\": \"$parent_toc_id\",
+              \"content\": {
+                  \"type\": \"$type\"
+              }
+          }")
+    else
+      local response=$(curl -s --request POST \
+          --url "$PORTAL_URL/sections/$product_section_id/table-of-contents" \
+          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data "{
+              \"type\": \"new\",
+              \"title\": \"$markdown_title\",
+              \"slug\": \"$markdown_slug\",
+              \"order\": $content_order,
+              \"parentId\": \"$parent_toc_id\",
+              \"content\": {
+                  \"type\": \"$type\",
+                  \"source\": \"$source\"
+              }
+          }")
+    fi
 
     log_message $DEBUG "Response: $response"
     product_toc_id=$(echo "$response" | jq -r .id)
@@ -787,32 +805,36 @@ function portal_product_document_markdown_patch() {
     local source=$3
 
     log_message $INFO "Updating markdown document in product $product_id for document $document_id..."
-    local escaped_contents=$(jq -Rs . <<< "$contents")
 
-    if [ -z "$source" ] || [ "$source" = "" ]; then
-      local response=$(curl -s --request PATCH \
-          --url "$PORTAL_URL/documents/$document_id" \
-          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
-          --header "Content-Type: application/json" \
-          --data "{
-              \"content\": $escaped_contents,
-              \"type\": \"$type\"
-          }")
+    if [ -z "$document_id" ] || [ "$document_id" = "" ]; then
+      log_message $INFO "Document ID is null or empty. Skipping the update of the document."
     else
-      local response=$(curl -s --request PATCH \
-          --url "$PORTAL_URL/documents/$document_id" \
-          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
-          --header "Content-Type: application/json" \
-          --data "{
-              \"content\": $escaped_contents,
-              \"type\": \"$type\",
-              \"source\": \"$source\"
-          }")
+
+      local escaped_contents=$(jq -Rs . <<< "$contents")
+      if [ -z "$source" ] || [ "$source" = "" ]; then
+        local response=$(curl -s --request PATCH \
+            --url "$PORTAL_URL/documents/$document_id" \
+            --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "{
+                \"content\": $escaped_contents,
+                \"type\": \"$type\"
+            }")
+      else
+        local response=$(curl -s --request PATCH \
+            --url "$PORTAL_URL/documents/$document_id" \
+            --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "{
+                \"content\": $escaped_contents,
+                \"type\": \"$type\",
+                \"source\": \"$source\"
+            }")
+      fi
+
+      log_message $DEBUG "Document patch response: $response"
+      log_message $INFO "Done updating $type document."
     fi
-
-
-    log_message $DEBUG "Document patch response: $response"
-    log_message $INFO "Done updating $type document."
     log_message $DEBUG "Exit portal_product_document_markdown_patch"
 }
 

--- a/docs/scripts/publish-portal-content.sh
+++ b/docs/scripts/publish-portal-content.sh
@@ -687,7 +687,7 @@ function portal_product_toc_markdown_upsert() {
         portal_product_toc_markdown_post "$section_id" "$markdown_title" "$markdown_slug" "$content_order" "$parent_toc_id" "$type" "$source"
     else
         log_message $INFO "Patching markdown TOC: $section_id, $product_toc_id, $markdown_title, $markdown_slug, $content_order, $parent_toc_id"
-        portal_product_toc_markdown_patch "$section_id" "$product_toc_id" "$markdown_title" "$markdown_slug" "$content_order" "$product_toc_slug" "$parent_toc_id" "$type"
+        portal_product_toc_markdown_patch "$section_id" "$product_toc_id" "$markdown_title" "$markdown_slug" "$content_order" "$product_toc_slug" "$parent_toc_id"
     fi
 
     log_message $DEBUG "Returning document_id: $document_id"
@@ -738,7 +738,6 @@ function portal_product_toc_markdown_patch() {
     local content_order=$5
     local product_toc_slug=$6
     local parent_toc_id=$7
-    local type=$8
 
     log_message $INFO "Updating markdown TOC: $markdown_title in product $product_id with parent $parent_toc_id ..."
     if [ "$markdown_slug" == "$product_toc_slug" ]; then
@@ -750,10 +749,7 @@ function portal_product_toc_markdown_patch() {
             --data "{
                 \"title\": \"$markdown_title\",
                 \"order\": $content_order,
-                \"parentId\": \"$parent_toc_id\",
-                \"content\": {
-                    \"type\": \"$type\"
-                }
+                \"parentId\": \"$parent_toc_id\"
             }")
     else
         local response=$(curl -s --request PATCH \
@@ -764,10 +760,7 @@ function portal_product_toc_markdown_patch() {
                 \"title\": \"$markdown_title\",
                 \"slug\": \"$markdown_slug\",
                 \"order\": $content_order,
-                \"parentId\": \"$parent_toc_id\",
-                \"content\": {
-                    \"type\": \"$type\"
-                }
+                \"parentId\": \"$parent_toc_id\"
             }")
     fi
 
@@ -791,19 +784,32 @@ function portal_product_document_markdown_patch() {
     log_message $DEBUG "Enter portal_product_document_markdown_patch"
     local contents=$1
     local type=$2
+    local source=$3
 
     log_message $INFO "Updating markdown document in product $product_id for document $document_id..."
     local escaped_contents=$(jq -Rs . <<< "$contents")
 
-    local response=$(curl -s --request PATCH \
-        --url "$PORTAL_URL/documents/$document_id" \
-        --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
-        --header "Content-Type: application/json" \
-        --data "{
-            \"content\": $escaped_contents,
-            \"type\": \"$type\",
-            \"source\": \"$source\"
-        }")
+    if [ -z "$source" ] || [ "$source" = "" ]; then
+      local response=$(curl -s --request PATCH \
+          --url "$PORTAL_URL/documents/$document_id" \
+          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data "{
+              \"content\": $escaped_contents,
+              \"type\": \"$type\"
+          }")
+    else
+      local response=$(curl -s --request PATCH \
+          --url "$PORTAL_URL/documents/$document_id" \
+          --header "Authorization: Bearer $SWAGGERHUB_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data "{
+              \"content\": $escaped_contents,
+              \"type\": \"$type\",
+              \"source\": \"$source\"
+          }")
+    fi
+
 
     log_message $DEBUG "Document patch response: $response"
     log_message $INFO "Done updating $type document."


### PR DESCRIPTION
**PROVCON-4978 - Nested pages not being publishing for MCP content via API**

## Goal

The goal of this PR is to address following errors caused by `publish-portal-content.sh` script

```
Cannot construct instance of `com.smartbear.swaggerhub.portal.apimodel.generated.model.Source`, problem: Unexpected value ''
```

```
Bad Request: Documents can be modified only via Documents API
```

See [PROVCON-4978](https://smartbear.atlassian.net/browse/PROVCON-4978)
## Design

Does not apply

## Changeset

- Added extra condition to check if `source` is not null, nor empty string in `portal_product_document_markdown_patch` and  `portal_product_toc_markdown_post`
- Added extra condition to check if `document_id` is not null, nor empty string in `portal_product_document_markdown_patch`
- Removed `type` parameter from `portal_product_toc_markdown_patch` as it is no longer supported by Portal API

## Testing

Tested by running [Publish Portal Content workflow](https://github.com/SmartBear/smartbear-mcp/actions/workflows/docs-as-code.yaml), that calls affected script under the hood:
https://github.com/SmartBear/smartbear-mcp/actions/runs/23895595549/job/69679462811

[PROVCON-4978]: https://smartbear.atlassian.net/browse/PROVCON-4978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ