### PR TITLE
fix: allow pact client start with no params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)
+
 ## [0.19.2] - 2026-05-05
 
 - [Zephyr] fix Zephyr for Rovo Agent (avoid using nullish for update test case and update test cycle tools) [#442](https://github.com/SmartBear/smartbear-mcp/pull/442)

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -242,11 +242,18 @@ export class PactflowClient implements Client {
    *   entitlements, and user entitlements.
    * @throws Error if the request fails or returns a non-OK response.
    */
-  async checkAIEntitlements(): Promise<Entitlement> {
-    return await this.fetchJson<Entitlement>(`${this.aiBaseUrl}/entitlement`, {
-      method: "GET",
-      errorContext: "PactFlow AI Entitlements Request",
-    });
+  async checkAIEntitlements(): Promise<Entitlement | null> {
+    if (this.aiBaseUrl) {
+      return await this.fetchJson<Entitlement>(
+        `${this.aiBaseUrl}/entitlement`,
+        {
+          method: "GET",
+          errorContext: "PactFlow AI Entitlements Request",
+        },
+      );
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -2359,7 +2366,7 @@ export class PactflowClient implements Client {
     let disablePactflowAItools = false;
     try {
       const entitlement = await this.checkAIEntitlements();
-      if (!entitlement.aiEnabled) {
+      if (!entitlement || !entitlement.aiEnabled) {
         disablePactflowAItools = true;
       }
     } catch (error) {


### PR DESCRIPTION
## Goal

It should be possible for each product to register tools without any configuration so that aggregators can list tools to see what is available. This was broken my an addition to the Pact tool that requires the URL, as it throws with:

```
[PactFlow AI Entitlements Request] Unexpected error: TypeError: Failed to parse URL from undefined/entitlement
```

## Changeset

Added a guard to the AI enablements logic to allow it to return empty rather than error.

## Testing

Regression tests and running with no configuation.
