### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.19.0] - 2026-04-29
+
 ### Added
 
+- [Reflect] Add jpeg format support for get-screenshot tool [#435](https://github.com/SmartBear/smartbear-mcp/pull/435)
 - [Swagger] Added optional `newVersion` parameter to the `standardize_api` tool to save the fixed API definition as a new version instead of overwriting the current one
 
 ## [0.18.3] - 2026-04-16

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: ghcr.io/smartbear/smartbear-mcp:v0.18.2
+          image: ghcr.io/smartbear/smartbear-mcp:v0.19.0
           env:
             - name: MCP_TRANSPORT
               value: "http"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
## [0.19.0] - 2026-04-29


## Added

- [Reflect] Add jpeg format support for get-screenshot tool [#435](https://github.com/SmartBear/smartbear-mcp/pull/435)
- [Swagger] Added optional `newVersion` parameter to the `standardize_api` tool to save the fixed API definition as a new version instead of overwriting the current one