### PR TITLE
[PIPE-9519] add support for commenting on an error

### DIFF
--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -23,7 +23,9 @@ import type {
 } from "./client/api/index";
 import { ProjectAPI } from "./client/api/Project";
 import type { FilterObject } from "./client/filters";
+import { CreateErrorComment } from "./tool/error/create-error-comment";
 import { GetError } from "./tool/error/get-error";
+import { ListErrorComments } from "./tool/error/list-error-comments";
 import { ListProjectErrors } from "./tool/error/list-project-errors";
 import { UpdateError } from "./tool/error/update-error";
 import { GetEvent } from "./tool/event/get-event";
@@ -437,6 +439,8 @@ export class BugsnagClient implements Client {
       new GetError(this),
       new ListProjectErrors(this),
       new UpdateError(this, getInput),
+      new ListErrorComments(this),
+      new CreateErrorComment(this),
       new GetEvent(this),
       new GetEventDetailsFromDashboardUrl(this),
       new ListErrorEvents(this),

--- a/src/bugsnag/client/api/Error.ts
+++ b/src/bugsnag/client/api/Error.ts
@@ -8,6 +8,19 @@ import {
   type PivotApiView,
 } from "./index";
 
+export interface CommentApiView {
+  id: string;
+  message: string;
+  created_at: string;
+  updated_at: string;
+  url: string;
+  collaborator?: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
 export class ErrorAPI extends BaseAPI {
   static filterFields: string[] = ["url", "project_url", "events_url"];
 
@@ -223,6 +236,39 @@ export class ErrorAPI extends BaseAPI {
       localVarFetchArgs.url,
       localVarFetchArgs.options,
     );
+  }
+
+  /**
+   * List Comments on an Error
+   * GET /projects/{project_id}/errors/{error_id}/comments
+   */
+  async listErrorComments(
+    projectId: string,
+    errorId: string,
+  ): Promise<ApiResponse<CommentApiView[]>> {
+    const path = `/projects/${projectId}/errors/${errorId}/comments`;
+    return await this.requestArray<CommentApiView>(
+      path,
+      { headers: this.resolveAuthHeader() },
+      false,
+    );
+  }
+
+  /**
+   * Create a Comment on an Error
+   * POST /projects/{project_id}/errors/{error_id}/comments
+   */
+  async createErrorComment(
+    projectId: string,
+    errorId: string,
+    message: string,
+  ): Promise<ApiResponse<CommentApiView>> {
+    const path = `/projects/${projectId}/errors/${errorId}/comments`;
+    return await this.requestObject<CommentApiView>(path, {
+      method: "POST",
+      body: JSON.stringify({ message }),
+      headers: this.resolveAuthHeader(),
+    });
   }
 
   /**

--- a/src/bugsnag/client/api/base.ts
+++ b/src/bugsnag/client/api/base.ts
@@ -85,6 +85,15 @@ export class BaseAPI {
     this.filterFields = filterFields || [];
   }
 
+  protected resolveAuthHeader(): Record<string, string> {
+    if (!this.configuration.apiKey) return {};
+    const value =
+      typeof this.configuration.apiKey === "function"
+        ? this.configuration.apiKey("Authorization")
+        : this.configuration.apiKey;
+    return { Authorization: value };
+  }
+
   async requestObject<T extends Record<string, any>>(
     url: string,
     options: Record<string, any> = {},

--- a/src/bugsnag/tool/error/create-error-comment.ts
+++ b/src/bugsnag/tool/error/create-error-comment.ts
@@ -1,0 +1,75 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
+import { Tool, ToolError } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { BugsnagClient } from "../../client";
+import { toolInputParameters } from "../../input-schemas";
+
+const inputSchema = z.object({
+  projectId: toolInputParameters.projectId,
+  errorId: toolInputParameters.errorId.describe(
+    "Unique identifier of the error to add a comment to",
+  ),
+  message: z
+    .string()
+    .min(1)
+    .describe("The comment message to add to the error"),
+});
+
+// Adds a comment to an error to record notes, decisions, or context.
+export class CreateErrorComment extends Tool<BugsnagClient> {
+  specification: ToolParams = {
+    title: "Create Error Comment",
+    summary: "Add a comment to an error",
+    purpose:
+      "Record notes, decisions, or context on an error to communicate with the team and build a discussion thread",
+    useCases: [
+      "Add investigation notes to an error being actively debugged",
+      "Record a decision about how to handle or prioritize an error",
+      "Leave context for teammates about the root cause or a workaround",
+      "Document when a fix was deployed or an incident was resolved",
+    ],
+    inputSchema,
+    outputDescription:
+      "JSON object containing the created comment with: id, message, created_at, updated_at, and user details",
+    examples: [
+      {
+        description: "Add an investigation note to an error",
+        parameters: {
+          errorId: "6863e2af8c857c0a5023b411",
+          message:
+            "This appears to be caused by a null user session on the checkout page. Fix deployed in v2.3.1.",
+        },
+        expectedOutput:
+          "JSON object with the created comment including its id and timestamps",
+      },
+    ],
+    hints: [
+      "Error IDs can be found using the List Project Errors tool",
+      "Use List Error Comments to read existing comments before adding a new one",
+      "Comments cannot be edited or deleted via this MCP server - be precise in your message",
+    ],
+    readOnly: false,
+    idempotent: false,
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+    const params = inputSchema.parse(args);
+    const project = await this.client.getInputProject(params.projectId);
+
+    const response = await this.client.errorsApi.createErrorComment(
+      project.id,
+      params.errorId,
+      params.message,
+    );
+
+    if (!response.body) {
+      throw new ToolError("Failed to create comment: no response body returned");
+    }
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(response.body) }],
+    };
+  };
+}

--- a/src/bugsnag/tool/error/list-error-comments.ts
+++ b/src/bugsnag/tool/error/list-error-comments.ts
@@ -1,0 +1,73 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { BugsnagClient } from "../../client";
+import { toolInputParameters } from "../../input-schemas";
+
+const inputSchema = z.object({
+  projectId: toolInputParameters.projectId,
+  errorId: toolInputParameters.errorId.describe(
+    "Unique identifier of the error to list comments for",
+  ),
+});
+
+// Lists all comments on a specific error.
+export class ListErrorComments extends Tool<BugsnagClient> {
+  specification: ToolParams = {
+    title: "List Error Comments",
+    summary: "List all comments that have been added to a specific error",
+    purpose:
+      "Retrieve the discussion thread on an error to understand context, decisions, and team communication around an issue",
+    useCases: [
+      "Review team notes and context added to an error during investigation",
+      "Check whether an error has already been acknowledged or assigned",
+      "Read decisions made about how to handle or prioritize an error",
+    ],
+    inputSchema,
+    outputDescription:
+      "JSON object containing: " +
+      " - data: Array of comment objects, each with id, message, created_at, updated_at, url, and collaborator details (id, name, email)" +
+      " - count: Number of comments returned",
+    examples: [
+      {
+        description: "List all comments on an error",
+        parameters: {
+          errorId: "6863e2af8c857c0a5023b411",
+        },
+        expectedOutput:
+          "JSON object with a list of comments in the 'data' field and a count of results",
+      },
+    ],
+    hints: [
+      "Error IDs can be found using the List Project Errors tool",
+      "Comments are returned in chronological order",
+      "Use Create Error Comment to add a new comment to an error",
+    ],
+    readOnly: true,
+    idempotent: true,
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+    const params = inputSchema.parse(args);
+    const project = await this.client.getInputProject(params.projectId);
+
+    const response = await this.client.errorsApi.listErrorComments(
+      project.id,
+      params.errorId,
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            data: response.body,
+            count: response.body?.length ?? 0,
+          }),
+        },
+      ],
+    };
+  };
+}

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -904,7 +904,9 @@ describe("BugsnagClient", () => {
       expect(registeredTools).toContain("List Trace Fields");
       expect(registeredTools).toContain("Get Network Endpoint Groupings");
       expect(registeredTools).toContain("Set Network Endpoint Groupings");
-      expect(registeredTools.length).toBe(19);
+      expect(registeredTools).toContain("List Error Comments");
+      expect(registeredTools).toContain("Create Error Comment");
+      expect(registeredTools.length).toBe(21);
     });
   });
 


### PR DESCRIPTION
## Goal

This adds MCP tools to list and create comments on errors, allowing AI assistants to read team discussion threads and contribute notes during investigation.

## Design

Two new tools are added following the existing tool pattern:

- **List Error Comments** — `GET /projects/{project_id}/errors/{error_id}/comments` — reads all comments on an error, returning each comment's message, timestamp, permalink, and collaborator details.
- **Create Error Comment** — `POST /projects/{project_id}/errors/{error_id}/comments` — posts a new comment on an error with a required `message` field.

A `CommentApiView` type is defined in `ErrorAPI` to match the API response schema (including the `collaborator` object and comment `url`). A `resolveAuthHeader()` helper is added to `BaseAPI` to correctly inject the `Authorization` header for direct HTTP calls that bypass the generated API client code.

## Changeset

- `src/bugsnag/client/api/Error.ts` — adds `CommentApiView` interface, `listErrorComments()` and `createErrorComment()` methods
- `src/bugsnag/client/api/base.ts` — adds `resolveAuthHeader()` helper to `BaseAPI`
- `src/bugsnag/tool/error/list-error-comments.ts` — new read-only tool
- `src/bugsnag/tool/error/create-error-comment.ts` — new write tool
- `src/bugsnag/client.ts` — registers both new tools
- `src/tests/unit/bugsnag/client.test.ts` — updates tool registration assertions

## Testing

Tested manually against a live Bugsnag error ([`62741ed878f00500081b9dcb`](https://app.bugsnag.com/bugsnag/event-service/errors/62741ed878f00500081b9dcb#comments)) using a local build of the MCP server. Both listing existing comments and creating new ones returned the expected responses.

Unit tests updated and passing (`npm run test:run`).