### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0] - 2026-04-10
 
+### Added
+
+- [Common] Added OAuth token support for HTTP transport clients. [#330](https://github.com/SmartBear/smartbear-mcp/pull/330)
+
 ### Changed
 
 - [Portal] Adjusted internal script to recent changes in Portal's API [#404](https://github.com/SmartBear/smartbear-mcp/pull/404)
+
 ## [0.17.1] - 2026-04-09
 
 ### Added
@@ -24,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Zephyr] Added a tool `update-test-steps` for updating test execution test steps [#386](https://github.com/SmartBear/smartbear-mcp/pull/386)
-- [Common] Added OAuth token support for HTTP transport clients. [#330](https://github.com/SmartBear/smartbear-mcp/pull/330)
 - [BugSnag] Added "Get Events on an Error" tool for listing the events that have grouped into a specified error [#406](https://github.com/SmartBear/smartbear-mcp/pull/406)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.0] - 2026-04-10
+
 ### Changed
 
 - [Portal] Adjusted internal script to recent changes in Portal's API [#404](https://github.com/SmartBear/smartbear-mcp/pull/404)

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: ghcr.io/smartbear/smartbear-mcp:v0.17.1
+          image: ghcr.io/smartbear/smartbear-mcp:v0.18.0
           env:
             - name: MCP_TRANSPORT
               value: "http"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
## [0.18.0] - 2026-04-10

### Added

- [Common] Added OAuth token support for HTTP transport clients. [#330](https://github.com/SmartBear/smartbear-mcp/pull/330)

### Changed

- [Portal] Adjusted internal script to recent changes in Portal's API [#404](https://github.com/SmartBear/smartbear-mcp/pull/404)