### PR TITLE
feat: Add ability to create a new version via Standardize API tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [Swagger] Added optional `newVersion` parameter to the `standardize_api` tool to save the fixed API definition as a new version instead of overwriting the current one
+
 ## [0.18.3] - 2026-04-16
 
 ### Added

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -868,23 +868,25 @@ export class SwaggerAPI {
 
   /**
    * Standardize and fix an API definition using AI
-   * @param params Parameters including owner, API name, and version
+   * @param params Parameters including owner, API name, version, and optional newVersion
    * @returns Standardization response with status and fixed definition
    */
   async standardizeApi(
     params: StandardizeApiParams,
   ): Promise<StandardizeApiResponse> {
+    const searchParams = new URLSearchParams();
+    if (params.newVersion) searchParams.set("newVersion", params.newVersion);
+    const queryString = searchParams.toString();
     const url = `${this.config.registryBasePath}/apis/${encodeURIComponent(
       params.owner,
     )}/${encodeURIComponent(params.api)}/${encodeURIComponent(
       params.version,
-    )}/standardize`;
+    )}/standardize${queryString ? `?${queryString}` : ""}`;
 
     const response = await fetch(url, {
       method: "POST",
       headers: this.headers,
     });
-
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
       throw new ToolError(

--- a/src/swagger/client/registry-types.ts
+++ b/src/swagger/client/registry-types.ts
@@ -115,6 +115,12 @@ export const StandardizeApiParamsSchema = z.object({
     .describe("API owner (organization or user, case-sensitive)"),
   api: z.string().describe("API name (case-sensitive)"),
   version: z.string().describe("Version identifier"),
+  newVersion: z
+    .string()
+    .optional()
+    .describe(
+      "The version to save the fixed definition as (e.g. '1.0.1'). Omitting this will overwrite the current version — prefer providing a patch bump (e.g. '1.0.0' → '1.0.1') unless the user specifies otherwise.",
+    ),
 });
 
 // Registry API types for SwaggerHub Design functionality - generated from Zod schemas
@@ -201,6 +207,7 @@ export interface StandardizeApiResponse {
   message: string;
   errorsFound: number;
   fixedDefinition?: string;
+  savedVersion?: string;
   errors?: Array<{
     description: string;
     line?: number;

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -192,7 +192,7 @@ export const TOOLS: SwaggerToolParams[] = [
   {
     title: "Standardize API",
     summary:
-      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. If errors are found, they will be sent to SmartBear AI to generate a corrected definition, which is then saved back to the registry. Returns the number of errors found and the fixed definition if successful. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
+      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found and the fixed definition if successful. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
     inputSchema: StandardizeApiParamsSchema,
     handler: "standardizeApi",
   },


### PR DESCRIPTION
This pull request enhances the API standardization workflow by allowing users to optionally save a fixed API definition as a new version rather than overwriting the existing one. It introduces a new parameter, updates the type definitions and documentation, and improves the tool description for clarity.

**API Standardization Versioning Enhancements:**

* Added an optional `newVersion` parameter to the `standardizeApi` method in `SwaggerAPI`, allowing users to specify a new version for saving the fixed API definition. If omitted, the current version will be overwritten. (`src/swagger/client/api.ts`)

**Documentation and Tooling Improvements:**

* Improved the summary for the "Standardize API" tool to document the new `newVersion` parameter and clarify its usage, including the default behavior of overwriting the current version if not provided. (`src/swagger/client/tools.ts`)