### PR TITLE
[ZEPHYR] TM4J-14840 Post test steps

### DIFF
--- a/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
@@ -37,9 +37,10 @@ describe("CreateTestSteps", () => {
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Create Test Case Steps");
     expect(instance.specification.summary).toBe(
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones. Always ask the user to choose between OVERWRITE or APPEND before calling this tool.",
     );
     expect(instance.specification.readOnly).toBe(false);
+    expect(instance.specification.destructive).toBe(true);
     expect(instance.specification.idempotent).toBe(false);
     expect(instance.specification.inputSchema).toBeDefined();
     expect(instance.specification.outputSchema).toBe(

--- a/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
@@ -37,7 +37,7 @@ describe("CreateTestSteps", () => {
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Create Test Case Steps");
     expect(instance.specification.summary).toBe(
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI).",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). IMPORTANT: Always ask the user which mode to use before calling this tool. `APPEND` adds steps to the end of the existing list. `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
     );
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(false);

--- a/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/create-test-steps.test.ts
@@ -37,7 +37,7 @@ describe("CreateTestSteps", () => {
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Create Test Case Steps");
     expect(instance.specification.summary).toBe(
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). IMPORTANT: Always ask the user which mode to use before calling this tool. `APPEND` adds steps to the end of the existing list. `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
     );
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(false);

--- a/src/zephyr/tool/test-case/create-test-steps.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.ts
@@ -12,12 +12,10 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
   specification: ToolParams = {
     title: "Create Test Case Steps",
     summary:
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI).",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). IMPORTANT: Always ask the user which mode to use before calling this tool. `APPEND` adds steps to the end of the existing list. `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCaseTestStepsParams.and(
-      CreateTestCaseTestStepsBody.partial(),
-    ),
+    inputSchema: CreateTestCaseTestStepsParams.and(CreateTestCaseTestStepsBody),
     outputSchema: createTestCaseTestStepsResponse,
     examples: [
       {

--- a/src/zephyr/tool/test-case/create-test-steps.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.ts
@@ -12,7 +12,7 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
   specification: ToolParams = {
     title: "Create Test Case Steps",
     summary:
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). IMPORTANT: Always ask the user which mode to use before calling this tool. `APPEND` adds steps to the end of the existing list. `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
     readOnly: false,
     idempotent: false,
     inputSchema: CreateTestCaseTestStepsParams.and(CreateTestCaseTestStepsBody),

--- a/src/zephyr/tool/test-case/create-test-steps.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.ts
@@ -12,8 +12,9 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
   specification: ToolParams = {
     title: "Create Test Case Steps",
     summary:
-      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones.",
+      "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: `APPEND` adds steps to the end of the existing list, `OVERWRITE` deletes all existing steps and replaces them with the provided ones. Always ask the user to choose between OVERWRITE or APPEND before calling this tool.",
     readOnly: false,
+    destructive: true,
     idempotent: false,
     inputSchema: CreateTestCaseTestStepsParams.and(CreateTestCaseTestStepsBody),
     outputSchema: createTestCaseTestStepsResponse,


### PR DESCRIPTION
## Summary
- Improved `CreateTestSteps` tool summary to guide LLM to ask users about `APPEND` vs `OVERWRITE` mode before calling the tool
- Removed `.partial()` from `CreateTestCaseTestStepsBody` schema — body fields should be required, not optional
- Marked tool as `destructive: true` to force client confirmation before execution

## Test plan
- [x] Unit test updated to match new summary
- [ ] Verify MCP tool description shows updated guidance in client
- [ ] Test APPEND and OVERWRITE modes work correctly

## Example
<img width="939" height="619" alt="image" src="https://github.com/user-attachments/assets/4a8c3c07-f622-4f11-b189-885ab24a6fdb" />

<img width="942" height="610" alt="image" src="https://github.com/user-attachments/assets/b08049e4-9158-4658-8aeb-3a8217a5f94f" />

