### PR TITLE
release: v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.1] - 2026-04-13
 
+### Fixed
+
+- [Common] Fixed an issue with configuring clients excessively when using stdio transport, only configure clients that have authentication provided [#421](https://github.com/SmartBear/smartbear-mcp/pull/421)
+
 ## [0.18.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1] - 2026-04-13
+
 ## [0.18.0] - 2026-04-10
 
 ### Added

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: ghcr.io/smartbear/smartbear-mcp:v0.18.0
+          image: ghcr.io/smartbear/smartbear-mcp:v0.18.1
           env:
             - name: MCP_TRANSPORT
               value: "http"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
## [0.18.1] - 2026-04-13

### Fixed

- [Common] Fixed an issue with configuring clients excessively when using stdio transport, only configure clients that have authentication provided [#421](https://github.com/SmartBear/smartbear-mcp/pull/421)
