### PR TITLE
[Reflect] RF-4313: Updated get-screenshot tool with jpeg format support and added oauth for some mcp tools.

### DIFF
--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -88,14 +88,36 @@ export class ReflectClient implements Client {
     return this.getAuthToken() || "";
   }
 
-  getHeaders(): Record<string, string> {
+  isOAuthRequest(): boolean {
+    if (
+      getRequestHeader("Reflect-Api-Token") ||
+      getRequestHeader("X-API-KEY")
+    ) {
+      return false;
+    }
+    const authHeader = getRequestHeader("Authorization");
+    return (
+      !!authHeader &&
+      (Array.isArray(authHeader) ? authHeader[0] : authHeader).startsWith(
+        "Bearer ",
+      )
+    );
+  }
+
+  getAuthHeader(): Record<string, string> {
     const token = this.getAuthToken();
     if (!token) {
       throw new Error("Reflect API token not found");
     }
+    if (this.isOAuthRequest()) {
+      return { Authorization: `Bearer ${token}` };
+    }
+    return { [API_KEY_HEADER]: token };
+  }
 
+  getHeaders(): Record<string, string> {
     return {
-      [API_KEY_HEADER]: token,
+      ...this.getAuthHeader(),
       "Content-Type": "application/json",
       "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
     };

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -10,7 +10,11 @@ import type {
   RegisterPromptFunction,
   RegisterToolsFunction,
 } from "../common/types";
-import { API_KEY_HEADER } from "./config/constants";
+import {
+  API_KEY_HEADER,
+  AUTHORIZATION_HEADER,
+  REFLECT_API_TOKEN_HEADER,
+} from "./config/constants";
 import { SapTest } from "./prompt/sap-test";
 import { AddPromptStep } from "./tool/recording/add-prompt-step";
 import { AddSegment } from "./tool/recording/add-segment";
@@ -60,9 +64,9 @@ export class ReflectClient implements Client {
   getAuthToken(): string | null {
     // 1. Try request context
     const contextHeader =
-      getRequestHeader("Reflect-Api-Token") ||
-      getRequestHeader("X-API-KEY") ||
-      getRequestHeader("Authorization");
+      getRequestHeader(REFLECT_API_TOKEN_HEADER) ||
+      getRequestHeader(API_KEY_HEADER) ||
+      getRequestHeader(AUTHORIZATION_HEADER);
 
     if (contextHeader) {
       let token = Array.isArray(contextHeader)
@@ -84,24 +88,19 @@ export class ReflectClient implements Client {
     return true; // Configured by default to support dynamic OAuth tokens
   }
 
-  getApiToken(): string {
-    return this.getAuthToken() || "";
-  }
-
   isOAuthRequest(): boolean {
     if (
-      getRequestHeader("Reflect-Api-Token") ||
-      getRequestHeader("X-API-KEY")
+      getRequestHeader(REFLECT_API_TOKEN_HEADER) ||
+      getRequestHeader(API_KEY_HEADER)
     ) {
       return false;
     }
-    const authHeader = getRequestHeader("Authorization");
-    return (
-      !!authHeader &&
-      (Array.isArray(authHeader) ? authHeader[0] : authHeader).startsWith(
-        "Bearer ",
-      )
-    );
+    const authHeader = getRequestHeader(AUTHORIZATION_HEADER);
+    if (!authHeader) {
+      return false;
+    }
+    const headerValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+    return headerValue.toLowerCase().startsWith("bearer ");
   }
 
   getAuthHeader(): Record<string, string> {
@@ -178,7 +177,8 @@ export class ReflectClient implements Client {
     register: RegisterToolsFunction,
     _getInput: GetInputFunction,
   ): Promise<void> {
-    const tools = [
+    // Only available for API key authentication
+    const apiOnlyTools = [
       new ListSuites(this),
       new ListSuiteExecutions(this),
       new GetSuiteExecutionStatus(this),
@@ -187,6 +187,10 @@ export class ReflectClient implements Client {
       new ListTests(this),
       new RunTest(this),
       new GetTestStatus(this),
+    ];
+
+    // Available for both OAuth and API key authentication
+    const oAuthAndAPISupportedTools = [
       new ListSegments(this),
       new ConnectToSession(this),
       new AddPromptStep(this),
@@ -194,6 +198,10 @@ export class ReflectClient implements Client {
       new DeletePreviousStep(this),
       new AddSegment(this),
     ];
+
+    const tools = this.isOAuthRequest()
+      ? oAuthAndAPISupportedTools
+      : [...oAuthAndAPISupportedTools, ...apiOnlyTools];
 
     for (const tool of tools) {
       register(tool.specification, tool.handle);

--- a/src/reflect/config/constants.ts
+++ b/src/reflect/config/constants.ts
@@ -1,4 +1,6 @@
 export const API_KEY_HEADER = "X-API-KEY";
+export const REFLECT_API_TOKEN_HEADER = "Reflect-Api-Token";
+export const AUTHORIZATION_HEADER = "Authorization";
 export const API_HOSTNAME = "api.reflect.run";
 export const WEBSOCKET_HOSTNAME = "recording.us-east-1.reflect.run";
 export const WEB_APP_HOSTNAME = "app.reflect.run";

--- a/src/reflect/config/constants.ts
+++ b/src/reflect/config/constants.ts
@@ -1,3 +1,4 @@
 export const API_KEY_HEADER = "X-API-KEY";
 export const API_HOSTNAME = "api.reflect.run";
 export const WEBSOCKET_HOSTNAME = "recording.us-east-1.reflect.run";
+export const WEB_APP_HOSTNAME = "app.reflect.run";

--- a/src/reflect/tool/recording/connect-to-session.ts
+++ b/src/reflect/tool/recording/connect-to-session.ts
@@ -52,7 +52,7 @@ export class ConnectToSession extends Tool<ReflectClient> {
 
     const wsManager = new WebSocketManager(
       sessionId,
-      this.client.getApiToken(),
+      this.client.getAuthHeader(),
     );
 
     try {

--- a/src/reflect/tool/recording/get-screenshot.ts
+++ b/src/reflect/tool/recording/get-screenshot.ts
@@ -21,19 +21,30 @@ export class GetScreenshot extends Tool<ReflectClient> {
         description: "The ID of the Reflect recording session",
         required: true,
       },
+      {
+        name: "format",
+        type: z.enum(["png", "jpeg"]),
+        description: "The image format for the screenshot (png or jpeg)",
+        required: false,
+      },
     ],
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
-    const { sessionId } = args as { sessionId: string };
+    const { sessionId, format } = args as {
+      sessionId: string;
+      format?: "png" | "jpeg";
+    };
     if (!sessionId) throw new ToolError("sessionId argument is required");
 
+    const imageFormat = format ?? "png";
     const wsManager = this.client.getConnectedSession(sessionId);
 
     const id = randomUUID();
     const responsePromise = wsManager.waitForResponse(id);
     await wsManager.sendMcpMessage({
       type: "mcp:get-screenshot",
+      format: imageFormat,
       id,
     });
 
@@ -49,7 +60,7 @@ export class GetScreenshot extends Tool<ReflectClient> {
         {
           type: "image",
           data: imageBase64,
-          mimeType: "image/png",
+          mimeType: `image/${imageFormat}`,
         },
         {
           type: "text",
@@ -57,6 +68,7 @@ export class GetScreenshot extends Tool<ReflectClient> {
             success: true,
             message: "Screenshot captured",
             state,
+            format: imageFormat,
           }),
         },
       ],

--- a/src/reflect/tool/tests/list-segments.ts
+++ b/src/reflect/tool/tests/list-segments.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { Tool, ToolError } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
-import { API_HOSTNAME, API_KEY_HEADER } from "../../config/constants";
+import { API_HOSTNAME, WEB_APP_HOSTNAME } from "../../config/constants";
 import type { TestPlatform } from "../../types/common";
 
 export class ListSegments extends Tool<ReflectClient> {
@@ -47,13 +47,13 @@ export class ListSegments extends Tool<ReflectClient> {
       limit?: number;
     };
 
-    const url = `https://${API_HOSTNAME}/v1/segments?type=${platform}&offset=${offset}&limit=${limit}`;
+    const urlPath = this.client.isOAuthRequest()
+      ? `https://${WEB_APP_HOSTNAME}/api/mcp`
+      : `https://${API_HOSTNAME}/v1`;
+    const url = `${urlPath}/segments?type=${platform}&offset=${offset}&limit=${limit}`;
     const response = await fetch(url, {
       method: "GET",
-      headers: {
-        [API_KEY_HEADER]: this.client.getApiToken(),
-        "Content-Type": "application/json",
-      },
+      headers: this.client.getHeaders(),
     });
 
     if (!response.ok) {

--- a/src/reflect/types/mcp.ts
+++ b/src/reflect/types/mcp.ts
@@ -28,6 +28,7 @@ export interface MCPDeleteStepMessage {
 
 export interface MCPGetScreenshotMessage {
   type: "mcp:get-screenshot";
+  format: "png" | "jpeg";
   id: string;
 }
 

--- a/src/reflect/websocket-manager.ts
+++ b/src/reflect/websocket-manager.ts
@@ -4,7 +4,7 @@
  */
 
 import WebSocket from "ws";
-import { API_KEY_HEADER, WEBSOCKET_HOSTNAME } from "./config/constants";
+import { WEBSOCKET_HOSTNAME } from "./config/constants";
 import type { MCPMessage } from "./types/mcp";
 
 interface PendingResponse {
@@ -14,13 +14,13 @@ interface PendingResponse {
 
 export class WebSocketManager {
   private sessionId: string;
-  private apiKey: string;
+  private authHeader: Record<string, string>;
   private mcpSocket: WebSocket | null = null;
   private pendingResponses: Map<string, PendingResponse> = new Map();
 
-  constructor(sessionId: string, apiKey: string) {
+  constructor(sessionId: string, authHeader: Record<string, string>) {
     this.sessionId = sessionId;
-    this.apiKey = apiKey;
+    this.authHeader = authHeader;
   }
 
   async connect(): Promise<void> {
@@ -39,10 +39,9 @@ export class WebSocketManager {
   private async connectMcpSocket(): Promise<void> {
     return new Promise((resolve, reject) => {
       const url = `wss://${WEBSOCKET_HOSTNAME}/websocket/v2/recordings/${this.sessionId}/topics/mcp?sid=${this.sessionId}`;
-
       this.mcpSocket = new WebSocket(url, {
         headers: {
-          [API_KEY_HEADER]: this.apiKey,
+          ...this.authHeader,
         },
       });
 

--- a/src/tests/unit/reflect/client.test.ts
+++ b/src/tests/unit/reflect/client.test.ts
@@ -18,11 +18,6 @@ describe("ReflectClient", () => {
     expect(client.isConfigured()).toBe(true);
   });
 
-  it("should expose api token after configure()", async () => {
-    await client.configure({} as any, { api_token: "my-api-key" });
-    expect(client.getApiToken()).toBe("my-api-key");
-  });
-
   it("should return undefined for unregistered session state", () => {
     expect(client.getSessionState("unknown-session")).toBeUndefined();
   });
@@ -52,6 +47,14 @@ describe("ReflectClient", () => {
     it("should return true when Authorization header starts with Bearer", () => {
       const result = requestContextStorage.run(
         { headers: { Authorization: "Bearer oauth-token" } },
+        () => client.isOAuthRequest(),
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return true when authorization header uses lowercase bearer scheme", () => {
+      const result = requestContextStorage.run(
+        { headers: { authorization: "bearer oauth-token" } },
         () => client.isOAuthRequest(),
       );
       expect(result).toBe(true);

--- a/src/tests/unit/reflect/client.test.ts
+++ b/src/tests/unit/reflect/client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestContextStorage } from "../../../common/request-context";
 import { ReflectClient } from "../../../reflect/client";
 
 describe("ReflectClient", () => {
@@ -45,5 +46,77 @@ describe("ReflectClient", () => {
 
   it("should have correct config prefix", () => {
     expect(client.configPrefix).toBe("Reflect");
+  });
+
+  describe("isOAuthRequest", () => {
+    it("should return true when Authorization header starts with Bearer", () => {
+      const result = requestContextStorage.run(
+        { headers: { Authorization: "Bearer oauth-token" } },
+        () => client.isOAuthRequest(),
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no Authorization header", () => {
+      const result = requestContextStorage.run({ headers: {} }, () =>
+        client.isOAuthRequest(),
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false when Authorization header does not start with Bearer", () => {
+      const result = requestContextStorage.run(
+        { headers: { Authorization: "Basic abc123" } },
+        () => client.isOAuthRequest(),
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false when Reflect-Api-Token is present alongside Authorization Bearer", () => {
+      const result = requestContextStorage.run(
+        {
+          headers: {
+            "Reflect-Api-Token": "my-api-token",
+            Authorization: "Bearer oauth-token",
+          },
+        },
+        () => client.isOAuthRequest(),
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getAuthHeader", () => {
+    it("should return Authorization Bearer header for OAuth request", () => {
+      const result = requestContextStorage.run(
+        { headers: { Authorization: "Bearer oauth-token" } },
+        () => client.getAuthHeader(),
+      );
+      expect(result).toEqual({ Authorization: "Bearer oauth-token" });
+    });
+
+    it("should return X-API-KEY header when using API key header", () => {
+      const result = requestContextStorage.run(
+        { headers: { "X-API-KEY": "my-api-key" } },
+        () => client.getAuthHeader(),
+      );
+      expect(result).toEqual({ "X-API-KEY": "my-api-key" });
+    });
+
+    it("should return X-API-KEY header when falling back to configured token", async () => {
+      await client.configure({} as any, { api_token: "configured-token" });
+      const result = requestContextStorage.run({ headers: {} }, () =>
+        client.getAuthHeader(),
+      );
+      expect(result).toEqual({ "X-API-KEY": "configured-token" });
+    });
+
+    it("should throw when no token is available", () => {
+      expect(() =>
+        requestContextStorage.run({ headers: {} }, () =>
+          client.getAuthHeader(),
+        ),
+      ).toThrow("Reflect API token not found");
+    });
   });
 });

--- a/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
+++ b/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
@@ -32,7 +32,7 @@ describe("ConnectToSession", () => {
       isSessionConnected: vi.fn().mockReturnValue(false),
       getSessionState: vi.fn().mockReturnValue(undefined),
       getWebSocketManager: vi.fn().mockReturnValue(undefined),
-      getApiToken: vi.fn().mockReturnValue("test-api-key"),
+      getAuthHeader: vi.fn().mockReturnValue({ "X-API-KEY": "test-api-key" }),
       registerConnection: vi.fn(),
     };
 

--- a/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
+++ b/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
@@ -108,4 +108,18 @@ describe("GetScreenshot", () => {
     const parsed = JSON.parse((result.content[1] as any).text);
     expect(parsed.format).toBe("jpeg");
   });
+
+  it("should use png format when format is png", async () => {
+    const result = await instance.handle(
+      { sessionId: "sess-1", format: "png" },
+      {},
+    );
+
+    expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mcp:get-screenshot", format: "png" }),
+    );
+    expect((result.content[0] as any).mimeType).toBe("image/png");
+    const parsed = JSON.parse((result.content[1] as any).text);
+    expect(parsed.format).toBe("png");
+  });
 });

--- a/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
+++ b/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
@@ -28,8 +28,10 @@ describe("GetScreenshot", () => {
     expect(instance.specification.title).toBe("Get Screenshot");
     expect(instance.specification.readOnly).toBe(true);
     expect(instance.specification.idempotent).toBe(true);
-    expect(instance.specification.parameters).toHaveLength(1);
+    expect(instance.specification.parameters).toHaveLength(2);
     expect(instance.specification.parameters?.[0].name).toBe("sessionId");
+    expect(instance.specification.parameters?.[1].name).toBe("format");
+    expect(instance.specification.parameters?.[1].required).toBe(false);
   });
 
   it("should send get-screenshot message and return image content", async () => {
@@ -83,5 +85,27 @@ describe("GetScreenshot", () => {
     await expect(instance.handle({}, {})).rejects.toThrow(
       "sessionId argument is required",
     );
+  });
+
+  it("should default to png format when format is not specified", async () => {
+    await instance.handle({ sessionId: "sess-1" }, {});
+
+    expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mcp:get-screenshot", format: "png" }),
+    );
+  });
+
+  it("should use jpeg format when format is jpeg", async () => {
+    const result = await instance.handle(
+      { sessionId: "sess-1", format: "jpeg" },
+      {},
+    );
+
+    expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mcp:get-screenshot", format: "jpeg" }),
+    );
+    expect((result.content[0] as any).mimeType).toBe("image/jpeg");
+    const parsed = JSON.parse((result.content[1] as any).text);
+    expect(parsed.format).toBe("jpeg");
   });
 });

--- a/src/tests/unit/reflect/tool/tests/list-segments.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-segments.test.ts
@@ -33,7 +33,11 @@ describe("ListSegments", () => {
     fetchMock.resetMocks();
 
     mockClient = {
-      getApiToken: vi.fn().mockReturnValue("test-api-key"),
+      isOAuthRequest: vi.fn().mockReturnValue(false),
+      getHeaders: vi.fn().mockReturnValue({
+        "X-API-KEY": "test-api-key",
+        "Content-Type": "application/json",
+      }),
     };
 
     instance = new ListSegments(mockClient as any);
@@ -84,6 +88,26 @@ describe("ListSegments", () => {
     fetchMock.mockResponseOnce("Not Found", { status: 404 });
     await expect(instance.handle({ platform: "web" }, {})).rejects.toThrow(
       "Failed to list segments",
+    );
+  });
+
+  it("should use WEB_APP_HOSTNAME URL for OAuth request", async () => {
+    mockClient.isOAuthRequest.mockReturnValue(true);
+    mockClient.getHeaders.mockReturnValue({
+      Authorization: "Bearer oauth-token",
+      "Content-Type": "application/json",
+    });
+    fetchMock.mockResponseOnce(JSON.stringify(segmentsMock));
+
+    await instance.handle({ platform: "web" }, {});
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.reflect.run/api/mcp/segments?type=web&offset=0&limit=25",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer oauth-token",
+        }),
+      }),
     );
   });
 });

--- a/src/tests/unit/reflect/tool/tests/list-segments.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-segments.test.ts
@@ -99,7 +99,7 @@ describe("ListSegments", () => {
     });
     fetchMock.mockResponseOnce(JSON.stringify(segmentsMock));
 
-    await instance.handle({ platform: "web" }, {});
+    const result = await instance.handle({ platform: "web" }, {});
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://app.reflect.run/api/mcp/segments?type=web&offset=0&limit=25",
@@ -109,5 +109,9 @@ describe("ListSegments", () => {
         }),
       }),
     );
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.count).toBe(2);
+    expect(parsed.segments).toHaveLength(2);
   });
 });

--- a/src/tests/unit/reflect/websocket-manager.test.ts
+++ b/src/tests/unit/reflect/websocket-manager.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketManager } from "../../../reflect/websocket-manager";
 
+const apiKeyHeader = (key = "test-api-key") => ({ "X-API-KEY": key });
+
 // Mock the ws module
 vi.mock("ws", () => {
   const OPEN = 1;
@@ -27,7 +29,7 @@ describe("WebSocketManager", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     const WebSocket = (await import("ws")).default as any;
-    manager = new WebSocketManager("test-session-123", "test-api-key");
+    manager = new WebSocketManager("test-session-123", apiKeyHeader());
 
     // Each new manager will use a new mock instance
     _mockWs = WebSocket.mock.results[0]?.value;
@@ -52,7 +54,7 @@ describe("WebSocketManager", () => {
       return instance;
     });
 
-    const newManager = new WebSocketManager("session-456", "key");
+    const newManager = new WebSocketManager("session-456", apiKeyHeader("key"));
 
     await newManager.connect();
     expect(newManager.isConnected()).toBe(true);
@@ -70,7 +72,7 @@ describe("WebSocketManager", () => {
       removeAllListeners: vi.fn(),
     }));
 
-    const newManager = new WebSocketManager("session-789", "key");
+    const newManager = new WebSocketManager("session-789", apiKeyHeader("key"));
 
     await newManager.connect();
     await expect(newManager.connect()).rejects.toThrow(
@@ -93,7 +95,10 @@ describe("WebSocketManager", () => {
       removeAllListeners: vi.fn(),
     }));
 
-    const newManager = new WebSocketManager("session-fail", "key");
+    const newManager = new WebSocketManager(
+      "session-fail",
+      apiKeyHeader("key"),
+    );
 
     await newManager.connect();
 
@@ -132,7 +137,7 @@ describe("WebSocketManager", () => {
       removeAllListeners: vi.fn(),
     }));
 
-    const newManager = new WebSocketManager("session-ok", "key");
+    const newManager = new WebSocketManager("session-ok", apiKeyHeader("key"));
 
     await newManager.connect();
 
@@ -158,6 +163,33 @@ describe("WebSocketManager", () => {
     });
   });
 
+  it("should pass Bearer token header to WebSocket for OAuth", async () => {
+    const WebSocket = (await import("ws")).default as any;
+    let capturedOpts: any = null;
+
+    WebSocket.mockImplementationOnce((_url: string, opts: any) => {
+      capturedOpts = opts;
+      return {
+        readyState: 1,
+        on: vi.fn().mockImplementation((event: string, handler: any) => {
+          if (event === "open") setTimeout(() => handler(), 0);
+        }),
+        send: vi.fn(),
+        close: vi.fn(),
+        removeAllListeners: vi.fn(),
+      };
+    });
+
+    const newManager = new WebSocketManager("session-oauth", {
+      Authorization: "Bearer oauth-token",
+    });
+    await newManager.connect();
+
+    expect(capturedOpts.headers).toEqual({
+      Authorization: "Bearer oauth-token",
+    });
+  });
+
   it("should disconnect cleanly", async () => {
     const WebSocket = (await import("ws")).default as any;
     const mockInstance = {
@@ -171,7 +203,10 @@ describe("WebSocketManager", () => {
     };
     WebSocket.mockImplementationOnce(() => mockInstance);
 
-    const newManager = new WebSocketManager("session-disc", "key");
+    const newManager = new WebSocketManager(
+      "session-disc",
+      apiKeyHeader("key"),
+    );
     await newManager.connect();
     await newManager.disconnect();
 


### PR DESCRIPTION
## Goal

Add OAuth support to some of the Reflect MCP tools so that requests authenticated via Authorization: Bearer token are handled correctly alongside the existing API key auth (X-API-KEY/Reflect-Api-Token). The list-segments endpoint also requires a different base URL when accessed via OAuth, and get-screenshot needed a format option to support JPEG in addition to PNG.
 
## Design

Auth detection is centralised in two new methods on ReflectClient:                                                             
  
 - isOAuthRequest() — checks whether the incoming request carries an Authorization: Bearer header, respecting the existing header priority (Reflect-Api-Token and X-API-KEY take precedence over Authorization).
 - getAuthHeader() — returns the correct auth header object (Authorization: Bearer <token> for OAuth, X-API-KEY: <token> for API key) based on the result of isOAuthRequest().                                                                       
  
WebSocketManager was updated to accept a Record<string, string> auth header instead of a raw API key string, so it works transparently for both auth types.                 
          
 For list-segments, the base URL is selected at call time based on isOAuthRequest() — OAuth requests route to app.reflect.run/api/mcp, API key requests continue to use api.reflect.run/v1. 
          
 The format parameter on get-screenshot defaults to png if not supplied, keeping the change fully backwards compatible.
## Changeset

- client.ts — added isOAuthRequest() and getAuthHeader(); updated getHeaders() to delegate to getAuthHeader()                                        
 - websocket-manager.ts — constructor now accepts authHeader: Record<string, string> instead of apiKey: string
 - connect-to-session.ts — passes getAuthHeader() to WebSocketManager instead of getApiToken()                                                
 - list-segments.ts — selects API base URL based on auth type; uses getHeaders() for all request headers                                           
 - get-screenshot.ts — added optional format parameter (png | jpeg, defaults to png); mimeType in the response reflects the chosen format                          
 - types/mcp.ts — added format field to MCPGetScreenshotMessage                                                               
 - constants.ts — added WEB_APP_HOSTNAME constant for the OAuth base URL
 
## Testing

- [x] Verified list_sgements, get-screenshot and connect to session with oAuth token
- [x] Verified list_sgements, get-screenshot and connect to session with API Key