### PR TITLE
fix: configuring clients in stdio excessively, reverts configschema for authtokens

### DIFF
--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -71,7 +71,7 @@ interface StabilityData {
 }
 
 const ConfigurationSchema = z.object({
-  auth_token: z.string().describe("BugSnag personal access token").optional(),
+  auth_token: z.string().describe("BugSnag personal access token"),
   project_api_key: z.string().describe("BugSnag project API key").optional(),
   endpoint: z.string().url().describe("BugSnag endpoint URL").optional(),
 });

--- a/src/common/client-registry.ts
+++ b/src/common/client-registry.ts
@@ -110,6 +110,7 @@ class ClientRegistry {
   async configure(
     server: SmartBearMcpServer,
     getConfigValue: (client: Client, key: string) => string | null,
+    ignoreMissingRequiredConfigs = false,
   ): Promise<number> {
     let configuredCount = 0;
     entryLoop: for (const entry of this.getAll()) {
@@ -120,7 +121,10 @@ class ClientRegistry {
           // validate if a config option is an Allowed Endpoint URL
           this.validateAllowedEndpoint(entry.config.shape[configKey], value);
           config[configKey] = value;
-        } else if (!isOptionalType(entry.config.shape[configKey])) {
+        } else if (
+          !ignoreMissingRequiredConfigs &&
+          !isOptionalType(entry.config.shape[configKey])
+        ) {
           continue entryLoop; // Skip configuring this client - missing required config
         }
       }

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -502,20 +502,24 @@ export async function newServer(
     // Run configuration within request context so that client getAuthToken()
     // methods can access request headers via AsyncLocalStorage
     const configuredCount = await withRequestContext(req, () =>
-      clientRegistry.configure(server, (client, key) => {
-        const headerName = getHeaderName(client, key);
-        // Check both original case and lower-case headers for compatibility
-        // (HTTP headers are case-insensitive, but Node.js lowercases them)
-        const value =
-          req.headers[headerName] || req.headers[headerName.toLowerCase()];
-        if (typeof value === "string") {
-          return value;
-        }
+      clientRegistry.configure(
+        server,
+        (client, key) => {
+          const headerName = getHeaderName(client, key);
+          // Check both original case and lower-case headers for compatibility
+          // (HTTP headers are case-insensitive, but Node.js lowercases them)
+          const value =
+            req.headers[headerName] || req.headers[headerName.toLowerCase()];
+          if (typeof value === "string") {
+            return value;
+          }
 
-        // Fall back to environment variable if header is not present
-        const envVarName = getEnvVarName(client, key);
-        return process.env[envVarName] || null;
-      }),
+          // Fall back to environment variable if header is not present
+          const envVarName = getEnvVarName(client, key);
+          return process.env[envVarName] || null;
+        },
+        true, // ignoreMissingRequiredConfigs
+      ),
     );
 
     console.log(

--- a/src/qmetry/client.ts
+++ b/src/qmetry/client.ts
@@ -15,7 +15,7 @@ import { TOOLS } from "./client/tools/index";
 import { QMETRY_DEFAULTS } from "./config/constants";
 
 const ConfigurationSchema = z.object({
-  api_key: z.string().describe("QMetry API key for authentication").optional(),
+  api_key: z.string().describe("QMetry API key for authentication"),
   base_url: z
     .string()
     .url()

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -30,7 +30,7 @@ import type { TestPlatform } from "./types/common";
 import type { WebSocketManager } from "./websocket-manager";
 
 const ConfigurationSchema = z.object({
-  api_token: z.string().describe("Reflect API authentication token").optional(),
+  api_token: z.string().describe("Reflect API authentication token"),
 });
 
 // ReflectClient class implementing the Client interface

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -53,7 +53,7 @@ import type {
 } from "./client/user-management-types";
 
 const ConfigurationSchema = z.object({
-  api_key: z.string().describe("Swagger API key for authentication").optional(),
+  api_key: z.string().describe("Swagger API key for authentication"),
   portal_base_path: z
     .string()
     .optional()

--- a/src/tests/unit/common/client-registry.test.ts
+++ b/src/tests/unit/common/client-registry.test.ts
@@ -81,7 +81,7 @@ describe("ClientRegistry", () => {
       ).resolves.toBe(1);
     });
 
-    it("skips clients missing required config", async () => {
+    it("skips clients missing required config by default (stdio mode)", async () => {
       const clientA = createMockClient(
         "client-a",
         z.object({ keyA: z.string() }),
@@ -90,6 +90,7 @@ describe("ClientRegistry", () => {
       await expect(
         clientRegistry.configure(mockServer, (_, __) => null),
       ).resolves.toBe(0);
+      expect(clientA.configure).not.toHaveBeenCalled();
     });
 
     it("doesn't skip clients missing optional config", async () => {
@@ -101,6 +102,55 @@ describe("ClientRegistry", () => {
       await expect(
         clientRegistry.configure(mockServer, (_, __) => null),
       ).resolves.toBe(1);
+      expect(clientA.configure).toHaveBeenCalled();
+    });
+
+    it("configures clients missing required config when ignoreMissingRequiredConfigs is true (http mode)", async () => {
+      const clientA = createMockClient(
+        "client-a",
+        z.object({ keyA: z.string() }),
+      );
+      clientRegistry.register(clientA);
+      await expect(
+        clientRegistry.configure(mockServer, (_, __) => null, true),
+      ).resolves.toBe(1);
+      expect(clientA.configure).toHaveBeenCalledWith(mockServer, {});
+    });
+
+    it("configures multiple clients missing required config when ignoreMissingRequiredConfigs is true", async () => {
+      const clientA = createMockClient(
+        "client-a",
+        z.object({ keyA: z.string() }),
+      );
+      const clientB = createMockClient(
+        "client-b",
+        z.object({ keyB: z.string() }),
+      );
+      clientRegistry.register(clientA);
+      clientRegistry.register(clientB);
+      await expect(
+        clientRegistry.configure(mockServer, (_, __) => null, true),
+      ).resolves.toBe(2);
+      expect(clientA.configure).toHaveBeenCalledWith(mockServer, {});
+      expect(clientB.configure).toHaveBeenCalledWith(mockServer, {});
+    });
+
+    it("skips multiple clients missing required config when ignoreMissingRequiredConfigs is false", async () => {
+      const clientA = createMockClient(
+        "client-a",
+        z.object({ keyA: z.string() }),
+      );
+      const clientB = createMockClient(
+        "client-b",
+        z.object({ keyB: z.string() }),
+      );
+      clientRegistry.register(clientA);
+      clientRegistry.register(clientB);
+      await expect(
+        clientRegistry.configure(mockServer, (_, __) => null, false),
+      ).resolves.toBe(0);
+      expect(clientA.configure).not.toHaveBeenCalled();
+      expect(clientB.configure).not.toHaveBeenCalled();
     });
   });
 

--- a/src/zephyr/client.ts
+++ b/src/zephyr/client.ts
@@ -46,10 +46,7 @@ import { UpdateTestExecutionSteps } from "./tool/test-execution/update-test-step
 const BASE_URL_DEFAULT = "https://api.zephyrscale.smartbear.com/v2";
 
 const ConfigurationSchema = z.object({
-  api_token: z
-    .string()
-    .describe("Zephyr Scale API token for authentication")
-    .optional(),
+  api_token: z.string().describe("Zephyr Scale API token for authentication"),
   base_url: z
     .string()
     .url()


### PR DESCRIPTION
## Goal
Ensures we arent configuring all clients in stdio mode when configuration is not passed for the client

## Design

reverts some of the changes made when adding oauth support

## Changeset

makes any required token mandatory for stdio

## Testing

locally with vscode to check only configured clients has tools registered
