### PR TITLE
fix: return 404 for unknown session id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Transport] Streamable HTTP requests carrying an `Mcp-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#449]([https:](https://github.com/SmartBear/smartbear-mcp/pull/449))
+- [Transport] Streamable HTTP requests carrying an `MCP-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#449](https://github.com/SmartBear/smartbear-mcp/pull/449)
 - [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)
 
 ## [0.19.2] - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Transport] Streamable HTTP requests carrying an `Mcp-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#448]([https:](https://github.com/SmartBear/smartbear-mcp/pull/448))
+
 ## [0.19.2] - 2026-05-05
 
 - [Zephyr] fix Zephyr for Rovo Agent (avoid using nullish for update test case and update test cycle tools) [#442](https://github.com/SmartBear/smartbear-mcp/pull/442)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Transport] Streamable HTTP requests carrying an `Mcp-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#448]([https:](https://github.com/SmartBear/smartbear-mcp/pull/448))
+- [Transport] Streamable HTTP requests carrying an `Mcp-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#449]([https:](https://github.com/SmartBear/smartbear-mcp/pull/449))
 
 ## [0.19.2] - 2026-05-05
 

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -300,8 +300,11 @@ async function createNewTransport(
  *    - Creates new server + transport, generates session ID
  * 2. Subsequent requests: Include MCP-Session-Id header
  *    - Routes to existing transport for the session
+ *    - Unknown session IDs return 404 per spec, prompting the client to
+ *      re-initialize (important for multi-pod deployments where a session
+ *      may not be known to every pod).
  */
-async function handleStreamableHttpRequest(
+export async function handleStreamableHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
   transports: Map<
@@ -318,8 +321,25 @@ async function handleStreamableHttpRequest(
 
     let transport: StreamableHTTPServerTransport;
 
-    // Case 1: Existing session - route to existing transport
-    if (sessionId && transports.has(sessionId)) {
+    // Case 1: Unknown session - per MCP Streamable HTTP spec, return 404 so
+    // clients know to re-run `initialize` (e.g. after a pod restart drops the
+    // in-memory session map) rather than treating this as a permanent error.
+    if (sessionId && !transports.has(sessionId)) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: {
+            code: -32001,
+            message: "Session not found",
+          },
+          id: null,
+        }),
+      );
+      return;
+    }
+    // Case 2: Existing session - route to existing transport
+    if (sessionId) {
       const existingTransport = getExistingTransport(
         sessionId,
         transports,
@@ -328,9 +348,8 @@ async function handleStreamableHttpRequest(
       if (!existingTransport) return;
       transport = existingTransport;
     }
-    // Case 2: New session - must be an initialize request
+    // Case 3: New session - must be an initialize request
     else if (
-      !sessionId &&
       req.method === "POST" &&
       parsedBody &&
       isInitializeRequest(parsedBody)
@@ -339,7 +358,7 @@ async function handleStreamableHttpRequest(
       if (!newTransport) return;
       transport = newTransport;
     }
-    // Case 3: Invalid request
+    // Case 4: Invalid request
     else {
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -317,14 +317,15 @@ export async function handleStreamableHttpRequest(
 ) {
   try {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
-    const parsedBody = await parseRequestBody(req);
-
-    let transport: StreamableHTTPServerTransport;
 
     // Case 1: Unknown session - per MCP Streamable HTTP spec, return 404 so
     // clients know to re-run `initialize` (e.g. after a pod restart drops the
     // in-memory session map) rather than treating this as a permanent error.
+    // Reject before buffering the body so a junk session id can't force JSON
+    // parsing of an arbitrary payload; drain the stream so keep-alive sockets
+    // aren't left half-read.
     if (sessionId && !transports.has(sessionId)) {
+      req.resume();
       res.writeHead(404, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
@@ -338,6 +339,11 @@ export async function handleStreamableHttpRequest(
       );
       return;
     }
+
+    const parsedBody = await parseRequestBody(req);
+
+    let transport: StreamableHTTPServerTransport;
+
     // Case 2: Existing session - route to existing transport
     if (sessionId) {
       const existingTransport = getExistingTransport(

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -4,6 +4,7 @@ import { clientRegistry } from "../../../common/client-registry";
 import {
   getBaseUrl,
   getHeaderName,
+  handleStreamableHttpRequest,
   newServer,
 } from "../../../common/transport-http";
 import type { Client } from "../../../common/types";
@@ -422,5 +423,156 @@ describe("newServer (OAuth flow)", () => {
     expect(res._body).toContain("Configuration error");
     expect(res._body).toContain("HelpTest");
     expect(res._body).toContain("HelpTest-Auth-Token");
+  });
+});
+
+/**
+ * Build a fakeRequest that also acts like a readable stream for parseRequestBody.
+ * If `body` is provided, the request emits "data" then "end" on next tick.
+ */
+function fakeStreamRequest(opts: {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+}): IncomingMessage {
+  const { method = "POST", headers = {}, body } = opts;
+  const listeners: Record<string, ((arg?: any) => void)[]> = {};
+  const req: any = {
+    method,
+    headers,
+    on(event: string, cb: (arg?: any) => void) {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+      // Schedule emission of data/end events after listeners have been registered
+      if (event === "end") {
+        queueMicrotask(() => {
+          if (body !== undefined) {
+            const chunk = Buffer.from(JSON.stringify(body));
+            for (const dataCb of listeners.data || []) dataCb(chunk);
+          }
+          for (const endCb of listeners.end || []) endCb();
+        });
+      }
+      return req;
+    },
+  };
+  return req as IncomingMessage;
+}
+
+describe("handleStreamableHttpRequest (session routing)", () => {
+  it("returns 404 with JSON-RPC -32001 when session id is unknown", async () => {
+    const transports = new Map();
+    const req = fakeStreamRequest({
+      method: "POST",
+      headers: { "mcp-session-id": "does-not-exist" },
+      body: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+    const res = fakeResponse();
+
+    await handleStreamableHttpRequest(req, res, transports);
+
+    expect(res._status).toBe(404);
+    expect(res._headers["Content-Type"]).toBe("application/json");
+    const parsed = JSON.parse(res._body);
+    expect(parsed).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Session not found" },
+      id: null,
+    });
+  });
+
+  it("returns 400 when no session id is present and body is not an initialize request", async () => {
+    const transports = new Map();
+    const req = fakeStreamRequest({
+      method: "POST",
+      headers: {},
+      body: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+    const res = fakeResponse();
+
+    await handleStreamableHttpRequest(req, res, transports);
+
+    expect(res._status).toBe(400);
+    const parsed = JSON.parse(res._body);
+    expect(parsed.error.code).toBe(-32000);
+    expect(parsed.error.message).toContain("Bad Request");
+  });
+
+  it("creates a new session when initialize request arrives without a session id", async () => {
+    const transports = new Map();
+    const req = fakeStreamRequest({
+      method: "POST",
+      headers: { host: "localhost:3000" },
+      body: {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test", version: "0.0.0" },
+        },
+      },
+    });
+    const res = fakeResponse();
+
+    // Provide a configured client so newServer() succeeds
+    const testClient = createTestClient({
+      name: "InitTest",
+      configPrefix: "InitTest",
+      hasGetAuthToken: false,
+    });
+    clientRegistry.getAll = () => [testClient];
+
+    const { SmartBearMcpServer } = await import("../../../common/server.js");
+    vi.mocked(SmartBearMcpServer).mockImplementation(
+      () =>
+        ({
+          getCache: () => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() }),
+          addClient: vi.fn(),
+          getClients: () => [testClient],
+          connect: vi.fn(),
+          setSamplingSupported: vi.fn(),
+          setElicitationSupported: vi.fn(),
+          cleanupSession: vi.fn(),
+          server: { elicitInput: vi.fn() },
+        }) as any,
+    );
+
+    await handleStreamableHttpRequest(req, res, transports);
+
+    // No 4xx error response was written for the initialize-without-session path
+    expect(res._status).not.toBe(400);
+    expect(res._status).not.toBe(404);
+  });
+
+  it("routes to existing transport when session id is known", async () => {
+    const transports = new Map();
+    const handleRequest = vi.fn().mockResolvedValue(undefined);
+    // Construct a stand-in for StreamableHTTPServerTransport that satisfies the
+    // instanceof check inside getExistingTransport without spinning up a real one.
+    const { StreamableHTTPServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/streamableHttp.js"
+    );
+    const fakeTransport = Object.create(
+      StreamableHTTPServerTransport.prototype,
+    );
+    fakeTransport.handleRequest = handleRequest;
+    transports.set("known-session", {
+      server: {} as any,
+      transport: fakeTransport,
+    });
+
+    const req = fakeStreamRequest({
+      method: "POST",
+      headers: { "mcp-session-id": "known-session" },
+      body: { jsonrpc: "2.0", method: "tools/list", id: 1 },
+    });
+    const res = fakeResponse();
+
+    await handleStreamableHttpRequest(req, res, transports);
+
+    expect(handleRequest).toHaveBeenCalledTimes(1);
+    expect(res._status).toBeNull();
   });
 });

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -4,8 +4,8 @@ import { clientRegistry } from "../../../common/client-registry";
 import {
   getBaseUrl,
   getHeaderName,
-  handleStreamableHttpRequest,
   getQueryStringName,
+  handleStreamableHttpRequest,
   newServer,
 } from "../../../common/transport-http";
 import type { Client } from "../../../common/types";

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -437,14 +437,23 @@ function fakeStreamRequest(opts: {
 }): IncomingMessage {
   const { method = "POST", headers = {}, body } = opts;
   const listeners: Record<string, ((arg?: any) => void)[]> = {};
+  let emitted = false;
   const req: any = {
     method,
     headers,
+    resume() {
+      // Drain: behave as if data/end fired with no consumers.
+      emitted = true;
+    },
     on(event: string, cb: (arg?: any) => void) {
       if (!listeners[event]) listeners[event] = [];
       listeners[event].push(cb);
-      // Schedule emission of data/end events after listeners have been registered
-      if (event === "end") {
+      // Emit body once on first 'end' subscription. Multiple subscribers see
+      // their callbacks invoked in the same emission cycle; later subscribers
+      // do not retrigger emission (which would duplicate the body and break
+      // JSON parsing).
+      if (event === "end" && !emitted) {
+        emitted = true;
         queueMicrotask(() => {
           if (body !== undefined) {
             const chunk = Buffer.from(JSON.stringify(body));
@@ -524,26 +533,47 @@ describe("handleStreamableHttpRequest (session routing)", () => {
     });
     clientRegistry.getAll = () => [testClient];
 
+    // Capture the connect spy so we can assert dispatch into createNewTransport.
+    let capturedConnect: ReturnType<typeof vi.fn> | undefined;
     const { SmartBearMcpServer } = await import("../../../common/server.js");
-    vi.mocked(SmartBearMcpServer).mockImplementation(
-      () =>
-        ({
-          getCache: () => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() }),
-          addClient: vi.fn(),
-          getClients: () => [testClient],
-          connect: vi.fn(),
-          setSamplingSupported: vi.fn(),
-          setElicitationSupported: vi.fn(),
-          cleanupSession: vi.fn(),
-          server: { elicitInput: vi.fn() },
-        }) as any,
+    vi.mocked(SmartBearMcpServer).mockImplementation(() => {
+      capturedConnect = vi.fn();
+      return {
+        getCache: () => ({ get: vi.fn(), set: vi.fn(), del: vi.fn() }),
+        addClient: vi.fn(),
+        getClients: () => [testClient],
+        connect: capturedConnect,
+        setSamplingSupported: vi.fn(),
+        setElicitationSupported: vi.fn(),
+        cleanupSession: vi.fn(),
+        server: { elicitInput: vi.fn() },
+      } as any;
+    });
+
+    // Stub the SDK transport's handleRequest so we don't run the real
+    // initialize flow against an incomplete fakeResponse stub. The point of
+    // this test is to verify dispatch *into* createNewTransport, not to
+    // exercise the SDK internals.
+    const { StreamableHTTPServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/streamableHttp.js"
     );
+    const handleRequestSpy = vi
+      .spyOn(StreamableHTTPServerTransport.prototype, "handleRequest")
+      .mockResolvedValue(undefined);
 
-    await handleStreamableHttpRequest(req, res, transports);
+    try {
+      await handleStreamableHttpRequest(req, res, transports);
 
-    // No 4xx error response was written for the initialize-without-session path
-    expect(res._status).not.toBe(400);
-    expect(res._status).not.toBe(404);
+      // Both signals must fire to prove we took the createNewTransport branch:
+      // server.connect(transport) and transport.handleRequest(req, res, body).
+      expect(capturedConnect).toBeDefined();
+      expect(capturedConnect).toHaveBeenCalledOnce();
+      expect(handleRequestSpy).toHaveBeenCalledOnce();
+      // No error response written — guards against 400, 404, AND 500.
+      expect(res._status).toBeNull();
+    } finally {
+      handleRequestSpy.mockRestore();
+    }
   });
 
   it("routes to existing transport when session id is known", async () => {


### PR DESCRIPTION
## Goal

Returns a 404 rather than 400 for unknown session ids

## Design

To better support the MCP spec for remote deployments

## Changeset

Updates HTTP transport to return a 404 for session id not in memory cache

## Testing

No functional change to MCP tools
