### PR TITLE
TM4J-17231:fixing rovo with gemini 

### DIFF
--- a/src/zephyr/common/rest-api-schemas.ts
+++ b/src/zephyr/common/rest-api-schemas.ts
@@ -1114,15 +1114,14 @@ export const UpdateTestCaseBody = zod
       .describe("Array of labels associated to this entity."),
     component: zod
       .object({
-        id: zod.number().min(1).describe("The ID of the entity"),
+        id: zod.number().min(1).describe("The ID of the entity").optional(),
         self: zod
           .string()
           .url()
           .optional()
           .describe("The REST API endpoint to get more resource details."),
       })
-      .strict()
-      .nullish()
+      .optional()
       .describe("ID and link to the Jira component resource."),
     priority: zod
       .object({
@@ -1146,18 +1145,7 @@ export const UpdateTestCaseBody = zod
       })
       .strict()
       .describe("ID and link to the status resource."),
-    folder: zod
-      .object({
-        id: zod.number().min(1).describe("The ID of the entity"),
-        self: zod
-          .string()
-          .url()
-          .optional()
-          .describe("The REST API endpoint to get more resource details."),
-      })
-      .strict()
-      .nullish()
-      .describe("ID and link to the folder resource."),
+    folder: zod.number().min(1).describe("The ID of the folder").nullable().optional(),
     owner: zod
       .object({
         accountId: zod
@@ -1172,9 +1160,7 @@ export const UpdateTestCaseBody = zod
           .describe(
             "The Jira REST API endpoint to get the full representation of the Jira user.",
           ),
-      })
-      .strict()
-      .nullish(),
+      }).optional(),
     customFields: zod
       .record(zod.string(), zod.unknown())
       .optional()
@@ -2886,7 +2872,6 @@ export const UpdateTestCycleBody = zod
             "The Jira REST API endpoint to get the full representation of the Jira user.",
           ),
       })
-      .strict()
       .nullish(),
     customFields: zod
       .record(zod.string(), zod.unknown())

--- a/src/zephyr/tool/test-case/update-test-case.ts
+++ b/src/zephyr/tool/test-case/update-test-case.ts
@@ -91,7 +91,9 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
     // and will delete any properties that are not included in the request
     const existingTestCase: zod.infer<typeof GetTestCase200Response> =
       await this.client.getApiClient().get(`/testcases/${testCaseKey}`);
-
+    if (updates.folder) {
+      (updates as any).folder =  { id: updates.folder };
+    }
     // Deep merge the updates with the existing test case
     // For nested objects like customFields, we merge instead of replacing
     const mergedBody = deepMerge(existingTestCase, updates);


### PR DESCRIPTION
so that folderId is not an object but is a number that is optional and nullable (nullish is not an option)

## Goal

Rovo (with gemini) is not working with our actual schemas (nullish is not supported)

## Design

avoid using nullish in our objects, decided not to use our own objects when we can use directly types (making our api schemas simpler)

## Changeset

changing folder to be folderId (number.optional.nullable)

## Testing

running manually on claude and rovo
