### PR TITLE
refactor: update all tools to use inputSchema rather than parameters

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -108,8 +108,10 @@ export class SmartBearMcpServer extends McpServer {
           {
             title: toolTitle,
             description: this.getDescription(params),
-            inputSchema: this.schemaToRawShape(params.inputSchema),
-            outputSchema: this.getOutputSchema(params),
+            inputSchema: params.inputSchema
+              ? this.schemaToRawShape(params.inputSchema)
+              : {},
+            outputSchema: this.schemaToRawShape(params.outputSchema),
             annotations: this.getAnnotations(toolTitle, params),
           },
           async (args: any, extra: any) => {
@@ -271,10 +273,6 @@ export class SmartBearMcpServer extends McpServer {
     return undefined;
   }
 
-  private getOutputSchema(params: ToolParams): any {
-    return this.schemaToRawShape(params.outputSchema);
-  }
-
   private getDescription(params: ToolParams): string {
     const {
       summary,
@@ -288,12 +286,15 @@ export class SmartBearMcpServer extends McpServer {
     let description = summary;
 
     if (inputSchema && inputSchema instanceof ZodObject) {
-      description += "\n\n**Parameters:**\n";
-      description += Object.keys(inputSchema.shape)
+      let parameters = Object.keys(inputSchema.shape)
         .map((key) =>
           this.formatParameterDescription(key, inputSchema.shape[key]),
         )
         .join("\n");
+      if (parameters.length === 0) {
+        parameters = "None";
+      }
+      description += `\n\n**Parameters:**\n${parameters}`;
     }
 
     if (outputDescription) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -108,7 +108,7 @@ export class SmartBearMcpServer extends McpServer {
           {
             title: toolTitle,
             description: this.getDescription(params),
-            inputSchema: this.getInputSchema(params),
+            inputSchema: this.schemaToRawShape(params.inputSchema),
             outputSchema: this.getOutputSchema(params),
             annotations: this.getAnnotations(toolTitle, params),
           },
@@ -251,21 +251,6 @@ export class SmartBearMcpServer extends McpServer {
     return annotations;
   }
 
-  private getInputSchema(params: ToolParams): any {
-    const args: Record<string, ZodType> = {};
-    for (const param of params.parameters ?? []) {
-      args[param.name] = param.type;
-      if (param.description) {
-        args[param.name] = args[param.name].describe(param.description);
-      }
-      if (!param.required) {
-        args[param.name] = args[param.name].optional();
-      }
-    }
-
-    return { ...args, ...this.schemaToRawShape(params.inputSchema) };
-  }
-
   private schemaToRawShape(
     schema: ZodType | undefined,
   ): ZodRawShape | undefined {
@@ -295,26 +280,12 @@ export class SmartBearMcpServer extends McpServer {
       summary,
       useCases,
       examples,
-      parameters,
       inputSchema,
       hints,
       outputDescription,
     } = params;
 
     let description = summary;
-
-    // Parameters if available otherwise use inputSchema
-    if ((parameters ?? []).length > 0) {
-      description += `\n\n**Parameters:**\n${parameters
-        ?.map(
-          (p) =>
-            `- ${p.name} (${this.getReadableTypeName(p.type)})${p.required ? " *required*" : ""}` +
-            `${p.description ? `: ${p.description}` : ""}` +
-            `${p.examples ? ` (e.g. ${p.examples.join(", ")})` : ""}` +
-            `${p.constraints ? `\n  - ${p.constraints.join("\n  - ")}` : ""}`,
-        )
-        .join("\n")}`;
-    }
 
     if (inputSchema && inputSchema instanceof ZodObject) {
       description += "\n\n**Parameters:**\n";

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -17,7 +17,6 @@ import type { SmartBearMcpServer } from "./server";
 export interface ToolParams {
   title: string;
   summary: string;
-  parameters?: Parameters; // either 'parameters' or an 'inputSchema' should be present
   inputSchema?: ZodType;
   /**
    * Specifies the type of object returned by the tool. <br>

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -2366,7 +2366,7 @@ export class PactflowClient implements Client {
     let disablePactflowAItools = false;
     try {
       const entitlement = await this.checkAIEntitlements();
-      if (!entitlement || !entitlement.aiEnabled) {
+      if (entitlement && !entitlement.aiEnabled) {
         disablePactflowAItools = true;
       }
     } catch (error) {

--- a/src/pactflow/client/tools.ts
+++ b/src/pactflow/client/tools.ts
@@ -114,14 +114,11 @@ export const TOOLS: PactflowToolParams[] = [
     summary: "Retrieve the states of a specific provider",
     purpose:
       "A provider state in Pact defines the specific preconditions that must be met on the provider side before a consumer-provider interaction can be tested. It sets up the provider in the right context—such as ensuring a particular user or record exists—so that the provider can return the response the consumer expects. This makes contract tests reliable, repeatable, and isolated by injecting or configuring the necessary data and conditions directly into the provider before each test runs.",
-    parameters: [
-      {
-        name: "provider",
-        type: z.string(),
-        description: "name of the provider to retrieve states for",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      provider: z
+        .string()
+        .describe("name of the provider to retrieve states for"),
+    }),
     handler: "getProviderStates",
     clients: ["pactflow", "pact_broker"],
   },

--- a/src/reflect/tool/recording/add-prompt-step.ts
+++ b/src/reflect/tool/recording/add-prompt-step.ts
@@ -14,26 +14,14 @@ export class AddPromptStep extends Tool<ReflectClient> {
       "Add a natural language prompt step to an active Reflect recording session",
     readOnly: false,
     idempotent: false,
-    parameters: [
-      {
-        name: "sessionId",
-        type: z.string(),
-        description: "The ID of the Reflect recording session",
-        required: true,
-      },
-      {
-        name: "prompt",
-        type: z.string(),
-        description:
-          "The natural language prompt describing the test step. The prompt " +
-          "should describe a single action, assertion, or query. The prompt can only contain literal " +
-          "text; it cannot contain template variables, secrets, or other dynamic syntax. If we are in a " +
-          'Web recording, the prompt can perform browser navigation (e.g. "Click on the back button", ' +
-          '"Navigate to https://www.example.com") and use the tab and enter keys to navigate (e.g. ' +
-          '"Press the tab key", "Press the enter key").',
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      sessionId: z.string().describe("The ID of the Reflect recording session"),
+      prompt: z
+        .string()
+        .describe(
+          "The natural language prompt describing the test step. The prompt should describe a single action, assertion, or query. The prompt can only contain literal text; it cannot contain template variables, secrets, or other dynamic syntax. If we are in a Web recording, the prompt can perform browser navigation (e.g. 'Click on the back button', 'Navigate to https://www.example.com') and use the tab and enter keys to navigate (e.g. 'Press the tab key', 'Press the enter key').",
+        ),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/recording/add-segment.ts
+++ b/src/reflect/tool/recording/add-segment.ts
@@ -13,20 +13,10 @@ export class AddSegment extends Tool<ReflectClient> {
       "Insert a reusable test segment into an active Reflect recording session",
     readOnly: false,
     idempotent: false,
-    parameters: [
-      {
-        name: "sessionId",
-        type: z.string(),
-        description: "The ID of the Reflect recording session",
-        required: true,
-      },
-      {
-        name: "segmentId",
-        type: z.number(),
-        description: "The ID of the segment to add",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      sessionId: z.string().describe("The ID of the Reflect recording session"),
+      segmentId: z.number().describe("The ID of the segment to add"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/recording/connect-to-session.ts
+++ b/src/reflect/tool/recording/connect-to-session.ts
@@ -22,14 +22,11 @@ export class ConnectToSession extends Tool<ReflectClient> {
 7. After completing a task, if the task required multiple prompt steps, add a final prompt step that validates the current state of the page based on what you see on the screen. In your validation, do not reference information that can change from run to run.`,
     readOnly: false,
     idempotent: true,
-    parameters: [
-      {
-        name: "sessionId",
-        type: z.string(),
-        description: "The ID of the Reflect recording session to connect to",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      sessionId: z
+        .string()
+        .describe("The ID of the Reflect recording session to connect to"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args, extra) => {

--- a/src/reflect/tool/recording/delete-previous-step.ts
+++ b/src/reflect/tool/recording/delete-previous-step.ts
@@ -14,14 +14,9 @@ export class DeletePreviousStep extends Tool<ReflectClient> {
     readOnly: false,
     idempotent: false,
     destructive: true,
-    parameters: [
-      {
-        name: "sessionId",
-        type: z.string(),
-        description: "The ID of the Reflect recording session",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      sessionId: z.string().describe("The ID of the Reflect recording session"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/recording/get-screenshot.ts
+++ b/src/reflect/tool/recording/get-screenshot.ts
@@ -14,20 +14,13 @@ export class GetScreenshot extends Tool<ReflectClient> {
       "Capture a screenshot from the current state of an active Reflect recording session",
     readOnly: true,
     idempotent: true,
-    parameters: [
-      {
-        name: "sessionId",
-        type: z.string(),
-        description: "The ID of the Reflect recording session",
-        required: true,
-      },
-      {
-        name: "format",
-        type: z.enum(["png", "jpeg"]),
-        description: "The image format for the screenshot (png or jpeg)",
-        required: false,
-      },
-    ],
+    inputSchema: z.object({
+      sessionId: z.string().describe("The ID of the Reflect recording session"),
+      format: z
+        .enum(["png", "jpeg"])
+        .optional()
+        .describe("The image format for the screenshot (png or jpeg)"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/suites/cancel-suite-execution.ts
+++ b/src/reflect/tool/suites/cancel-suite-execution.ts
@@ -10,20 +10,14 @@ export class CancelSuiteExecution extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "Cancel Suite Execution",
     summary: "Cancel a reflect suite execution",
-    parameters: [
-      {
-        name: "suiteId",
-        type: z.string(),
-        description: "ID of the reflect suite to cancel execution for",
-        required: true,
-      },
-      {
-        name: "executionId",
-        type: z.string(),
-        description: "ID of the reflect suite execution to cancel",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      suiteId: z
+        .string()
+        .describe("ID of the reflect suite to cancel execution for"),
+      executionId: z
+        .string()
+        .describe("ID of the reflect suite execution to cancel"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/suites/execute-suite.ts
+++ b/src/reflect/tool/suites/execute-suite.ts
@@ -10,14 +10,9 @@ export class ExecuteSuite extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "Execute Suite",
     summary: "Execute a reflect suite",
-    parameters: [
-      {
-        name: "suiteId",
-        type: z.string(),
-        description: "ID of the reflect suite to execute",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      suiteId: z.string().describe("ID of the reflect suite to execute"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/suites/get-suite-execution-status.ts
+++ b/src/reflect/tool/suites/get-suite-execution-status.ts
@@ -10,20 +10,14 @@ export class GetSuiteExecutionStatus extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "Get Suite Execution Status",
     summary: "Get the status of a reflect suite execution",
-    parameters: [
-      {
-        name: "suiteId",
-        type: z.string(),
-        description: "ID of the reflect suite to get execution status for",
-        required: true,
-      },
-      {
-        name: "executionId",
-        type: z.string(),
-        description: "ID of the reflect suite execution to get status for",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      suiteId: z
+        .string()
+        .describe("ID of the reflect suite to get execution status for"),
+      executionId: z
+        .string()
+        .describe("ID of the reflect suite execution to get status for"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/suites/list-suite-executions.ts
+++ b/src/reflect/tool/suites/list-suite-executions.ts
@@ -10,14 +10,11 @@ export class ListSuiteExecutions extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "List Suite Executions",
     summary: "List all executions for a given suite",
-    parameters: [
-      {
-        name: "suiteId",
-        type: z.string(),
-        description: "ID of the reflect suite to list executions for",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      suiteId: z
+        .string()
+        .describe("ID of the reflect suite to list executions for"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/suites/list-suites.ts
+++ b/src/reflect/tool/suites/list-suites.ts
@@ -1,5 +1,5 @@
 import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
+import { type ZodRawShape, z } from "zod";
 import { Tool, ToolError } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
@@ -9,7 +9,7 @@ export class ListSuites extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "List Suites",
     summary: "Retrieve a list of all reflect suites available",
-    parameters: [],
+    inputSchema: z.object({}),
   };
 
   handle: ToolCallback<ZodRawShape> = async (_args) => {

--- a/src/reflect/tool/tests/get-test-status.ts
+++ b/src/reflect/tool/tests/get-test-status.ts
@@ -10,14 +10,11 @@ export class GetTestStatus extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "Get Test Status",
     summary: "Get the status of a reflect test execution",
-    parameters: [
-      {
-        name: "executionId",
-        type: z.string(),
-        description: "ID of the reflect test execution to get status for",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      executionId: z
+        .string()
+        .describe("ID of the reflect test execution to get status for"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/tests/list-segments.ts
+++ b/src/reflect/tool/tests/list-segments.ts
@@ -14,26 +14,16 @@ export class ListSegments extends Tool<ReflectClient> {
       "Retrieve available reusable test segments for the given platform type. Segments are reusable test steps with an optional set of parameters that can used across multiple tests.",
     readOnly: true,
     idempotent: true,
-    parameters: [
-      {
-        name: "platform",
-        type: z.enum(["api", "native-mobile", "web"]),
-        description: "The platform type to retrieve segments for",
-        required: true,
-      },
-      {
-        name: "offset",
-        type: z.number(),
-        description: "Offset for pagination",
-        required: false,
-      },
-      {
-        name: "limit",
-        type: z.number(),
-        description: "Maximum number of segments to return",
-        required: false,
-      },
-    ],
+    inputSchema: z.object({
+      platform: z
+        .enum(["api", "native-mobile", "web"])
+        .describe("The platform type to retrieve segments for"),
+      offset: z.number().optional().describe("Offset for pagination"),
+      limit: z
+        .number()
+        .optional()
+        .describe("Maximum number of segments to return"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/reflect/tool/tests/list-tests.ts
+++ b/src/reflect/tool/tests/list-tests.ts
@@ -1,5 +1,5 @@
 import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
+import { type ZodRawShape, z } from "zod";
 import { Tool, ToolError } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
@@ -9,7 +9,7 @@ export class ListTests extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "List Tests",
     summary: "List all reflect tests",
-    parameters: [],
+    inputSchema: z.object({}),
   };
 
   handle: ToolCallback<ZodRawShape> = async (_args) => {

--- a/src/reflect/tool/tests/run-test.ts
+++ b/src/reflect/tool/tests/run-test.ts
@@ -10,14 +10,9 @@ export class RunTest extends Tool<ReflectClient> {
   specification: ToolParams = {
     title: "Run Test",
     summary: "Run a reflect test",
-    parameters: [
-      {
-        name: "testId",
-        type: z.string(),
-        description: "ID of the reflect test to run",
-        required: true,
-      },
-    ],
+    inputSchema: z.object({
+      testId: z.string().describe("ID of the reflect test to run"),
+    }),
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -42,7 +42,6 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "List Portals",
     summary:
       "Search for available portals within Swagger. Only portals where you have at least a designer role, either at the product level or organization level, are returned.",
-    parameters: [],
     handler: "getPortals",
   },
   {

--- a/src/tests/unit/common/__snapshots__/registered-tools.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/registered-tools.test.ts.snap
@@ -48,7 +48,7 @@ Expected Output: JSON object with build details including version, source contro
     "description": "Retrieve the 'current' project on which tools should operate by default. This allows BugSnag tools to be called with no projectId parameter.
 
 **Parameters:**
-
+None
 
 **Use Cases:** 1. Understand if a current project has been set
 
@@ -1394,7 +1394,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "List all available permission scopes (admin).
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Admin List Permissions",
@@ -1409,7 +1410,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "List all roles defined in the workspace (admin).
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Admin List Roles",
@@ -1550,7 +1552,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Reset all roles to their factory defaults (admin).
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Admin Reset Roles",
@@ -1826,7 +1829,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Delete ALL consumer-provider integrations in the workspace.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Delete All Integrations",
@@ -1960,6 +1964,34 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     ],
     "outputSchema": undefined,
     "title": "Contract Testing: Execute Webhook",
+  },
+  "contract-testing_generate_pact_tests": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Generate Pact Tests",
+    },
+    "description": "Generate Pact tests using PactFlow AI. You can provide one or more of the following input types: (1) request/response pairs for specific interactions, (2) code files to analyze and extract interactions from, and/or (3) OpenAPI document to generate tests for specific endpoints. When providing an OpenAPI document, a matcher is required to specify which endpoints to generate tests for.
+
+**Parameters:**
+- language (enum): Target language for the generated Pact tests. If not provided, will be inferred from other inputs.
+- requestResponse (object): Direct request/response pair for a specific interaction. Use this when you have concrete examples of API requests and responses
+- code (array): Collection of source code files to analyze and extract API interactions from. Include client code, data models, existing tests, or any code that makes API calls
+- openapi (any)
+- additionalInstructions (string): Optional free-form instructions to guide the generation process (e.g., 'Focus on error scenarios', 'Include authentication headers', 'Use specific test framework patterns')
+- testTemplate (object): Optional test template to use as a basis for generation. Helps ensure generated tests follow your specific patterns, frameworks, and coding standards",
+    "inputSchema": [
+      "additionalInstructions",
+      "code",
+      "language",
+      "openapi",
+      "requestResponse",
+      "testTemplate",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Generate Pact Tests",
   },
   "contract-testing_get_audit_log": {
     "annotations": {
@@ -2267,7 +2299,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve the profile of the currently authenticated user.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Get Current User",
@@ -2396,7 +2429,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Fetch metrics across the entire workspace
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Get Metrics",
@@ -2573,7 +2607,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve system-wide preferences.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Get System Preferences",
@@ -2588,7 +2623,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Fetch metrics for all teams
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Get Team Metrics",
@@ -2603,7 +2639,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve the current user's preferences.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Get User Preferences",
@@ -2636,7 +2673,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve API tokens for the current user.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: List API Tokens",
@@ -2675,7 +2713,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve all environments configured in the Pact Broker or PactFlow workspace.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: List Environments",
@@ -2690,7 +2729,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve all consumer-provider integrations registered in the workspace.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: List Integrations",
@@ -2785,7 +2825,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve all secrets stored in the workspace.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: List Secrets",
@@ -2800,7 +2841,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Retrieve all webhooks configured in the workspace.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: List Webhooks",
@@ -2997,6 +3039,32 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     "outputSchema": undefined,
     "title": "Contract Testing: Remove Label from Pacticipant",
   },
+  "contract-testing_review_pact_tests": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Review Pact Tests",
+    },
+    "description": "Review Pact tests using PactFlow AI. You can provide the following inputs: (1) Pact tests to be reviewed along with metadata
+
+**Parameters:**
+- pactTests (object) *required*: Primary pact tests that needs to be refined.
+- code (array): Collection of source code files to analyze and extract API interactions from. Include client code, data models, existing tests, or any code that makes API calls
+- userInstructions (string): Optional free-form instructions that provide additional context or specify areas of focus during the refinement process of the Pact test.
+- errorMessages (array): Optional error output from failed contract test runs. These can be used to better understand the context or failures observed and guide the recommendations toward resolving specific issues.
+- openapi (any)",
+    "inputSchema": [
+      "code",
+      "errorMessages",
+      "openapi",
+      "pactTests",
+      "userInstructions",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Review Pact Tests",
+  },
   "contract-testing_test_execute_webhooks": {
     "annotations": {
       "destructiveHint": false,
@@ -3007,7 +3075,8 @@ Expected Output: Success response indicating the Jira issue was unlinked from th
     },
     "description": "Trigger a test execution of all matching webhooks without a real event.
 
-**Parameters:**",
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Contract Testing: Test Execute Webhooks",
@@ -6934,7 +7003,7 @@ Expected Output: description updated only. Field IDs auto-resolved from project 
 
 **Parameters:**
 - sessionId (string) *required*: The ID of the Reflect recording session
-- prompt (string) *required*: The natural language prompt describing the test step. The prompt should describe a single action, assertion, or query. The prompt can only contain literal text; it cannot contain template variables, secrets, or other dynamic syntax. If we are in a Web recording, the prompt can perform browser navigation (e.g. "Click on the back button", "Navigate to https://www.example.com") and use the tab and enter keys to navigate (e.g. "Press the tab key", "Press the enter key").",
+- prompt (string) *required*: The natural language prompt describing the test step. The prompt should describe a single action, assertion, or query. The prompt can only contain literal text; it cannot contain template variables, secrets, or other dynamic syntax. If we are in a Web recording, the prompt can perform browser navigation (e.g. 'Click on the back button', 'Navigate to https://www.example.com') and use the tab and enter keys to navigate (e.g. 'Press the tab key', 'Press the enter key').",
     "inputSchema": [
       "prompt",
       "sessionId",
@@ -7150,7 +7219,10 @@ Expected Output: description updated only. Field IDs auto-resolved from project 
       "readOnlyHint": true,
       "title": "Reflect: List Suites",
     },
-    "description": "Retrieve a list of all reflect suites available",
+    "description": "Retrieve a list of all reflect suites available
+
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Reflect: List Suites",
@@ -7163,7 +7235,10 @@ Expected Output: description updated only. Field IDs auto-resolved from project 
       "readOnlyHint": true,
       "title": "Reflect: List Tests",
     },
-    "description": "List all reflect tests",
+    "description": "List all reflect tests
+
+**Parameters:**
+None",
     "inputSchema": [],
     "outputSchema": undefined,
     "title": "Reflect: List Tests",

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -72,14 +72,9 @@ describe("SmartBearMcpServer", () => {
         {
           title: "Test Tool",
           summary: "A test tool",
-          parameters: [
-            {
-              name: "p1",
-              type: z.string(),
-              required: true,
-              description: "The input for the tool",
-            },
-          ],
+          inputSchema: z.object({
+            p1: z.string().describe("The input for the tool"),
+          }),
         },
         registerCbMock,
       );
@@ -150,60 +145,23 @@ describe("SmartBearMcpServer", () => {
         {
           title: "Test Tool",
           summary: "A test tool",
-          parameters: [
-            {
-              name: "p1",
-              type: z.string(),
-              required: true,
-              description: "The input for the tool",
-              examples: ["example1", "example2"],
-              constraints: ["constraint1", "constraint2"],
-            },
-            {
-              name: "p2",
-              type: z.number(),
-              required: false,
-              description: "The optional numeric input for the tool",
-            },
-            {
-              name: "p3",
-              type: z.boolean(),
-              required: true,
-            },
-            {
-              name: "p4",
-              type: z.array(z.string()),
-              required: true,
-            },
-            {
-              name: "p5",
-              type: z.object({
-                key1: z.string(),
-                key2: z.number(),
-              }),
-              required: true,
-            },
-            {
-              name: "p6",
-              type: z.enum(["value1", "value2", "value3"]),
-              required: true,
-            },
-            {
-              name: "p7",
-              type: z.literal("value"),
-              required: true,
-            },
-            {
-              name: "p8",
-              type: z.union([z.literal("value1"), z.literal("value2")]),
-              required: true,
-            },
-            {
-              name: "p9",
-              type: z.any(),
-              required: true,
-            },
-          ],
+          inputSchema: z.object({
+            p1: z.string().describe("The input for the tool"),
+            p2: z
+              .number()
+              .describe("The optional numeric input for the tool")
+              .optional(),
+            p3: z.boolean(),
+            p4: z.array(z.string()),
+            p5: z.object({
+              key1: z.string(),
+              key2: z.number(),
+            }),
+            p6: z.enum(["value1", "value2", "value3"]),
+            p7: z.literal("value"),
+            p8: z.union([z.literal("value1"), z.literal("value2")]),
+            p9: z.any(),
+          }),
           purpose: "To test the tool registration process",
           useCases: ["Testing", "Development"],
           examples: [
@@ -240,9 +198,7 @@ describe("SmartBearMcpServer", () => {
       expect(registerToolParams[1].description).toBe(
         "A test tool\n\n" +
           "**Parameters:**\n" +
-          "- p1 (string) *required*: The input for the tool (e.g. example1, example2)\n" +
-          "  - constraint1\n" +
-          "  - constraint2\n" +
+          "- p1 (string) *required*: The input for the tool\n" +
           "- p2 (number): The optional numeric input for the tool\n" +
           "- p3 (boolean) *required*\n" +
           "- p4 (array) *required*\n" +

--- a/src/tests/unit/reflect/tool/recording/add-prompt-step.test.ts
+++ b/src/tests/unit/reflect/tool/recording/add-prompt-step.test.ts
@@ -27,9 +27,6 @@ describe("AddPromptStep", () => {
     expect(instance.specification.title).toBe("Add Prompt Step");
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(false);
-    expect(instance.specification.parameters).toHaveLength(2);
-    expect(instance.specification.parameters?.[0].name).toBe("sessionId");
-    expect(instance.specification.parameters?.[1].name).toBe("prompt");
   });
 
   it("should send add-prompt-step message and return success", async () => {

--- a/src/tests/unit/reflect/tool/recording/add-segment.test.ts
+++ b/src/tests/unit/reflect/tool/recording/add-segment.test.ts
@@ -26,10 +26,6 @@ describe("AddSegment", () => {
     expect(instance.specification.title).toBe("Add Segment");
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(false);
-    expect(instance.specification.parameters).toHaveLength(2);
-    expect(instance.specification.parameters?.[0].name).toBe("sessionId");
-    expect(instance.specification.parameters?.[1].name).toBe("segmentId");
-    expect(instance.specification.parameters?.[1].required).toBe(true);
   });
 
   it("should send add-segment message and return success", async () => {

--- a/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
+++ b/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
@@ -43,9 +43,6 @@ describe("ConnectToSession", () => {
     expect(instance.specification.title).toBe("Connect To Session");
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(true);
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("sessionId");
-    expect(instance.specification.parameters?.[0].required).toBe(true);
   });
 
   it("should return cached connection if already connected", async () => {

--- a/src/tests/unit/reflect/tool/recording/delete-previous-step.test.ts
+++ b/src/tests/unit/reflect/tool/recording/delete-previous-step.test.ts
@@ -27,8 +27,6 @@ describe("DeletePreviousStep", () => {
     expect(instance.specification.readOnly).toBe(false);
     expect(instance.specification.idempotent).toBe(false);
     expect(instance.specification.destructive).toBe(true);
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("sessionId");
   });
 
   it("should send delete-step message and return success", async () => {

--- a/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
+++ b/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
@@ -28,10 +28,6 @@ describe("GetScreenshot", () => {
     expect(instance.specification.title).toBe("Get Screenshot");
     expect(instance.specification.readOnly).toBe(true);
     expect(instance.specification.idempotent).toBe(true);
-    expect(instance.specification.parameters).toHaveLength(2);
-    expect(instance.specification.parameters?.[0].name).toBe("sessionId");
-    expect(instance.specification.parameters?.[1].name).toBe("format");
-    expect(instance.specification.parameters?.[1].required).toBe(false);
   });
 
   it("should send get-screenshot message and return image content", async () => {

--- a/src/tests/unit/reflect/tool/suites/cancel-suite-execution.test.ts
+++ b/src/tests/unit/reflect/tool/suites/cancel-suite-execution.test.ts
@@ -26,9 +26,6 @@ describe("CancelSuiteExecution", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Cancel Suite Execution");
-    expect(instance.specification.parameters).toHaveLength(2);
-    expect(instance.specification.parameters?.[0].name).toBe("suiteId");
-    expect(instance.specification.parameters?.[1].name).toBe("executionId");
   });
 
   it("should PATCH to cancel execution and return results", async () => {

--- a/src/tests/unit/reflect/tool/suites/execute-suite.test.ts
+++ b/src/tests/unit/reflect/tool/suites/execute-suite.test.ts
@@ -26,9 +26,6 @@ describe("ExecuteSuite", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Execute Suite");
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("suiteId");
-    expect(instance.specification.parameters?.[0].required).toBe(true);
   });
 
   it("should POST to execute suite and return results", async () => {

--- a/src/tests/unit/reflect/tool/suites/get-suite-execution-status.test.ts
+++ b/src/tests/unit/reflect/tool/suites/get-suite-execution-status.test.ts
@@ -26,9 +26,6 @@ describe("GetSuiteExecutionStatus", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Get Suite Execution Status");
-    expect(instance.specification.parameters).toHaveLength(2);
-    expect(instance.specification.parameters?.[0].name).toBe("suiteId");
-    expect(instance.specification.parameters?.[1].name).toBe("executionId");
   });
 
   it("should call status API and return results", async () => {

--- a/src/tests/unit/reflect/tool/suites/list-suite-executions.test.ts
+++ b/src/tests/unit/reflect/tool/suites/list-suite-executions.test.ts
@@ -29,9 +29,6 @@ describe("ListSuiteExecutions", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("List Suite Executions");
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("suiteId");
-    expect(instance.specification.parameters?.[0].required).toBe(true);
   });
 
   it("should call suite executions API and return results", async () => {

--- a/src/tests/unit/reflect/tool/suites/list-suites.test.ts
+++ b/src/tests/unit/reflect/tool/suites/list-suites.test.ts
@@ -32,7 +32,6 @@ describe("ListSuites", () => {
     expect(instance.specification.summary).toBe(
       "Retrieve a list of all reflect suites available",
     );
-    expect(instance.specification.parameters).toHaveLength(0);
   });
 
   it("should call suites API and return results", async () => {

--- a/src/tests/unit/reflect/tool/tests/get-test-status.test.ts
+++ b/src/tests/unit/reflect/tool/tests/get-test-status.test.ts
@@ -26,8 +26,6 @@ describe("GetTestStatus", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Get Test Status");
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("executionId");
   });
 
   it("should call execution status API with executionId in URL", async () => {

--- a/src/tests/unit/reflect/tool/tests/list-segments.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-segments.test.ts
@@ -47,12 +47,6 @@ describe("ListSegments", () => {
     expect(instance.specification.title).toBe("List Segments");
     expect(instance.specification.readOnly).toBe(true);
     expect(instance.specification.idempotent).toBe(true);
-    expect(instance.specification.parameters).toHaveLength(3);
-    expect(instance.specification.parameters?.[0].name).toBe("platform");
-    expect(instance.specification.parameters?.[1].name).toBe("offset");
-    expect(instance.specification.parameters?.[1].required).toBe(false);
-    expect(instance.specification.parameters?.[2].name).toBe("limit");
-    expect(instance.specification.parameters?.[2].required).toBe(false);
   });
 
   it("should call segments API and return results", async () => {

--- a/src/tests/unit/reflect/tool/tests/list-tests.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-tests.test.ts
@@ -30,7 +30,6 @@ describe("ListTests", () => {
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("List Tests");
     expect(instance.specification.summary).toBe("List all reflect tests");
-    expect(instance.specification.parameters).toHaveLength(0);
   });
 
   it("should call tests API and return results", async () => {

--- a/src/tests/unit/reflect/tool/tests/run-test.test.ts
+++ b/src/tests/unit/reflect/tool/tests/run-test.test.ts
@@ -26,9 +26,6 @@ describe("RunTest", () => {
 
   it("should set specification correctly", () => {
     expect(instance.specification.title).toBe("Run Test");
-    expect(instance.specification.parameters).toHaveLength(1);
-    expect(instance.specification.parameters?.[0].name).toBe("testId");
-    expect(instance.specification.parameters?.[0].required).toBe(true);
   });
 
   it("should POST to run test and return results", async () => {


### PR DESCRIPTION
## Goal

For a while we have had both `parameters` and `inputSchema` in the `ToolParams` interface – the latter allows the input schema to be defined once and used in both the implementation and the definition: keeping them in sync and type-safe.

## Changeset

Remove `ToolParams.parameters` and updated all uses to use `inputSchema` with the equivalent Zod definition.

## Testing

Removed some assertions on the parameters - these seemed unneccessary as there are already tools covering this for the common code (`src/tests/unit/common/server.test.ts`).
