### PR TITLE
test: add snapshot tests to detect changes in tool definitions

### DIFF
--- a/src/tests/unit/common/__snapshots__/registered-tools.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/registered-tools.test.ts.snap
@@ -1,0 +1,9810 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`tool definitions > all registered tool definitions match the snapshot 1`] = `
+{
+  "bugsnag_get_build": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Build",
+    },
+    "description": "Get more details for a specific build by its ID
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- buildId (string) *required*: Unique identifier of the app build
+
+**Output Description:** JSON object containing build details along with stability metrics such as user and session stability, and whether it meets project targets
+
+**Use Cases:** 1. View build metadata such as version, source control info, and error counts 2. Analyze a specific build to correlate with error spikes or deployments 3. See the stability targets for a project and if the build meets them
+
+**Examples:**
+1. Get details for a specific build
+\`\`\`json
+{
+  "buildId": "5f8d0d55c9e77c0017a1b2c3"
+}
+\`\`\`
+Expected Output: JSON object with build details including version, source control info, error counts and stability data.
+
+**Hints:** 1. Build IDs can be found using the List builds tool",
+    "inputSchema": [
+      "buildId",
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Build",
+  },
+  "bugsnag_get_current_project": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Current Project",
+    },
+    "description": "Retrieve the 'current' project on which tools should operate by default. This allows BugSnag tools to be called with no projectId parameter.
+
+**Parameters:**
+
+
+**Use Cases:** 1. Understand if a current project has been set
+
+**Hints:** 1. If a project is returned, it can be assumed that the user expects interactions with BugSnag tools to refer to this project 2. If this tool returns no current project then other BugSnag tools will require an explicit project ID parameter 3. Call the List Projects tool to see all projects that the user has access to. Get the project ID from this list either by asking the user for the project name or slug 4. You might find a BugSnag API key in the user's code where they configure the BugSnag SDK that can be matched to a project 'apiKey' field from the project list",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Current Project",
+  },
+  "bugsnag_get_error": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Error",
+    },
+    "description": "Get full details on an error, including aggregated and summarized data across all events (occurrences) and details of the latest event (occurrence), such as breadcrumbs, metadata and the stacktrace. Use the filters parameter to narrow down the summaries further.
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- errorId (string) *required*: Unique identifier of the error to retrieve
+- filters (record<string, array>): Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"event.since":[{"type":"eq","value":"30d"}],"error.status":[{"type":"eq","value":"open"}]})
+
+**Output Description:** JSON object containing:  - error_details: Aggregated data about the error, including first and last seen occurrence - latest_event: Detailed information about the most recent occurrence of the error, including stacktrace, breadcrumbs, user and context - pivots: List of pivots (summaries) for the error, which can be used to analyze patterns in occurrences - url: A link to the error in the dashboard - this should be shown to the user for them to perform further analysis
+
+**Use Cases:** 1. Investigate a specific error found through the List Project Errors tool 2. Understand which types of user are affected by the error using summarized event data 3. Get error details for debugging and root cause analysis 4. Retrieve error metadata for incident reports and documentation
+
+**Examples:**
+1. Get details for a specific error
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411"
+}
+\`\`\`
+Expected Output: JSON object with error details including message, stack trace, occurrence count, and metadata
+
+**Hints:** 1. Error IDs can be found using the List Project Errors tool 2. Use this after filtering errors to get detailed information about specific errors 3. Use Get Event Details tool if you need detailed information about a specific event (occurrence) rather than the aggregated error 4. If you used a filter to get this error, you can pass the same filters here to restrict the results or apply further filters 5. The URL provided in the response points should be shown to the user in all cases as it allows them to view the error in the dashboard and perform further analysis",
+    "inputSchema": [
+      "errorId",
+      "filters",
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Error",
+  },
+  "bugsnag_get_event": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Event",
+    },
+    "description": "Get detailed information about a specific event
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- eventId (string) *required*: Unique identifier of the event
+
+**Use Cases:** 1. Get the full details of an event, including any thread stack traces
+
+**Examples:**
+1. Get event details of an event
+\`\`\`json
+{
+  "eventId": "6863e2af012caf1d5c320000"
+}
+\`\`\`
+Expected Output: JSON object with complete event details including stack trace (error trace and other threads, if present), metadata, and context",
+    "inputSchema": [
+      "eventId",
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Event",
+  },
+  "bugsnag_get_event_details_from_dashboard_url": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Event Details From Dashboard URL",
+    },
+    "description": "Get detailed information about a specific event using its dashboard URL
+
+**Parameters:**
+- link (string) *required*: Full URL to the event details page in the BugSnag dashboard (web interface), containing project slug and event_id parameter.
+
+**Use Cases:** 1. Get event details when given a dashboard URL from a user or notification 2. Extract event information from shared links or browser URLs 3. Quick lookup of event details without needing separate project and event IDs
+
+**Examples:**
+1. Get event details from a dashboard URL
+\`\`\`json
+{
+  "link": "https://app.bugsnag.com/my-org/my-project/errors/6863e2af8c857c0a5023b411?event_id=6863e2af012caf1d5c320000"
+}
+\`\`\`
+Expected Output: JSON object with complete event details including stack trace, metadata, and context
+
+**Hints:** 1. The URL must contain both project slug in the path and event_id in query parameters 2. This is useful when users share BugSnag dashboard URLs and you need to extract the event data",
+    "inputSchema": [
+      "link",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Event Details From Dashboard URL",
+  },
+  "bugsnag_get_events_on_an_error": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Events on an Error",
+    },
+    "description": "Gets a list of events that have grouped into the specified error
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- errorId (string) *required*: Unique identifier of the error
+- filters (record<string, array>): Apply filters to narrow down the event list. Use the List Project Event Filters tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"event.since":[{"type":"eq","value":"30d"}],"error.status":[{"type":"eq","value":"open"}]})
+- direction (enum): Sort direction for ordering results (default: "desc")
+- perPage (number): How many results to return per page. (default: 30)
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+
+**Use Cases:** 1. Retrieving all the events for comparison to find commonalities or differences in stack traces, breadcrumbs and metadata
+
+**Examples:**
+1. Get events of an error
+\`\`\`json
+{
+  "projectId": "1234567890abcdef12345678",
+  "errorId": "6863e2af012caf1d5c320000"
+}
+\`\`\`
+Expected Output: A list of events, ordered by timestamp, with complete details including stack trace, breadcrumbs, metadata, and context",
+    "inputSchema": [
+      "direction",
+      "errorId",
+      "filters",
+      "nextUrl",
+      "perPage",
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Events on an Error",
+  },
+  "bugsnag_get_network_endpoint_groupings": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Network Endpoint Groupings",
+    },
+    "description": "Get the network endpoint grouping rules for a project
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+
+**Use Cases:** 1. View current network endpoint grouping configuration 2. Understand how network requests are being grouped in performance monitoring 3. Check grouping patterns before making updates
+
+**Examples:**
+1. Get network grouping rules for a project
+\`\`\`json
+{}
+\`\`\`
+Expected Output: Array of endpoint URL patterns
+
+**Hints:** 1. Network grouping patterns help consolidate similar requests into single span groups 2. Patterns use OpenAPI path templating syntax with curly braces for path parameters (e.g., /users/{userId}) 3. Wildcards (*) can be used in domains to match multiple subdomains (e.g., https://*.example.com)",
+    "inputSchema": [
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Network Endpoint Groupings",
+  },
+  "bugsnag_get_release": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Release",
+    },
+    "description": "Get more details for a specific release by its ID, including source control information and associated builds
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- releaseId (string) *required*: Unique identifier of the app release
+
+**Output Description:** JSON object containing release details along with stability metrics such as user and session stability, and whether it meets project targets
+
+**Use Cases:** 1. View release metadata such as version, source control info, and error counts 2. Analyze the stability data and targets for a release 3. See the builds that make up the release
+
+**Examples:**
+1. Get details for a specific release
+\`\`\`json
+{
+  "releaseId": "5f8d0d55c9e77c0017a1b2c3"
+}
+\`\`\`
+Expected Output: JSON object with release details including version, source control info, error counts and stability data.
+
+**Hints:** 1. Release IDs can be found using the List releases tool",
+    "inputSchema": [
+      "projectId",
+      "releaseId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Release",
+  },
+  "bugsnag_get_span_group": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Span Group",
+    },
+    "description": "Get detailed performance metrics for a specific span group
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- spanGroupId (string) *required*: ID of the span group
+- filters (record<string, array>): Apply filters to narrow down the span group list. Use the List Trace Fields tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"span.since":[{"type":"eq","value":"7d"}]})
+
+**Use Cases:** 1. View detailed statistics (p50, p75, p90, p95, p99) for an operation 2. Check if performance targets are configured 3. Monitor span count to understand operation volume
+
+**Examples:**
+1. Get details for an API endpoint span group
+\`\`\`json
+{
+  "spanGroupId": "[HttpClient]GET-api.example.com"
+}
+\`\`\`
+Expected Output: Statistics, category, and performance target info
+
+2. Get span group details with device filtering
+\`\`\`json
+{
+  "spanGroupId": "[HttpClient]GET-api.example.com",
+  "filters": {
+    "device.browser_name": [
+      {
+        "type": "eq",
+        "value": "Chrome"
+      }
+    ]
+  }
+}
+\`\`\`
+Expected Output: Statistics filtered for Chrome browser only
+
+**Hints:** 1. Use List Span Groups first to discover available span group IDs 2. IDs are automatically URL-encoded - provide the raw ID 3. Statistics include p50, p75, p90, p95, p99 percentiles",
+    "inputSchema": [
+      "filters",
+      "projectId",
+      "spanGroupId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Span Group",
+  },
+  "bugsnag_get_trace": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: Get Trace",
+    },
+    "description": "Get all spans within a specific trace
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- traceId (string) *required*: Trace ID
+- from (string) *required*: Start time (ISO 8601 format)
+- to (string) *required*: End time (ISO 8601 format)
+- targetSpanId (string): Optional target span ID to focus on
+- perPage (number): How many results to return per page. (default: 30)
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+
+**Use Cases:** 1. Debug slow requests by viewing all operations in the trace 2. Understand the flow of a request through the system 3. Identify bottlenecks in distributed systems
+
+**Examples:**
+1. Get all spans for a trace
+\`\`\`json
+{
+  "traceId": "abc123",
+  "from": "2024-01-01T00:00:00Z",
+  "to": "2024-01-01T23:59:59Z"
+}
+\`\`\`
+Expected Output: Array of all spans in the trace with timing and hierarchy
+
+2. Get spans for a trace with pagination and target span
+\`\`\`json
+{
+  "traceId": "def456",
+  "from": "2024-01-01T00:00:00Z",
+  "to": "2024-01-01T23:59:59Z",
+  "targetSpanId": "span-789",
+  "perPage": 50
+}
+\`\`\`
+Expected Output: Array of up to 50 spans focused around the target span
+
+**Hints:** 1. Traces show the complete execution path of a request 2. Use from/to parameters to narrow the time window 3. targetSpanId can be used to focus on a specific span in the trace",
+    "inputSchema": [
+      "from",
+      "nextUrl",
+      "perPage",
+      "projectId",
+      "targetSpanId",
+      "to",
+      "traceId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Get Trace",
+  },
+  "bugsnag_list_project_errors": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Project Errors",
+    },
+    "description": "List and search errors in a project using customizable filters and pagination
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- filters (record<string, array>): Apply filters to narrow down the error list. Use the List Project Event Filters tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"event.since":[{"type":"eq","value":"30d"}],"error.status":[{"type":"eq","value":"open"}]})
+- sort (enum): Field to sort the errors by (default: "last_seen")
+- direction (enum): Sort direction for ordering results (default: "desc")
+- perPage (number): How many results to return per page. (default: 30)
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+
+**Use Cases:** 1. Debug recent application errors by filtering for open errors in the last 7 days 2. Generate error reports for stakeholders by filtering specific error types or severity levels 3. Monitor error trends over time using date range filters 4. Find errors affecting specific users or environments using metadata filters
+
+**Examples:**
+1. Find errors affecting a specific user in the last 24 hours
+\`\`\`json
+{
+  "filters": {
+    "user.email": [
+      {
+        "type": "eq",
+        "value": "user@example.com"
+      }
+    ],
+    "event.since": [
+      {
+        "type": "eq",
+        "value": "24h"
+      }
+    ]
+  }
+}
+\`\`\`
+Expected Output: JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field
+
+2. Get the 10 open errors with the most users affected in the last 30 days
+\`\`\`json
+{
+  "filters": {
+    "event.since": [
+      {
+        "type": "eq",
+        "value": "30d"
+      }
+    ],
+    "error.status": [
+      {
+        "type": "eq",
+        "value": "open"
+      }
+    ]
+  },
+  "sort": "users",
+  "direction": "desc",
+  "perPage": 10
+}
+\`\`\`
+Expected Output: JSON object with a list of errors in the 'data' field, a count of the current page of results in the 'count' field, and a total count of all results in the 'total' field
+
+3. Get the next 50 results
+\`\`\`json
+{
+  "nextUrl": "https://api.bugsnag.com/projects/515fb9337c1074f6fd000003/errors?base=2025-08-29T13%3A11%3A37Z&direction=desc&filters%5Berror.status%5D%5B%5D%5Btype%5D=eq&filters%5Berror.status%5D%5B%5D%5Bvalue%5D=open&offset=10&per_page=10&sort=users",
+  "perPage": 50
+}
+\`\`\`
+Expected Output: JSON object with a list of errors, with a URL to the next page if more results are available and a total count of all errors matched
+
+**Hints:** 1. Use List Project Event Filters tool first to discover valid filter field names for your project 2. Combine multiple filters to narrow results - filters are applied with AND logic 3. For time filters: use relative format (7d, 24h) for recent periods or ISO 8601 UTC format (2018-05-20T00:00:00Z) for specific dates 4. Common time filters: event.since (from this time), event.before (until this time) 5. The 'event.since' filter and 'error.status' filters are always applied and if not specified are set to '30d' and 'open' respectively 6. There may not be any errors matching the filters - this is not a problem with the tool, in fact it might be a good thing that the user's application had no errors 7. This tool returns paged results. The 'page_error_count' field indicates the number of results returned in the current page, and the 'total_error_count' field indicates the total number of results across all pages. 8. If the output contains a 'next_url' value, there are more results available - call this tool again supplying the next URL as a parameter to retrieve the next page. 9. Do not modify the next URL as this can cause incorrect results. The only other parameter that can be used with 'next' is 'per_page' to control the page size.",
+    "inputSchema": [
+      "direction",
+      "filters",
+      "nextUrl",
+      "perPage",
+      "projectId",
+      "sort",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Project Errors",
+  },
+  "bugsnag_list_project_event_filters": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Project Event Filters",
+    },
+    "description": "Get available event filter fields for a project
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+
+**Use Cases:** 1. Discover what filter fields are available before searching for errors 2. Find the correct field names for filtering by user, environment, or custom metadata 3. Understand filter options and data types for building complex queries
+
+**Examples:**
+1. Get all available filter fields
+\`\`\`json
+{}
+\`\`\`
+Expected Output: JSON array of EventField objects containing display_id, custom flag, and filter/pivot options
+
+**Hints:** 1. Use this tool before the List Errors or Get Error tools to understand available filters 2. Look for display_id field in the response - these are the field names to use in filters",
+    "inputSchema": [
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Project Event Filters",
+  },
+  "bugsnag_list_projects": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Projects",
+    },
+    "description": "List all projects in the organization that the current user has access to, or find a project matching an API key.
+
+**Parameters:**
+- apiKey (string): The API key of the BugSnag project, if known.
+
+**Use Cases:** 1. Get an overview of all projects in the organization 2. Locate a project by its API key if known from the user's code
+
+**Hints:** 1. Project IDs from this list can be used with other tools when no project API key is configured",
+    "inputSchema": [
+      "apiKey",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Projects",
+  },
+  "bugsnag_list_releases": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Releases",
+    },
+    "description": "List releases for a project
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- releaseStage (string): Filter releases by this stage (e.g. production, staging), defaults to 'production' (default: "production")
+- visibleOnly (boolean): Whether to only include releases that are marked as visible in the dashboard (default: false)
+- perPage (number): How many results to return per page. (default: 30)
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+
+**Output Description:** JSON array of release summary objects with metadata, with a URL to the next page if more results are available
+
+**Use Cases:** 1. View recent releases to correlate with error spikes 2. Filter releases by stage (e.g. production, staging) for targeted analysis
+
+**Examples:**
+1. List production releases for a project
+\`\`\`json
+{}
+\`\`\`
+Expected Output: JSON array of release objects in the production stage
+
+2. List staging releases for a project
+\`\`\`json
+{
+  "releaseStage": "staging"
+}
+\`\`\`
+Expected Output: JSON array of release objects in the staging stage
+
+3. Get the next page of results
+\`\`\`json
+{
+  "nextUrl": "/projects/515fb9337c1074f6fd000003/releases?offset=30&per_page=30"
+}
+\`\`\`
+Expected Output: JSON array of release objects with metadata from the next page
+
+**Hints:** 1. Use the Get Release tool to get more details on a specific release, including the builds it contains 2. The release stage defaults to 'production' if not specified 3. Use visibleOnly to filter out releases that have been marked as hidden in the dashboard",
+    "inputSchema": [
+      "nextUrl",
+      "perPage",
+      "projectId",
+      "releaseStage",
+      "visibleOnly",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Releases",
+  },
+  "bugsnag_list_span_groups": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Span Groups",
+    },
+    "description": "List span groups (operations) tracked for performance monitoring
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- sort (enum): Field to sort by
+- direction (enum): Sort direction for ordering results (default: "desc")
+- perPage (number): How many results to return per page. (default: 30)
+- starredOnly (boolean): Show only starred span groups
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+- filters (record<string, array>): Apply filters to narrow down the span group list. Use the List Trace Fields tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"span.since":[{"type":"eq","value":"7d"}]})
+
+**Use Cases:** 1. View all operations being tracked for performance 2. Find slow operations by sorting by duration metrics 3. Filter to starred/important span groups
+
+**Examples:**
+1. List slowest operations
+\`\`\`json
+{
+  "sort": "duration_p95",
+  "direction": "desc",
+  "perPage": 10
+}
+\`\`\`
+Expected Output: Array of span groups sorted by 95th percentile duration
+
+2. List starred span groups with filtering
+\`\`\`json
+{
+  "starredOnly": true,
+  "filters": {
+    "span_group.category": [
+      {
+        "type": "eq",
+        "value": "full_page_load"
+      }
+    ]
+  }
+}
+\`\`\`
+Expected Output: Array of starred span groups filtered by category
+
+**Hints:** 1. Span groups represent different operation types (page loads, API calls, etc.) 2. Use sort by duration_p95 or duration_p99 to find the slowest operations 3. Star important span groups for quick access 4. Use nextUrl for pagination",
+    "inputSchema": [
+      "direction",
+      "filters",
+      "nextUrl",
+      "perPage",
+      "projectId",
+      "sort",
+      "starredOnly",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Span Groups",
+  },
+  "bugsnag_list_spans": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Spans",
+    },
+    "description": "Get individual spans belonging to a span group
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- spanGroupId (string) *required*: ID of the span group
+- sort (enum): Field to sort by
+- direction (enum): Sort direction for ordering results (default: "desc")
+- perPage (number): How many results to return per page. (default: 30)
+- nextUrl (string): URL for retrieving the next page of results. Use the value in the previous response to get the next page when more results are available. Only values provided in the output from this tool can be used. Do not attempt to construct it manually.
+- filters (record<string, array>): Apply filters to narrow down the span group list. Use the List Trace Fields tool to discover available filter fields. Time filters support extended ISO 8601 format (e.g. 2018-05-20T00:00:00Z) or relative format (e.g. 7d, 24h). (default: {"span.since":[{"type":"eq","value":"7d"}]})
+
+**Use Cases:** 1. Analyze individual slow operations 2. Debug performance issues by examining specific traces 3. Find patterns in operation attributes
+
+**Examples:**
+1. Get slowest spans for an operation
+\`\`\`json
+{
+  "spanGroupId": "[HttpClient]GET-api.example.com",
+  "sort": "duration",
+  "direction": "desc",
+  "perPage": 10
+}
+\`\`\`
+Expected Output: Array of the 10 slowest span instances
+
+2. Get spans filtered by OS with pagination
+\`\`\`json
+{
+  "spanGroupId": "[HttpClient]GET-api.example.com",
+  "sort": "timestamp",
+  "filters": {
+    "os.name": [
+      {
+        "type": "eq",
+        "value": "iOS"
+      }
+    ]
+  },
+  "nextUrl": "/projects/123/spans?offset=30&per_page=30"
+}
+\`\`\`
+Expected Output: Array of spans from iOS devices with next page navigation
+
+**Hints:** 1. Sort by duration descending to find the slowest instances 2. Each span includes trace ID for further investigation",
+    "inputSchema": [
+      "direction",
+      "filters",
+      "nextUrl",
+      "perPage",
+      "projectId",
+      "sort",
+      "spanGroupId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Spans",
+  },
+  "bugsnag_list_trace_fields": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BugSnag: List Trace Fields",
+    },
+    "description": "Get available trace fields/attributes for filtering
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+
+**Use Cases:** 1. Find available custom attributes for performance filtering 2. Understand what metadata is attached to traces 3. Build dynamic filters based on available fields
+
+**Examples:**
+1. Get all trace fields
+\`\`\`json
+{}
+\`\`\`
+Expected Output: Array of field names and types available for filtering
+
+**Hints:** 1. Trace fields are custom attributes added to spans 2. Use these fields for filtering other performance queries",
+    "inputSchema": [
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: List Trace Fields",
+  },
+  "bugsnag_set_network_endpoint_groupings": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "BugSnag: Set Network Endpoint Groupings",
+    },
+    "description": "Set the network endpoint grouping rules for a project
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- endpoints (array) *required*: Array of URL patterns by which network spans are grouped. Endpoints follow OpenAPI path templating syntax (https://swagger.io/specification/#path-templating) where path parameters use curly braces (e.g., /users/{id}). If you encounter colon-prefixed parameters (e.g., :userId from Express/React Router), convert them to curly braces (e.g., {userId}). Wildcards (*) can be used in domains (e.g., https://*.example.com) to match multiple subdomains.
+
+**Use Cases:** 1. Consolidate similar API endpoints into single span groups 2. Group dynamic URLs using path parameters (e.g., /api/users/{userId} groups /api/users/123, /api/users/456) 3. Match multiple subdomains using wildcards (e.g., https://*.example.com groups api.example.com, cdn.example.com) 4. Simplify performance monitoring by reducing span group clutter
+
+**Examples:**
+1. Group API endpoints with path parameters
+\`\`\`json
+{
+  "endpoints": [
+    "/api/users/{userId}",
+    "/api/products/{productId}",
+    "/api/orders/{orderId}/items/{itemId}"
+  ]
+}
+\`\`\`
+Expected Output: Success response confirming the update
+
+2. Group endpoints with domain wildcards and path parameters
+\`\`\`json
+{
+  "endpoints": [
+    "https://*.example.com/api/v1/{resourceId}",
+    "https://api.example.com/v2/users/{userId}",
+    "/graphql"
+  ]
+}
+\`\`\`
+Expected Output: Success response confirming the update
+
+3. Convert colon-prefixed parameters to curly braces (e.g., from Express/React Router)
+\`\`\`json
+{
+  "endpoints": [
+    "/{organizationSlug}/{projectSlug}/performance/view-load",
+    "/api/{version}/items/{itemId}"
+  ]
+}
+\`\`\`
+Expected Output: Success response confirming the update
+
+**Hints:** 1. Use Get Network Grouping first to see current patterns 2. Use OpenAPI path templating with curly braces for path parameters: /users/{userId}, /orders/{orderId}/items/{itemId} 3. Convert colon-prefixed parameters to curly braces: :organizationSlug becomes {organizationSlug}, :projectSlug becomes {projectSlug} 4. Wildcards (*) can be used in domains to match subdomains: https://*.example.com/api 5. This replaces all existing patterns - include all patterns you want to keep 6. Well-designed patterns reduce noise in performance monitoring",
+    "inputSchema": [
+      "endpoints",
+      "projectId",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Set Network Endpoint Groupings",
+  },
+  "bugsnag_update_error": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "BugSnag: Update Error",
+    },
+    "description": "Update the status of an error
+
+**Parameters:**
+- projectId (string): Unique identifier of the project. This is optional if a current project is set and is used to set the current project for BugSnag tools.
+- errorId (string) *required*: Unique identifier of the error
+- operation (enum) *required*: The operation to apply to the error
+- issue_url (string): The URL of the issue to link to the error - required when operation is 'link_issue'
+- reopenRules (object): Reopen rules for snooze operation - required when operation is 'snooze'
+
+**Use Cases:** 1. Mark an error as open, fixed or ignored 2. Discard or un-discard an error 3. Update the severity of an error 4. Snooze an error with defined conditions for when it should be reopened
+
+**Examples:**
+1. Mark an error as fixed
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "fix"
+}
+\`\`\`
+Expected Output: Success response indicating the error was marked as fixed
+
+2. Snooze an error for 1 hour
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "snooze",
+  "reopenRules": {
+    "reopenIf": "occurs_after",
+    "seconds": 3600
+  }
+}
+\`\`\`
+Expected Output: Success response indicating the error was snoozed for 1 hour
+
+3. Snooze an error until 5 additional users are affected
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "snooze",
+  "reopenRules": {
+    "reopenIf": "n_additional_users",
+    "additionalUsers": 5
+  }
+}
+\`\`\`
+Expected Output: Success response indicating the error was snoozed until 5 additional users are affected
+
+4. Snooze an error until 10 occurrences in 24 hours
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "snooze",
+  "reopenRules": {
+    "reopenIf": "n_occurrences_in_m_hours",
+    "occurrences": 10,
+    "hours": 24
+  }
+}
+\`\`\`
+Expected Output: Success response indicating the error was snoozed until 10 occurrences in 24 hours
+
+5. Link a Jira issue to an error
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "link_issue",
+  "issue_url": "https://smartbear.atlassian.net/browse/PIPE-9547"
+}
+\`\`\`
+Expected Output: Success response indicating the Jira issue was linked to the error
+
+6. Unlink a Jira issue from an error
+\`\`\`json
+{
+  "errorId": "6863e2af8c857c0a5023b411",
+  "operation": "unlink_issue"
+}
+\`\`\`
+Expected Output: Success response indicating the Jira issue was unlinked from the error
+
+**Hints:** 1. Only use valid operations - BugSnag may reject invalid values 2. When using 'snooze' operation, reopenRules parameter is required 3. When using 'link_issue' operation, issue_url parameter is required 4. Use 'unlink_issue' to remove the link between an error and its issue 5. For 'occurs_after' reopen rules, specify 'seconds' parameter 6. For 'n_additional_users' reopen rules, specify 'additionalUsers' parameter (max 100,000) 7. For 'n_occurrences_in_m_hours' reopen rules, specify both 'occurrences' and 'hours' parameters 8. For 'n_additional_occurrences' reopen rules, specify 'additionalOccurrences' parameter 9. Snoozing temporarily silences an error until the specified reopen condition is met",
+    "inputSchema": [
+      "errorId",
+      "issue_url",
+      "operation",
+      "projectId",
+      "reopenRules",
+    ],
+    "outputSchema": undefined,
+    "title": "BugSnag: Update Error",
+  },
+  "collaborator_create_collaborator_remote_system_configuration": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Create Collaborator Remote System Configuration",
+    },
+    "description": "Creates a remote system configuration in Collaborator (e.g., Bitbucket, GitHub, etc).
+
+**Parameters:**
+- token (string) *required*: Remote system token, e.g., BITBUCKET, GITHUB, etc.
+- title (string) *required*: Remote system title.
+- config (string) *required*: JSON string containing configuration parameters for the remote system.
+- reviewTemplateId (string): Optional review template ID used by this remote system.",
+    "inputSchema": [
+      "config",
+      "reviewTemplateId",
+      "title",
+      "token",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Create Collaborator Remote System Configuration",
+  },
+  "collaborator_create_collaborator_review": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Create Collaborator Review",
+    },
+    "description": "Creates a new review in Collaborator. All parameters are optional.
+
+**Parameters:**
+- creator (string): Collaborator username of the review creator. Optional. Default: currently logged in user.
+- title (string): Title of the review. Optional. Default: null.
+- templateName (string): Review template name. Optional. Default: system default template.
+- accessPolicy (string): Access policy for the review. Optional. Default: ANYONE.",
+    "inputSchema": [
+      "accessPolicy",
+      "creator",
+      "templateName",
+      "title",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Create Collaborator Review",
+  },
+  "collaborator_delete_collaborator_remote_system_configuration": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Delete Collaborator Remote System Configuration",
+    },
+    "description": "Deletes a remote system configuration in Collaborator by its ID.
+
+**Parameters:**
+- id (union) *required*: ID of the remote system Configuration to delete.",
+    "inputSchema": [
+      "id",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Delete Collaborator Remote System Configuration",
+  },
+  "collaborator_edit_collaborator_remote_system_configuration": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Edit Collaborator Remote System Configuration",
+    },
+    "description": "Edits parameters of an existing remote system configuration in Collaborator. Only title and config are editable after creation.
+
+**Parameters:**
+- id (string) *required*: ID of the remote system Configuration to edit.
+- title (string): Remote system title.
+- config (string): JSON string containing configuration parameters for the remote system.
+- reviewTemplateId (string): Optional review template ID used by this remote system.",
+    "inputSchema": [
+      "config",
+      "id",
+      "reviewTemplateId",
+      "title",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Edit Collaborator Remote System Configuration",
+  },
+  "collaborator_find_collaborator_review_by_id": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Find Collaborator Review By ID",
+    },
+    "description": "Finds a review in Collaborator by its review ID.
+
+**Parameters:**
+- reviewId (string) *required*: The Collaborator review ID to find.",
+    "inputSchema": [
+      "reviewId",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Find Collaborator Review By ID",
+  },
+  "collaborator_get_collaborator_reviews": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Get Collaborator Reviews",
+    },
+    "description": "Retrieves reviews from Collaborator using ReviewService.getReviews. All parameters are optional and only provided ones are sent.
+
+**Parameters:**
+- login (string): Collaborator username to filter reviews.
+- role (string): Role to filter reviews (e.g., AUTHOR).
+- creator (boolean): Whether to filter by creator.
+- reviewPhase (string): Review phase to filter (e.g., PLANNING).
+- fullInfo (boolean): Whether to retrieve full review info.
+- fromDate (string): Minimal creation date in format "yyyy-MM-dd"
+- toDate (string): Maximal creation date in format "yyyy-MM-dd"",
+    "inputSchema": [
+      "creator",
+      "fromDate",
+      "fullInfo",
+      "login",
+      "reviewPhase",
+      "role",
+      "toDate",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Get Collaborator Reviews",
+  },
+  "collaborator_reject_collaborator_review": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Reject Collaborator Review",
+    },
+    "description": "Rejects a review in Collaborator by its review ID and reason.
+
+**Parameters:**
+- reviewId (union) *required*: The Collaborator review ID to reject.
+- reason (string) *required*: Reason for rejecting the review.",
+    "inputSchema": [
+      "reason",
+      "reviewId",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Reject Collaborator Review",
+  },
+  "collaborator_reviewservice_action": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: ReviewService Action",
+    },
+    "description": "Invoke any ReviewService method by name and arguments. For finishReviewPhase and waitOnPhase, provide reviewId (required) and until (optional, defaults to 'ANY').
+
+**Parameters:**
+- action (enum) *required*
+- args (record<string, any>) *required*",
+    "inputSchema": [
+      "action",
+      "args",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: ReviewService Action",
+  },
+  "collaborator_test_collaborator_remote_system_configuration_connection": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Test Collaborator Remote System Configuration Connection",
+    },
+    "description": "Tests the connection for a remote system configuration in Collaborator by its ID.
+
+**Parameters:**
+- id (union) *required*: ID of the remote system Configuration to test connection for.",
+    "inputSchema": [
+      "id",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Test Collaborator Remote System Configuration Connection",
+  },
+  "collaborator_update_collaborator_remote_system_configuration_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Collaborator: Update Collaborator Remote System Configuration Webhook",
+    },
+    "description": "Updates the webhook for a remote system configuration in Collaborator by its ID.
+
+**Parameters:**
+- id (union) *required*: ID of the remote system Configuration to update the webhook for.",
+    "inputSchema": [
+      "id",
+    ],
+    "outputSchema": undefined,
+    "title": "Collaborator: Update Collaborator Remote System Configuration Webhook",
+  },
+  "contract-testing_add_label_to_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Add Label to Pacticipant",
+    },
+    "description": "Apply a label to a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- labelName (string) *required*: Name of the label",
+    "inputSchema": [
+      "labelName",
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Add Label to Pacticipant",
+  },
+  "contract-testing_admin_add_role_to_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Add Role to User",
+    },
+    "description": "Add a single role to a user (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user
+- roleId (string) *required*: UUID of the role",
+    "inputSchema": [
+      "roleId",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Add Role to User",
+  },
+  "contract-testing_admin_create_role": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Create Role",
+    },
+    "description": "Create a new role with specific permissions (admin).
+
+**Parameters:**
+- name (string) *required*: Name of the role
+- permissions (array) *required*: Permissions granted by this role
+- description (string): Description of the role",
+    "inputSchema": [
+      "description",
+      "name",
+      "permissions",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Create Role",
+  },
+  "contract-testing_admin_create_system_account": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Create System Account",
+    },
+    "description": "Create a new system account (admin).
+
+**Parameters:**
+- name (string) *required*: Name of the system account",
+    "inputSchema": [
+      "name",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Create System Account",
+  },
+  "contract-testing_admin_create_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Create Team",
+    },
+    "description": "Create a new team (admin).
+
+**Parameters:**
+- name (string) *required*: Name of the team
+- administratorUuids (array): UUIDs of team administrators
+- environmentUuids (array): UUIDs of environments assigned to this team
+- pacticipantNames (array): Names of pacticipants assigned to this team",
+    "inputSchema": [
+      "administratorUuids",
+      "environmentUuids",
+      "name",
+      "pacticipantNames",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Create Team",
+  },
+  "contract-testing_admin_create_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Create User",
+    },
+    "description": "Create a new user account (admin).
+
+**Parameters:**
+- email (string) *required*: Email address of the new user
+- name (string) *required*: Display name of the new user
+- firstName (string): First name
+- lastName (string): Last name
+- externalIdpId (string): External identity provider ID (for SAML/SSO)
+- externalIdpUsername (string): External IdP username (for SAML/SSO)",
+    "inputSchema": [
+      "email",
+      "externalIdpId",
+      "externalIdpUsername",
+      "firstName",
+      "lastName",
+      "name",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Create User",
+  },
+  "contract-testing_admin_delete_role": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Delete Role",
+    },
+    "description": "Delete a role (admin).
+
+**Parameters:**
+- roleId (string) *required*: UUID of the role",
+    "inputSchema": [
+      "roleId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Delete Role",
+  },
+  "contract-testing_admin_delete_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Delete Team",
+    },
+    "description": "Delete a team (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team",
+    "inputSchema": [
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Delete Team",
+  },
+  "contract-testing_admin_delete_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Delete User",
+    },
+    "description": "Delete a user account (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user",
+    "inputSchema": [
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Delete User",
+  },
+  "contract-testing_admin_get_role": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Get Role",
+    },
+    "description": "Retrieve details for a specific role by UUID (admin).
+
+**Parameters:**
+- roleId (string) *required*: UUID of the role",
+    "inputSchema": [
+      "roleId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Get Role",
+  },
+  "contract-testing_admin_get_system_account_tokens": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Get System Account Tokens",
+    },
+    "description": "Retrieve API tokens for a system account (admin).
+
+**Parameters:**
+- accountId (string) *required*: UUID of the system account",
+    "inputSchema": [
+      "accountId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Get System Account Tokens",
+  },
+  "contract-testing_admin_get_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Get Team",
+    },
+    "description": "Retrieve details for a specific team by UUID (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team",
+    "inputSchema": [
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Get Team",
+  },
+  "contract-testing_admin_get_team_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Get Team User",
+    },
+    "description": "Check if a specific user is a member of a team (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team
+- userId (string) *required*: UUID of the user",
+    "inputSchema": [
+      "teamId",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Get Team User",
+  },
+  "contract-testing_admin_get_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Get User",
+    },
+    "description": "Retrieve details for a specific user by UUID (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user",
+    "inputSchema": [
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Get User",
+  },
+  "contract-testing_admin_invite_users": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Invite Users",
+    },
+    "description": "Send invitations to new users (admin).
+
+**Parameters:**
+- users (array) *required*: List of users to invite",
+    "inputSchema": [
+      "users",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Invite Users",
+  },
+  "contract-testing_admin_list_permissions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin List Permissions",
+    },
+    "description": "List all available permission scopes (admin).
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin List Permissions",
+  },
+  "contract-testing_admin_list_roles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin List Roles",
+    },
+    "description": "List all roles defined in the workspace (admin).
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin List Roles",
+  },
+  "contract-testing_admin_list_team_users": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin List Team Users",
+    },
+    "description": "List all users in a specific team (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team",
+    "inputSchema": [
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin List Team Users",
+  },
+  "contract-testing_admin_list_teams": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin List Teams",
+    },
+    "description": "List all teams in the workspace (admin).
+
+**Parameters:**
+- q (string): Filter teams by name
+- page (number): Page number
+- size (number): Results per page",
+    "inputSchema": [
+      "page",
+      "q",
+      "size",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin List Teams",
+  },
+  "contract-testing_admin_list_users": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin List Users",
+    },
+    "description": "List all users in the workspace (admin).
+
+**Parameters:**
+- active (boolean): Filter by active/inactive status
+- q (string): Filter by name or email
+- userType (number): 0 = regular users, 1 = system accounts
+- page (number): Page number
+- size (number): Results per page",
+    "inputSchema": [
+      "active",
+      "page",
+      "q",
+      "size",
+      "userType",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin List Users",
+  },
+  "contract-testing_admin_patch_team_users": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Patch Team Users",
+    },
+    "description": "Add or remove individual users from a team using JSON Patch (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team
+- operations (array) *required*: JSON Patch operations to apply",
+    "inputSchema": [
+      "operations",
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Patch Team Users",
+  },
+  "contract-testing_admin_remove_role_from_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Remove Role from User",
+    },
+    "description": "Remove a single role from a user (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user
+- roleId (string) *required*: UUID of the role",
+    "inputSchema": [
+      "roleId",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Remove Role from User",
+  },
+  "contract-testing_admin_remove_user_from_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Remove User from Team",
+    },
+    "description": "Remove a specific user from a team (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team
+- userId (string) *required*: UUID of the user",
+    "inputSchema": [
+      "teamId",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Remove User from Team",
+  },
+  "contract-testing_admin_reset_roles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Reset Roles",
+    },
+    "description": "Reset all roles to their factory defaults (admin).
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Reset Roles",
+  },
+  "contract-testing_admin_set_team_users": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Set Team Users",
+    },
+    "description": "Replace all members of a team (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team
+- uuids (array) *required*: UUIDs of users to set as team members (replaces existing)",
+    "inputSchema": [
+      "teamId",
+      "uuids",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Set Team Users",
+  },
+  "contract-testing_admin_set_user_roles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Set User Roles",
+    },
+    "description": "Replace all roles assigned to a user (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user
+- roles (array) *required*: Array of role UUIDs to assign",
+    "inputSchema": [
+      "roles",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Set User Roles",
+  },
+  "contract-testing_admin_update_role": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Update Role",
+    },
+    "description": "Update an existing role's name and permissions (admin).
+
+**Parameters:**
+- roleId (string) *required*: UUID of the role to update
+- name (string) *required*: Name of the role
+- permissions (array) *required*: Permissions granted by this role
+- description (string): Description of the role",
+    "inputSchema": [
+      "description",
+      "name",
+      "permissions",
+      "roleId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Update Role",
+  },
+  "contract-testing_admin_update_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Update Team",
+    },
+    "description": "Replace a team's configuration (admin).
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team to update
+- name (string) *required*: Name of the team
+- administratorUuids (array): UUIDs of team administrators
+- environmentUuids (array): UUIDs of environments assigned to this team
+- pacticipantNames (array): Names of pacticipants assigned to this team",
+    "inputSchema": [
+      "administratorUuids",
+      "environmentUuids",
+      "name",
+      "pacticipantNames",
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Update Team",
+  },
+  "contract-testing_admin_update_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Admin Update User",
+    },
+    "description": "Update a user's profile or active status (admin).
+
+**Parameters:**
+- userId (string) *required*: UUID of the user to update
+- active (boolean): Whether the user is active
+- email (string): New email address
+- firstName (string): First name
+- lastName (string): Last name
+- name (string): Display name",
+    "inputSchema": [
+      "active",
+      "email",
+      "firstName",
+      "lastName",
+      "name",
+      "userId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Admin Update User",
+  },
+  "contract-testing_can_i_deploy": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Can I Deploy",
+    },
+    "description": "Performs a comprehensive compatibility check to determine whether a specific version of a service (pacticipant) can be safely deployed into a given environment. It analyzes the complete contract matrix of consumer-provider relationships to confirm that all required integrations are verified and compatible.
+
+**Parameters:**
+- pacticipant (string) *required*: The name of the pacticipant (application/service) being evaluated for deployment
+- version (string) *required*: The version of the pacticipant that you want to check if it's safe to deploy
+- environment (string) *required*: The target environment where the pacticipant version will be deployed (e.g., 'production', 'staging', 'test')",
+    "inputSchema": [
+      "environment",
+      "pacticipant",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Can I Deploy",
+  },
+  "contract-testing_check_pactflow_ai_entitlements": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Check PactFlow AI Entitlements",
+    },
+    "description": "Check your PactFlow AI entitlements and credit balance if you encounter 401 Unauthorized errors or permission/credit issues when using PactFlow AI features.
+
+**Use Cases:** 1. Diagnose 401 unauthorized errors when attempting to use PactFlow AI features 2. Check remaining AI credits when PactFlow AI operations are rejected due to insufficient credits 3. Verify account entitlements when users receive permission denied errors for PactFlow AI functionality 4. Troubleshoot PactFlow AI access issues by retrieving current entitlement status and credit balance 5. Provide detailed error context when PactFlow AI features are unavailable due to account limitations",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Check PactFlow AI Entitlements",
+  },
+  "contract-testing_create_environment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Create Environment",
+    },
+    "description": "Create a new deployment environment in PactFlow.
+
+**Parameters:**
+- name (string) *required*: Unique name for the environment (e.g. 'production', 'staging')
+- production (boolean) *required*: Whether this is a production environment
+- displayName (string): Human-readable display name
+- teamUuids (array): UUIDs of teams that own this environment",
+    "inputSchema": [
+      "displayName",
+      "name",
+      "production",
+      "teamUuids",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Create Environment",
+  },
+  "contract-testing_create_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Create Pacticipant",
+    },
+    "description": "Register a new application/service (pacticipant) in the workspace.
+
+**Parameters:**
+- name (string) *required*: Name of the pacticipant (cannot be changed after creation)
+- displayName (string): Human-readable display name
+- mainBranch (string): Name of the main/trunk branch (e.g. 'main')
+- repositoryName (string): Repository name
+- repositoryNamespace (string): Repository namespace/organisation
+- repositoryUrl (string): URL of the source repository",
+    "inputSchema": [
+      "displayName",
+      "mainBranch",
+      "name",
+      "repositoryName",
+      "repositoryNamespace",
+      "repositoryUrl",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Create Pacticipant",
+  },
+  "contract-testing_create_secret": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Create Secret",
+    },
+    "description": "Create a new secret for use in webhook authentication.
+
+**Parameters:**
+- name (string) *required*: Name of the secret
+- value (string) *required*: Value of the secret
+- description (string): Description of the secret
+- teamUuid (string): UUID of the owning team (cannot be changed after creation)",
+    "inputSchema": [
+      "description",
+      "name",
+      "teamUuid",
+      "value",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Create Secret",
+  },
+  "contract-testing_create_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Create Webhook",
+    },
+    "description": "Create a new webhook to trigger on contract events.
+
+**Parameters:**
+- description (string) *required*: Human-readable description of the webhook
+- events (array) *required*: Events that trigger this webhook
+- request (object) *required*: HTTP request to send when triggered
+- consumer (object): Restrict to a specific consumer (omit for all)
+- provider (object): Restrict to a specific provider (omit for all)
+- enabled (boolean): Whether the webhook is enabled (default: true)
+- teamUuid (string): UUID of the owning team (null for global)",
+    "inputSchema": [
+      "consumer",
+      "description",
+      "enabled",
+      "events",
+      "provider",
+      "request",
+      "teamUuid",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Create Webhook",
+  },
+  "contract-testing_delete_all_integrations": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete All Integrations",
+    },
+    "description": "Delete ALL consumer-provider integrations in the workspace.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete All Integrations",
+  },
+  "contract-testing_delete_branch": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Branch",
+    },
+    "description": "Delete a branch from a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- branchName (string) *required*: Name of the branch to delete",
+    "inputSchema": [
+      "branchName",
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Branch",
+  },
+  "contract-testing_delete_environment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Environment",
+    },
+    "description": "Delete an environment by UUID.
+
+**Parameters:**
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Environment",
+  },
+  "contract-testing_delete_integration": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Integration",
+    },
+    "description": "Delete a specific consumer-provider integration.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- consumerName (string) *required*: Name of the consumer",
+    "inputSchema": [
+      "consumerName",
+      "providerName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Integration",
+  },
+  "contract-testing_delete_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Pacticipant",
+    },
+    "description": "Delete a pacticipant and all its associated data.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant to delete",
+    "inputSchema": [
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Pacticipant",
+  },
+  "contract-testing_delete_secret": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Secret",
+    },
+    "description": "Delete a secret by UUID.
+
+**Parameters:**
+- secretId (string) *required*: UUID of the secret",
+    "inputSchema": [
+      "secretId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Secret",
+  },
+  "contract-testing_delete_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Delete Webhook",
+    },
+    "description": "Delete a webhook by UUID.
+
+**Parameters:**
+- webhookId (string) *required*: UUID of the webhook",
+    "inputSchema": [
+      "webhookId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Delete Webhook",
+  },
+  "contract-testing_execute_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Execute Webhook",
+    },
+    "description": "Trigger a test execution of a specific webhook.
+
+**Parameters:**
+- webhookId (string) *required*: UUID of the webhook",
+    "inputSchema": [
+      "webhookId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Execute Webhook",
+  },
+  "contract-testing_get_audit_log": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Audit Log",
+    },
+    "description": "Retrieve the audit log of events in the workspace.
+
+**Parameters:**
+- since (string): Only include events at or after this ISO 8601 timestamp
+- userUuid (string): Filter events by PactFlow user UUID
+- type (string): Filter events by type (e.g. 'pact_publication')
+- sort (string): Sort order: '+timestamp' (asc, default) or '-timestamp' (desc)
+- from (string): Start result set from this audit event UUID (keyset pagination)
+- pageNumber (number): Page number
+- pageSize (number): Results per page (max 100)
+
+**Use Cases:** 1. Review recent changes to pacticipants, webhooks, or secrets 2. Investigate who published a specific pact or verification 3. Filter events by user or event type for compliance reporting 4. Track deployment recording activity across environments",
+    "inputSchema": [
+      "from",
+      "pageNumber",
+      "pageSize",
+      "since",
+      "sort",
+      "type",
+      "userUuid",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Audit Log",
+  },
+  "contract-testing_get_bdct_consumer_contract_by_consumer_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Consumer Contract by Consumer Version",
+    },
+    "description": "Fetch the consumer Pact contract for a specific consumer-provider version pair in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number
+- consumerName (string) *required*: Name of the consumer
+- consumerVersionNumber (string) *required*: Consumer version number",
+    "inputSchema": [
+      "consumerName",
+      "consumerVersionNumber",
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Consumer Contract by Consumer Version",
+  },
+  "contract-testing_get_bdct_consumer_contract_verification_results": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Consumer Contract Verification Results",
+    },
+    "description": "Fetch the consumer contract verification results for a given provider version in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number",
+    "inputSchema": [
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Consumer Contract Verification Results",
+  },
+  "contract-testing_get_bdct_consumer_contract_verification_results_by_consumer_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Consumer Contract Verification Results by Consumer Version",
+    },
+    "description": "Fetch the consumer contract verification results for a specific consumer-provider version pair in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number
+- consumerName (string) *required*: Name of the consumer
+- consumerVersionNumber (string) *required*: Consumer version number",
+    "inputSchema": [
+      "consumerName",
+      "consumerVersionNumber",
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Consumer Contract Verification Results by Consumer Version",
+  },
+  "contract-testing_get_bdct_consumer_contracts": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Consumer Contracts",
+    },
+    "description": "Fetch all consumer Pact contracts relevant to a given provider version in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number",
+    "inputSchema": [
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Consumer Contracts",
+  },
+  "contract-testing_get_bdct_cross-contract_verification_results": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Cross-Contract Verification Results",
+    },
+    "description": "Fetch the cross-contract verification results for a given provider version in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number",
+    "inputSchema": [
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Cross-Contract Verification Results",
+  },
+  "contract-testing_get_bdct_cross-contract_verification_results_by_consumer_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Cross-Contract Verification Results by Consumer Version",
+    },
+    "description": "Fetch the cross-contract verification results for a specific consumer-provider version pair in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number
+- consumerName (string) *required*: Name of the consumer
+- consumerVersionNumber (string) *required*: Consumer version number",
+    "inputSchema": [
+      "consumerName",
+      "consumerVersionNumber",
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Cross-Contract Verification Results by Consumer Version",
+  },
+  "contract-testing_get_bdct_provider_contract": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Provider Contract",
+    },
+    "description": "Fetch the provider OpenAPI contract for a given provider version in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number",
+    "inputSchema": [
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Provider Contract",
+  },
+  "contract-testing_get_bdct_provider_contract_by_consumer_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Provider Contract by Consumer Version",
+    },
+    "description": "Fetch the provider OpenAPI contract for a specific consumer-provider version pair in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number
+- consumerName (string) *required*: Name of the consumer
+- consumerVersionNumber (string) *required*: Consumer version number",
+    "inputSchema": [
+      "consumerName",
+      "consumerVersionNumber",
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Provider Contract by Consumer Version",
+  },
+  "contract-testing_get_bdct_provider_contract_verification_results": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Provider Contract Verification Results",
+    },
+    "description": "Fetch the self-verification results for a provider contract version in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number",
+    "inputSchema": [
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Provider Contract Verification Results",
+  },
+  "contract-testing_get_bdct_provider_contract_verification_results_by_consumer_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get BDCT Provider Contract Verification Results by Consumer Version",
+    },
+    "description": "Fetch the provider contract self-verification results for a specific consumer-provider version pair in Bi-Directional Contract Testing.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider
+- providerVersionNumber (string) *required*: Provider version number
+- consumerName (string) *required*: Name of the consumer
+- consumerVersionNumber (string) *required*: Consumer version number",
+    "inputSchema": [
+      "consumerName",
+      "consumerVersionNumber",
+      "providerName",
+      "providerVersionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get BDCT Provider Contract Verification Results by Consumer Version",
+  },
+  "contract-testing_get_branch": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Branch",
+    },
+    "description": "Retrieve details for a specific branch of a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- branchName (string) *required*: Name of the branch",
+    "inputSchema": [
+      "branchName",
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Branch",
+  },
+  "contract-testing_get_branch_versions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Branch Versions",
+    },
+    "description": "Retrieve all versions published from a specific branch of a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- branchName (string) *required*: Name of the branch
+- pageNumber (number): Page number
+- pageSize (number): Results per page",
+    "inputSchema": [
+      "branchName",
+      "pacticipantName",
+      "pageNumber",
+      "pageSize",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Branch Versions",
+  },
+  "contract-testing_get_current_user": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Current User",
+    },
+    "description": "Retrieve the profile of the currently authenticated user.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Current User",
+  },
+  "contract-testing_get_currently_deployed_versions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Currently Deployed Versions",
+    },
+    "description": "Retrieve all versions currently deployed to a given environment.
+
+**Parameters:**
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Currently Deployed Versions",
+  },
+  "contract-testing_get_currently_supported_versions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Currently Supported Versions",
+    },
+    "description": "Retrieve all versions currently released and supported in a given environment.
+
+**Parameters:**
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Currently Supported Versions",
+  },
+  "contract-testing_get_deployed_versions_for_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Deployed Versions for Version",
+    },
+    "description": "Retrieve deployment records for a specific pacticipant version in a specific environment.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- versionNumber (string) *required*: Version number
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Deployed Versions for Version",
+  },
+  "contract-testing_get_environment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Environment",
+    },
+    "description": "Retrieve details for a specific environment by UUID.
+
+**Parameters:**
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Environment",
+  },
+  "contract-testing_get_integrations_by_team": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Integrations by Team",
+    },
+    "description": "Retrieve all consumer-provider integrations belonging to a specific team.
+
+**Parameters:**
+- teamId (string) *required*: UUID of the team",
+    "inputSchema": [
+      "teamId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Integrations by Team",
+  },
+  "contract-testing_get_latest_pacticipant_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Latest Pacticipant Version",
+    },
+    "description": "Retrieve the latest version of a pacticipant, optionally filtered by tag.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- tag (string): Tag to filter by. If omitted, returns the overall latest version.",
+    "inputSchema": [
+      "pacticipantName",
+      "tag",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Latest Pacticipant Version",
+  },
+  "contract-testing_get_metrics": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Metrics",
+    },
+    "description": "Fetch metrics across the entire workspace
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Metrics",
+  },
+  "contract-testing_get_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Pacticipant",
+    },
+    "description": "Retrieve details for a specific pacticipant by name.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant (application or service)",
+    "inputSchema": [
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Pacticipant",
+  },
+  "contract-testing_get_pacticipant_label": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Pacticipant Label",
+    },
+    "description": "Check whether a specific label is applied to a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- labelName (string) *required*: Name of the label",
+    "inputSchema": [
+      "labelName",
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Pacticipant Label",
+  },
+  "contract-testing_get_pacticipant_network": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Pacticipant Network",
+    },
+    "description": "Retrieve the integration network graph for a specific pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant to get network for",
+    "inputSchema": [
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Pacticipant Network",
+  },
+  "contract-testing_get_pacticipant_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Pacticipant Version",
+    },
+    "description": "Retrieve details for a specific version of a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- versionNumber (string) *required*: Version number to retrieve",
+    "inputSchema": [
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Pacticipant Version",
+  },
+  "contract-testing_get_pacts_for_verification": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Pacts for Verification",
+    },
+    "description": "Retrieve the pacts that a provider should verify, based on consumer version selectors and WIP/pending pact configuration.
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider to get pacts for
+- consumerVersionSelectors (array): Selectors specifying which consumer versions to include
+- includePendingStatus (boolean): Include the pending status in the results
+- includeWipPactsSince (string): Include WIP pacts published since this date (ISO 8601)
+- providerVersionBranch (string): Branch of the provider version being verified
+- providerVersionTags (array): Tags for the provider version being verified",
+    "inputSchema": [
+      "consumerVersionSelectors",
+      "includePendingStatus",
+      "includeWipPactsSince",
+      "providerName",
+      "providerVersionBranch",
+      "providerVersionTags",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Pacts for Verification",
+  },
+  "contract-testing_get_provider_states": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Provider States",
+    },
+    "description": "Retrieve the states of a specific provider
+
+**Parameters:**
+- provider (string) *required*: name of the provider to retrieve states for",
+    "inputSchema": [
+      "provider",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Provider States",
+  },
+  "contract-testing_get_released_versions_for_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Released Versions for Version",
+    },
+    "description": "Retrieve release records for a specific pacticipant version in a specific environment.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- versionNumber (string) *required*: Version number
+- environmentId (string) *required*: UUID of the environment",
+    "inputSchema": [
+      "environmentId",
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Released Versions for Version",
+  },
+  "contract-testing_get_secret": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Secret",
+    },
+    "description": "Retrieve metadata for a specific secret by UUID.
+
+**Parameters:**
+- secretId (string) *required*: UUID of the secret",
+    "inputSchema": [
+      "secretId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Secret",
+  },
+  "contract-testing_get_system_preferences": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get System Preferences",
+    },
+    "description": "Retrieve system-wide preferences.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get System Preferences",
+  },
+  "contract-testing_get_team_metrics": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Team Metrics",
+    },
+    "description": "Fetch metrics for all teams
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Team Metrics",
+  },
+  "contract-testing_get_user_preferences": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get User Preferences",
+    },
+    "description": "Retrieve the current user's preferences.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get User Preferences",
+  },
+  "contract-testing_get_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Get Webhook",
+    },
+    "description": "Retrieve details for a specific webhook by UUID.
+
+**Parameters:**
+- webhookId (string) *required*: UUID of the webhook",
+    "inputSchema": [
+      "webhookId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Get Webhook",
+  },
+  "contract-testing_list_api_tokens": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List API Tokens",
+    },
+    "description": "Retrieve API tokens for the current user.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List API Tokens",
+  },
+  "contract-testing_list_branches": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Branches",
+    },
+    "description": "Retrieve all branches for a given pacticipant, with optional filtering and pagination.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- q (string): Filter branches by name
+- pageNumber (number): Page number (default: 1)
+- pageSize (number): Results per page (default: 100)",
+    "inputSchema": [
+      "pacticipantName",
+      "pageNumber",
+      "pageSize",
+      "q",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Branches",
+  },
+  "contract-testing_list_environments": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Environments",
+    },
+    "description": "Retrieve all environments configured in the Pact Broker or PactFlow workspace.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Environments",
+  },
+  "contract-testing_list_integrations": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Integrations",
+    },
+    "description": "Retrieve all consumer-provider integrations registered in the workspace.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Integrations",
+  },
+  "contract-testing_list_labels": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Labels",
+    },
+    "description": "Retrieve all labels used across the workspace.
+
+**Parameters:**
+- pageNumber (number): Page number
+- pageSize (number): Results per page",
+    "inputSchema": [
+      "pageNumber",
+      "pageSize",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Labels",
+  },
+  "contract-testing_list_pacticipant_versions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Pacticipant Versions",
+    },
+    "description": "Retrieve all versions for a given pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- pageNumber (number): Page number
+- pageSize (number): Results per page",
+    "inputSchema": [
+      "pacticipantName",
+      "pageNumber",
+      "pageSize",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Pacticipant Versions",
+  },
+  "contract-testing_list_pacticipants": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Pacticipants",
+    },
+    "description": "Retrieve all pacticipants (applications/services) registered in the Pact Broker or PactFlow workspace.
+
+**Parameters:**
+- pageNumber (number): Page number (default: 1)
+- pageSize (number): Number of results per page",
+    "inputSchema": [
+      "pageNumber",
+      "pageSize",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Pacticipants",
+  },
+  "contract-testing_list_pacticipants_by_label": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Pacticipants by Label",
+    },
+    "description": "Retrieve all pacticipants that have a specific label applied.
+
+**Parameters:**
+- labelName (string) *required*: Label name to filter by",
+    "inputSchema": [
+      "labelName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Pacticipants by Label",
+  },
+  "contract-testing_list_secrets": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Secrets",
+    },
+    "description": "Retrieve all secrets stored in the workspace.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Secrets",
+  },
+  "contract-testing_list_webhooks": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: List Webhooks",
+    },
+    "description": "Retrieve all webhooks configured in the workspace.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: List Webhooks",
+  },
+  "contract-testing_matrix": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Matrix",
+    },
+    "description": "Retrieve the comprehensive contract verification matrix that shows the relationship between consumer and provider versions, their associated pact files, and verification results stored in the Pact Broker or Pactflow. The matrix provides detailed visibility into which consumer and provider versions have been successfully verified against each other, and highlights failures with detailed information about the cause.
+
+**Parameters:**
+- latestby (string): This property removes the rows for the overridden pacts/verifications from the results. The options are cvp (show only the latest row for each consumer version and provider) and cvpv (show only the latest row each consumer version and provider version). For a can-i-deploy query with one selector, it should be set to cvp. For a can-i-deploy query with two selectors, it should be set to cvpv.
+- limit (number): The limit on the number of results to return (1-1000, default: 100) (default: 100)
+- q (array) *required*
+
+**Use Cases:** 1. Quickly identify which consumer and provider version combinations have passed or failed verification. 2. Diagnose and investigate why a particular consumer-provider verification failed. 3. Visualize the overall contract compatibility across two pacticipants / services. 4. Perform advanced queries using selectors to understand compatibility within specific branches, environments, or version ranges. 5. Support informed deployment decisions by answering 'can I deploy version X of this service to production?' 6. Expose contract verification details to non-frequent API users in a more accessible format.",
+    "inputSchema": [
+      "latestby",
+      "limit",
+      "q",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Matrix",
+  },
+  "contract-testing_patch_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Patch Pacticipant",
+    },
+    "description": "Partially update a pacticipant's metadata — only fields provided are changed.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant to update
+- displayName (string): Human-readable display name
+- mainBranch (string): Name of the main/trunk branch (e.g. 'main')
+- repositoryName (string): Repository name
+- repositoryNamespace (string): Repository namespace/organisation
+- repositoryUrl (string): URL of the source repository",
+    "inputSchema": [
+      "displayName",
+      "mainBranch",
+      "pacticipantName",
+      "repositoryName",
+      "repositoryNamespace",
+      "repositoryUrl",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Patch Pacticipant",
+  },
+  "contract-testing_publish_consumer_contracts": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Publish Consumer Contracts",
+    },
+    "description": "Publish one or more consumer Pact contracts to the Pact Broker or PactFlow, with branch and tag metadata.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the consumer application
+- pacticipantVersionNumber (string) *required*: Version number of the consumer
+- contracts (array) *required*: Contracts to publish
+- tags (array): Version tags (e.g. 'main', 'staging')
+- branch (string): Branch name of the consumer
+- buildUrl (string): URL of the CI build that produced these contracts",
+    "inputSchema": [
+      "branch",
+      "buildUrl",
+      "contracts",
+      "pacticipantName",
+      "pacticipantVersionNumber",
+      "tags",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Publish Consumer Contracts",
+  },
+  "contract-testing_publish_provider_contract": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Publish Provider Contract",
+    },
+    "description": "Publish a provider OpenAPI contract and self-verification results to PactFlow (Bi-Directional Contract Testing).
+
+**Parameters:**
+- providerName (string) *required*: Name of the provider application
+- pacticipantVersionNumber (string) *required*: Version number of the provider
+- contract (object) *required*: Provider contract (OpenAPI spec) and verification details
+- tags (array): Version tags
+- branch (string): Branch name of the provider
+- buildUrl (string): URL of the CI build",
+    "inputSchema": [
+      "branch",
+      "buildUrl",
+      "contract",
+      "pacticipantVersionNumber",
+      "providerName",
+      "tags",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Publish Provider Contract",
+  },
+  "contract-testing_record_deployment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Record Deployment",
+    },
+    "description": "Record that a version of a pacticipant has been deployed to an environment.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant that was deployed
+- versionNumber (string) *required*: Version number that was deployed
+- environmentId (string) *required*: UUID of the target environment
+- applicationInstance (string): Identifies a specific instance when multiple instances of the same application are deployed to the same environment (e.g. 'blue', 'green')",
+    "inputSchema": [
+      "applicationInstance",
+      "environmentId",
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Record Deployment",
+  },
+  "contract-testing_record_release": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Record Release",
+    },
+    "description": "Record that a version of a pacticipant has been released to an environment (for mobile/library release workflows).
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant that was released
+- versionNumber (string) *required*: Version number that was released
+- environmentId (string) *required*: UUID of the target environment",
+    "inputSchema": [
+      "environmentId",
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Record Release",
+  },
+  "contract-testing_regenerate_api_token": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Regenerate API Token",
+    },
+    "description": "Regenerate (rotate) an API token by ID.
+
+**Parameters:**
+- tokenId (string) *required*: ID of the token to regenerate",
+    "inputSchema": [
+      "tokenId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Regenerate API Token",
+  },
+  "contract-testing_remove_label_from_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Remove Label from Pacticipant",
+    },
+    "description": "Remove a label from a pacticipant.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- labelName (string) *required*: Name of the label",
+    "inputSchema": [
+      "labelName",
+      "pacticipantName",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Remove Label from Pacticipant",
+  },
+  "contract-testing_test_execute_webhooks": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Test Execute Webhooks",
+    },
+    "description": "Trigger a test execution of all matching webhooks without a real event.
+
+**Parameters:**",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Test Execute Webhooks",
+  },
+  "contract-testing_update_environment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Update Environment",
+    },
+    "description": "Update an existing environment's metadata.
+
+**Parameters:**
+- environmentId (string) *required*: UUID of the environment to update
+- name (string) *required*: Unique name for the environment
+- production (boolean) *required*: Whether this is a production environment
+- displayName (string): Human-readable display name
+- teamUuids (array): UUIDs of teams that own this environment",
+    "inputSchema": [
+      "displayName",
+      "environmentId",
+      "name",
+      "production",
+      "teamUuids",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Update Environment",
+  },
+  "contract-testing_update_pacticipant": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Update Pacticipant",
+    },
+    "description": "Fully replace a pacticipant's metadata (display name, main branch, repository URL, etc.).
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant to update
+- displayName (string): Human-readable display name
+- mainBranch (string): Name of the main/trunk branch (e.g. 'main')
+- repositoryName (string): Repository name
+- repositoryNamespace (string): Repository namespace/organisation
+- repositoryUrl (string): URL of the source repository",
+    "inputSchema": [
+      "displayName",
+      "mainBranch",
+      "pacticipantName",
+      "repositoryName",
+      "repositoryNamespace",
+      "repositoryUrl",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Update Pacticipant",
+  },
+  "contract-testing_update_pacticipant_version": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Update Pacticipant Version",
+    },
+    "description": "Update metadata for a specific pacticipant version.
+
+**Parameters:**
+- pacticipantName (string) *required*: Name of the pacticipant
+- versionNumber (string) *required*: Version number to update
+- buildUrl (string): URL of the CI build that produced this version",
+    "inputSchema": [
+      "buildUrl",
+      "pacticipantName",
+      "versionNumber",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Update Pacticipant Version",
+  },
+  "contract-testing_update_secret": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Update Secret",
+    },
+    "description": "Update an existing secret's name, value, or description.
+
+**Parameters:**
+- secretId (string) *required*: UUID of the secret to update
+- name (string): New name for the secret
+- value (string): New value for the secret
+- description (string): New description",
+    "inputSchema": [
+      "description",
+      "name",
+      "secretId",
+      "value",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Update Secret",
+  },
+  "contract-testing_update_webhook": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Contract Testing: Update Webhook",
+    },
+    "description": "Update an existing webhook's configuration.
+
+**Parameters:**
+- webhookId (string) *required*: UUID of the webhook to update
+- description (string): Human-readable description
+- events (array): Events that trigger this webhook
+- request (object): HTTP request to send when triggered
+- consumer (object): Restrict to a specific consumer
+- provider (object): Restrict to a specific provider
+- enabled (boolean): Whether the webhook is enabled
+- teamUuid (string): UUID of the owning team",
+    "inputSchema": [
+      "consumer",
+      "description",
+      "enabled",
+      "events",
+      "provider",
+      "request",
+      "teamUuid",
+      "webhookId",
+    ],
+    "outputSchema": undefined,
+    "title": "Contract Testing: Update Webhook",
+  },
+  "qmetry_bulk_update_test_case_execution_status": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Bulk Update Test Case Execution Status",
+    },
+    "description": "Update execution status for individual or multiple test case runs in bulk
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- entityIDs (string) *required*: Comma-separated IDs of Test Case Runs to update (e.g., '66095087' for single or '66095069,66095075' for bulk). To get the entityIDs - Call API 'Execution/Fetch Testcase Run ID' From the response, get value of following attribute -> data[<index>].tcRunID
+- entityType (enum): Type of Entity to Execute: 'TCR' (Test Case Run) or 'TCSR' (Test Case Step Run) (default: "TCR")
+- qmTsRunId (string) *required*: Id of Test Suite Run to execute (required). To get the qmTsRunId - Call API 'Execution/Fetch Executions' From the response, get value of following attribute -> data[<index>].tsRunID
+- runStatusID (number) *required*: Id of the execution status to set (required). To get the runStatusID - Call API 'Admin/Project GET info Service' From the response, get value of following attribute -> allstatus[<index>].id Common statuses: Pass, Fail, Not Run, Blocked, WIP, etc.
+- dropID (union): Unique identifier of drop/build on which execution is to be performed (optional). To get the dropID - Call API 'Fetch Build/List' From the response, get value of following attribute -> data[<index>].dropID
+- isAutoExecuted (enum): Set '1' for automated and '0' for manual Execution Type
+- isBulkOperation (boolean): Set true for bulk operations (multiple entityIDs), false for single execution update. Default: true if multiple comma-separated entityIDs, false otherwise
+- comments (string): Optional comments for the execution status update
+- username (string): If Part 11 Compliance is active then required for authentication
+- password (string): If Part 11 Compliance is active then required for authentication
+- qmRunObj (string): Internal QMetry run object (optional, usually empty string)
+- type (enum): Type of Entity - same as entityType (for backwards compatibility)
+
+**Output Description:** JSON object with success status, updated execution details, and confirmation message
+
+**Use Cases:** 1. Update single test case run status to Pass, Fail, Blocked, or Not Run 2. Bulk update multiple test case run statuses in a single operation 3. Mark all selected test case runs as Not Run for re-execution 4. Update execution status after manual test execution 5. Set execution status based on automated test results 6. Update test execution status across different test environments 7. Track test execution progress and completion 8. Manage test execution status for compliance and reporting
+
+**Examples:**
+1. Update single test case run status to Failed (single execution)
+\`\`\`json
+{
+  "entityIDs": "66095087",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123266,
+  "isBulkOperation": false
+}
+\`\`\`
+Expected Output: Test case run 66095087 status updated to Failed successfully
+
+2. Bulk update two test case runs to Pass status (bulk execution)
+\`\`\`json
+{
+  "entityIDs": "66095069,66095075",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123268,
+  "isBulkOperation": true,
+  "comments": "All test cases passed successfully"
+}
+\`\`\`
+Expected Output: Test case runs 66095069 and 66095075 updated to Pass status successfully
+
+3. Bulk update all selected test case runs to Not Run status
+\`\`\`json
+{
+  "entityIDs": "66095069,66095075,66095081,66095087,66095093,66095099,66095105",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123269,
+  "isBulkOperation": true
+}
+\`\`\`
+Expected Output: 7 test case runs updated to Not Run status successfully for re-execution
+
+4. Update test case run with build/drop information
+\`\`\`json
+{
+  "entityIDs": "66095087",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123266,
+  "dropID": 947,
+  "isBulkOperation": false
+}
+\`\`\`
+Expected Output: Test case run updated with execution status and build information
+
+5. Update automated test execution status with automation flag
+\`\`\`json
+{
+  "entityIDs": "66095069,66095075",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123268,
+  "isAutoExecuted": "1",
+  "isBulkOperation": true,
+  "comments": "Automated test execution completed"
+}
+\`\`\`
+Expected Output: Automated test case runs updated to Pass status with automation flag
+
+6. Update test case run status with Part 11 Compliance authentication
+\`\`\`json
+{
+  "entityIDs": "66095087",
+  "entityType": "TCR",
+  "qmTsRunId": "2720260",
+  "runStatusID": 123266,
+  "username": "dhaval.mistry",
+  "password": "Ispl123#",
+  "isBulkOperation": false
+}
+\`\`\`
+Expected Output: Test case run status updated with Part 11 Compliance authentication
+
+7. Update ALL executions of test suite VKMC-TS-20 to Failed (MULTI-CALL OPERATION)
+\`\`\`json
+{
+  "entityIDs": "66341841,66342887,66342893,66342899",
+  "entityType": "TCR",
+  "qmTsRunId": "2733104",
+  "runStatusID": 123269,
+  "isBulkOperation": true
+}
+\`\`\`
+Expected Output: Execution 1/4 updated. The MCP Agent will automatically repeat this operation for executions 2733205, 2733306, and 2733407 using their corresponding entityIDs.
+
+**Hints:** 1. CRITICAL: entityIDs, entityType, qmTsRunId, and runStatusID are REQUIRED parameters 2.  3. CRITICAL - ALWAYS FETCH STATUS IDs FROM PROJECT INFO: 4. NEVER use hardcoded or memorized status IDs. Status IDs are PROJECT-SPECIFIC and must be fetched dynamically. 5. MANDATORY WORKFLOW BEFORE USING runStatusID: 6. 1. Call mcp_smartbear_qmetry_fetch_qmetry_project_info with the current projectKey 7. 2. Extract the 'allstatus' array from the response 8. 3. Match the desired status NAME to find its corresponding ID 9. 4. Use the fetched ID in the runStatusID parameter 10.  11. EXAMPLE STATUS ID RESOLUTION: 12. User says: 'Update status to Failed' 13. Step 1: Call FETCH_PROJECT_INFO → Get allstatus array 14. Step 2: Find status where name='Failed' → Extract its id property 15. Step 3: Use that id as runStatusID (e.g., 123269 for 'Failed') 16.  17. COMMON STATUS NAMES (IDs vary by project - MUST VALIDATE): 18. - 'Passed' / 'Pass' - Test case executed successfully 19. - 'Failed' / 'Fail' - Test case failed with errors 20. - 'Blocked' - Test case cannot be executed due to blockers 21. - 'Not Run' - Test case not yet executed or needs re-execution 22. - 'WIP' / 'Work In Progress' - Test case execution in progress 23. - 'Not Applicable' - Test case not applicable for this execution 24.  25. WHY THIS IS CRITICAL: 26. - Status IDs are assigned per QMetry project and are NOT universal 27. - Using wrong status ID will update tests with incorrect status 28. - Example: ID 123268 might be 'Blocked' in one project but 'Passed' in another 29. - The allstatus array is the AUTHORITATIVE source for all status mappings 30.  31. HOW TO GET entityIDs (Test Case Run IDs): 32. 1. Call API 'Execution/Fetch Testcase Run ID' (FETCH_TESTCASE_RUNS_BY_TESTSUITE_RUN tool) 33. 2. From the response, get value of following attribute -> data[<index>].tcRunID 34. 3. Example: Single ID '66095087' or Multiple IDs '66095069,66095075,66095081' 35. 4. For bulk operations, provide comma-separated IDs without spaces 36. HOW TO GET qmTsRunId (Test Suite Run ID): 37. 1. Call API 'Execution/Fetch Executions' (FETCH_EXECUTIONS_BY_TESTSUITE tool) 38. 2. From the response, get value of following attribute -> data[<index>].tsRunID 39. 3. Example: Test Suite Run ID might be '2720260' 40. HOW TO GET runStatusID (Execution Status ID) - DETAILED PROCESS: 41. 1. Call API 'Admin/Get info Service' (FETCH_PROJECT_INFO tool) with projectKey 42. 2. From the response, locate the 'allstatus' array 43. 3. Search for the status object where name matches your desired status (case-insensitive) 44. 4. Extract the 'id' property from the matching status object 45. 5. NEVER use example IDs from documentation - they are project-specific 46.  47. EXAMPLE allstatus ARRAY STRUCTURE: 48. allstatus: [ 49.   { name: 'Passed', defaultName: 'passed', id: 123266, color: '#14892C|#FFFFFF' }, 50.   { name: 'Failed', defaultName: 'failed', id: 123269, color: '#FF6666|#FFFFFF' }, 51.   { name: 'Blocked', defaultName: 'blocked', id: 123268, color: '#CCCCCC|#FFFFFF' }, 52.   { name: 'Not Run', defaultName: 'notrun', id: 123270, color: '#205081|#FFFFFF', isdefault: true }, 53.   { name: 'Not Applicable', defaultName: 'empty', id: 123267, color: '#59AFE1|#FFFFFF' } 54. ] 55. Note: Above IDs are EXAMPLES ONLY - fetch actual IDs from your project 56. HOW TO GET dropID (Build/Drop ID) - OPTIONAL: 57. 1. Call API 'Build/List' (FETCH_BUILDS tool) 58. 2. From the response, get value of following attribute -> data[<index>].dropID 59. 3. Example: Build/Drop ID might be 947 60. ENTITY TYPES: 61. - 'TCR' = Test Case Run (most common use case) 62. - 'TCSR' = Test Case Step Run (for step-level execution updates) 63. BULK OPERATION FLAG: 64. - isBulkOperation=false: Single test case run update (one entityID) 65. - isBulkOperation=true: Multiple test case runs update (comma-separated entityIDs) 66. - Auto-detected: If entityIDs contains comma, defaults to true; otherwise false 67. AUTOMATION FLAG (isAutoExecuted) - OPTIONAL: 68. - '1' = Automated execution (test run by automation framework) 69. - '0' = Manual execution (test run by human tester) 70. - Used for execution tracking and reporting purposes 71. PART 11 COMPLIANCE (username & password) - CONDITIONAL: 72. - Required ONLY if Part 11 Compliance is active in your QMetry instance 73. - Used for regulatory compliance and audit trail purposes 74. - Not needed for standard QMetry installations 75. COMMENTS FIELD - OPTIONAL: 76. - Add execution notes, failure reasons, or status change context 77. - Useful for tracking why status was changed 78. - Appears in execution history and audit logs 79. COMMON EXECUTION STATUS NAMES: 80. - Pass: Test case executed successfully 81. - Fail: Test case failed with errors 82. - Blocked: Test case cannot be executed due to blockers 83. - Not Run: Test case not yet executed or needs re-execution 84. - WIP: Work In Progress - test case execution in progress 85. WORKFLOW FOR USER PROMPTS: 86. 1. If user says 'execute test case run by id to failed' or 'update status to fail': 87.    - Fetch test case runs to get tcRunID (entityIDs) 88.    - Fetch project info to get 'Fail' status ID (runStatusID) 89.    - Set isBulkOperation=false for single ID 90. 2. If user says 'bulk update test case run status to pass' or 'update all to passed': 91.    - Fetch test case runs to get multiple tcRunIDs 92.    - Fetch project info to get 'Pass' status ID 93.    - Set isBulkOperation=true 94.    - Join multiple IDs with commas (no spaces) 95. 3. If user says 'execute status to not run of given test case run ids': 96.    - Use provided IDs or fetch if needed 97.    - Fetch project info to get 'Not Run' status ID 98.    - Set isBulkOperation based on ID count 99. 4. If the user requests updating status for ALL executions of a test suite, the agent must: 100.    1. Call FETCH_EXECUTIONS_BY_TESTSUITE to get all qmTsRunIds. 101.    2. For each qmTsRunId: 102.       - Call FETCH_TESTCASE_RUNS_BY_TESTSUITE_RUN to get tcRunID (entityIDs) 103.       - Fetch project info to get 'Fail' status ID (runStatusID) 104.       - Call BULK_UPDATE_EXECUTION_STATUS with the corresponding qmTsRunId + tcRunID + desired runStatusID 105.    3. Repeat until all executions are updated. 106.    This tool is intended to be invoked multiple times in sequence for multi-execution updates. 107. FIELD MAPPING CRITICAL NOTES: 108. - entityIDs must be comma-separated STRING (e.g., '66095069,66095075') 109. - qmTsRunId must be STRING format (e.g., '2720260') 110. - runStatusID must be NUMERIC (e.g., 123268) 111. - dropID can be numeric or string (flexible) 112. API ENDPOINT: PUT /rest/execution/runstatus/bulkupdate 113. This tool is essential for test execution management and status tracking 114. Critical for maintaining accurate test execution records and reporting 115. Use for manual test execution updates and automated test result integration 116. Essential for test execution audit trails and compliance requirements",
+    "inputSchema": [
+      "baseUrl",
+      "comments",
+      "dropID",
+      "entityIDs",
+      "entityType",
+      "isAutoExecuted",
+      "isBulkOperation",
+      "password",
+      "projectKey",
+      "qmRunObj",
+      "qmTsRunId",
+      "runStatusID",
+      "type",
+      "username",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Bulk Update Test Case Execution Status",
+  },
+  "qmetry_create_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Create Cycle",
+    },
+    "description": "Create a new cycle within an existing release in QMetry for test execution planning
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- cycle (object) *required*
+
+**Output Description:** JSON object containing the created cycle ID, cycle details, and association with the release
+
+**Use Cases:** 1. Create a new test cycle for a sprint within an existing release 2. Add additional testing phases to an existing release 3. Set up regression testing cycles for a specific release 4. Organize test execution by sprints, phases, or iterations 5. Create cycles with specific date ranges for milestone tracking 6. Establish test execution phases within release planning
+
+**Examples:**
+1. Create a basic cycle with just a name in a release
+\`\`\`json
+{
+  "cycle": {
+    "name": "Sprint 2",
+    "releaseID": 12345
+  }
+}
+\`\`\`
+Expected Output: Cycle 'Sprint 2' created successfully in release ID 12345
+
+2. Create a cycle with description and dates
+\`\`\`json
+{
+  "cycle": {
+    "name": "Regression Testing Cycle",
+    "description": "Full regression testing for release 2.0",
+    "startDate": "15-01-2024",
+    "targetDate": "31-01-2024",
+    "releaseID": 12345
+  }
+}
+\`\`\`
+Expected Output: Cycle 'Regression Testing Cycle' created with start date 15-01-2024 and target date 31-01-2024 in release 12345
+
+3. Create a locked cycle to prevent modifications
+\`\`\`json
+{
+  "cycle": {
+    "name": "Final QA Cycle",
+    "description": "Locked cycle for final QA testing",
+    "isLocked": true,
+    "isArchived": false,
+    "releaseID": 12345
+  }
+}
+\`\`\`
+Expected Output: Locked cycle 'Final QA Cycle' created in release 12345 to prevent modifications
+
+4. Create a cycle with all details including project ID and dates
+\`\`\`json
+{
+  "cycle": {
+    "name": "Sprint 3 - Feature Testing",
+    "description": "Testing new features for Sprint 3",
+    "startDate": "01-02-2024",
+    "targetDate": "15-02-2024",
+    "isLocked": false,
+    "isArchived": false,
+    "projectID": 67890,
+    "releaseID": 12345
+  }
+}
+\`\`\`
+Expected Output: Cycle 'Sprint 3 - Feature Testing' created with dates and project context in release 12345
+
+**Hints:** 1. CRITICAL: cycle.releaseID is REQUIRED - must provide the release ID to associate this cycle with 2. CRITICAL: cycle.name is REQUIRED - must provide a name for the cycle 3. HOW TO GET releaseID: 4. 1. Call FETCH_RELEASES_CYCLES tool to get all releases and their IDs 5. 2. From the response, get value from projects.releases[<index>].releaseID 6. 3. Use that numeric releaseID in the cycle.releaseID parameter 7. Example: Release 'Q1 2024' might have releaseID: 12345 8. CRITICAL WORKFLOW - IF USER PROVIDES RELEASE NAME: 9. 1. User says: 'Create cycle Sprint 2 in release Q1 2024' 10. 2. You MUST first call FETCH_RELEASES_CYCLES tool to get all releases 11. 3. Search the response for release with name 'Q1 2024' 12. 4. Extract projects.releases[<index>].releaseID from matching release 13. 5. Use that releaseID in cycle.releaseID parameter 14. 6. If release name not found, inform user and list available releases 15. Example workflow: 16. - User request: 'Create cycle Sprint 2 in Release 2.0' 17. - Step 1: Call FETCH_RELEASES_CYCLES 18. - Step 2: Find release where name = 'Release 2.0', get its releaseID (e.g., 12345) 19. - Step 3: Call CREATE_CYCLE with cycle.releaseID = 12345 20. RELEASE NAME RESOLUTION: 21. - NEVER assume or guess release IDs - always fetch from API 22. - Release names are user-defined strings (e.g., 'Q1 2024', 'Release 2.0', 'Sprint 15') 23. - Release IDs are numeric identifiers assigned by QMetry (e.g., 12345, 67890) 24. - Match release names case-insensitively when searching 25. - If multiple releases match the name, ask user to clarify or use the most recent one 26. - FETCH_RELEASES_CYCLES returns: projects.releases[] array with name and releaseID fields 27. Date format depends on QMetry instance configuration: DD-MM-YYYY or MM-DD-YYYY 28. Check your QMetry instance settings to determine the correct date format 29. If dates are in wrong format, QMetry will return an error - verify format with admin 30. projectID is optional in the cycle object - it will be auto-resolved from the project key if not provided 31. To explicitly set projectID, first call FETCH_PROJECT_INFO to get the numeric project ID 32. cycle.isLocked defaults to false if not provided - set to true to prevent modifications 33. cycle.isArchived defaults to false if not provided - set to true to archive immediately (rare) 34. Use descriptive cycle names like 'Sprint 2', 'Regression Cycle', 'Alpha Testing' for better organization 35. startDate and targetDate help with sprint planning and milestone tracking 36. Cycle hierarchy: Project → Release → Cycle → Test Execution 37. After creating a cycle, you can associate test suites and test cases with it 38. Use FETCH_RELEASES_CYCLES tool after creation to verify the cycle was created successfully 39. DIFFERENCE FROM CREATE_RELEASE: This tool creates a cycle in an EXISTING release, while CREATE_RELEASE can create a release with an optional cycle 40. If you need to create both a release and a cycle together, use CREATE_RELEASE tool instead 41. If release doesn't exist yet, create it first with CREATE_RELEASE, then add more cycles with this tool",
+    "inputSchema": [
+      "baseUrl",
+      "cycle",
+      "projectKey",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Create Cycle",
+  },
+  "qmetry_create_defect_or_issue": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Create Defect or Issue",
+    },
+    "description": "Create a new defect/issue internally in QMetry.
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- issueType (number) *required*: Issue type ID (e.g. Bug, Enhancement, etc.)
+- issuePriority (number) *required*: Issue priority ID (e.g. High, Medium, Low, etc.)
+- summary (string) *required*: Summary or title of the defect/issue
+- description (string): Detailed description of the defect/issue
+- sync_with (string): External system to sync with (e.g. JIRA, QMetry, etc.)
+- issueOwner (number): Owner/user ID for the issue
+- component (array): Component IDs associated with the issue
+- affectedRelease (array): Release IDs affected by this issue
+- affectedCycles (array): Cycle IDs affected by this issue
+- tcRunID (number): Test Case Run ID to link this defect/issue to a test execution (optional)
+
+**Output Description:** JSON object containing the new create issue with id, dfid(defectID).
+
+**Use Cases:** 1. Create a basic defect/issue with just a summary 2. Set issueType, issueOwner, component, and affectedRelease using valid IDs from project info 3. Create defects/issues for automation or manual testing types 4. Link defects/issues to specific test case runs using tcRunID
+
+**Examples:**
+1. Create an issue with summary 'Login Issue'
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issuePriority": 2231988,
+  "issueType": 2231983
+}
+\`\`\`
+Expected Output: Issue created in summary details
+
+2. Create an issue with Major priority and Bug type to Bug with summary 'Login Issue'
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issuePriority": 2231988,
+  "issueType": 2231983
+}
+\`\`\`
+Expected Output: Issue created in summary details with priority and Bug type
+
+3. Create an issue with summary 'Login Issue' and set issueOwner to 'John Doe'
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issueOwner": 15112,
+  "issuePriority": 2231988,
+  "issueType": 2231983
+}
+\`\`\`
+Expected Output: Issue created in summary details with owner, priority and Bug type
+
+4. Create an issue with summary 'Login Issue' and link it to test case run ID 567890
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issueOwner": 15112,
+  "issuePriority": 2231988,
+  "issueType": 2231983,
+  "tcRunID": 567890
+}
+\`\`\`
+Expected Output: Issue created in summary details and linked to test case run ID 567890
+
+5. Create an issue with summary 'Login Issue' and set description to 'User is unable to login' and owner to 'John Doe' and link it to test case run ID 567890
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issueOwner": 15112,
+  "issuePriority": 2231988,
+  "issueType": 2231983,
+  "tcRunID": 567890,
+  "description": "User is unable to login"
+}
+\`\`\`
+Expected Output: Issue created in summary details with description, owner, priority, Bug type and linked to test case run ID 567890
+
+6. Create an issue with summary 'Login Issue' and set release to 'Release 1.0' and its associated all cycles and owner to 'John Doe'
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issueOwner": 15112,
+  "issuePriority": 2231988,
+  "issueType": 2231983,
+  "affectedRelease": [
+    111840
+  ],
+  "affectedCycles": [
+    112345,
+    112346
+  ]
+}
+\`\`\`
+Expected Output: Issue created in summary details with release and associated all cycles, owner
+
+7. Create an issue with summary 'Login Issue' and set release to 'Release 1.0' and its associated all cycle 'Cycle 1.0.1', 'Cycle 1.0.2'
+\`\`\`json
+{
+  "name": "Login Issue",
+  "issuePriority": 2231988,
+  "issueType": 2231983,
+  "affectedRelease": [
+    111840
+  ],
+  "affectedCycles": [
+    112345,
+    112346
+  ]
+}
+\`\`\`
+Expected Output: Issue created in summary details with release and cycles
+
+**Hints:** 1. CRITICAL: name (summary), issueType, issuePriority are REQUIRED fields to create an issue 2. OPTIONAL: issueOwner, component, affectedRelease, description, tcRunID can also be provided 3. To get valid values for sync_with (igConfigurationID or internalTrackerId), issueType, issuePriority, issueOwner, component, affectedRelease, and tcRunID, call the 'project get info tools' use the following mappings: 4. - sync_with: customListObjs.component[<index>].igConfigurationID or internalTrackerId 5. - issueType: customListObjs.issueType[<index>].id 6. - issuePriority: customListObjs.issuePriority[<index>].id 7. - issueOwner: customListObjs.users[<index>].id 8. - affectedRelease: data[<index>].releaseID 9. - tcRunID: data[<index>].tcRunID (from 'Execution/Fetch Testcase Run ID') 10. If the user provides a issuePriority name (e.g. 'Blocker'), fetch project info, find the matching priority in customListObjs.issuePriority[index].name, and use its ID in the payload. If the name is not found, skip the issuePriority field and show a user-friendly message: 'Defect/issue created without issuePriority, as given issuePriority is not available in the current project.' 11. If the user provides an issueOwner name, fetch project info, find the matching issueOwner in customListObjs.users[index].name, and use its ID in the payload as issueOwner. If the name is not found, skip the issueOwner field and show a user-friendly message: 'Defect/issue created without issueOwner, as given issueOwner is not available in the current project.' 12. If the user provides an issue type name, fetch project info, find the matching type in customListObjs.issueType[index].name, and use its ID in the payload as issueType. If the name is not found, skip the issueType field and show a user-friendly message: 'Defect/issue created without issue type, as given type is not available in the current project.' 13. Release/cycle mapping is optional but useful for planning. 14. If the user wants to link or associate a release and cycle to the issue, follow these rules: 15. If the user provides a release ID, map it from projects.releases[index].releaseID in the project info response, and use that ID in affectedRelease as an array of numeric IDs. 16. If the user provides both release and cycle IDs, validate both against the current project's releases and cycles; if valid, use them in affectedCycles and affectedRelease as arrays of numeric IDs respectively. 17. If the user provides a release name, map it to its ID from project info; if a cycle name is provided, map it to its ID and use it in payload as value of field affectedRelease and affectedCycles. 18. LLM should ensure that provided release/cycle names or IDs exist in the current project before using them in the payload. If not found, skip and show a user-friendly message: 'Issue created without release/cycle association, as given release/cycle is not available in the current project.' 19. Ensure all IDs used are valid for the current QMetry project context 20. This tool is essential for defect management and test execution linkage 21. Helps maintain traceability between test executions and reported issues 22. Critical for quality assurance and defect lifecycle management 23. Use for creating issues directly from test execution contexts",
+    "inputSchema": [
+      "affectedCycles",
+      "affectedRelease",
+      "baseUrl",
+      "component",
+      "description",
+      "issueOwner",
+      "issuePriority",
+      "issueType",
+      "projectKey",
+      "summary",
+      "sync_with",
+      "tcRunID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Create Defect or Issue",
+  },
+  "qmetry_create_release": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Create Release",
+    },
+    "description": "Create a new release in QMetry with optional cycle for test planning and execution tracking
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- release (object) *required*
+- cycle (object): Optional cycle to create within the release
+
+**Output Description:** JSON object containing the created release ID, release details, and cycle information if provided
+
+**Use Cases:** 1. Create a new release for a major product version (e.g., v2.0, Q1 Release) 2. Create a release with an initial cycle for immediate test planning 3. Set up release dates for sprint planning and milestone tracking 4. Organize test execution by product versions and cycles 5. Create release hierarchy for better test planning and reporting 6. Establish test execution phases with releases and cycles
+
+**Examples:**
+1. Create a basic release with just a name
+\`\`\`json
+{
+  "release": {
+    "name": "Release 2.0"
+  }
+}
+\`\`\`
+Expected Output: Release 'Release 2.0' created successfully with generated release ID
+
+2. Create a release with description and dates
+\`\`\`json
+{
+  "release": {
+    "name": "Q1 2024 Release",
+    "description": "First quarter release for 2024",
+    "startDate": "01-01-2024",
+    "targetDate": "31-03-2024"
+  }
+}
+\`\`\`
+Expected Output: Release 'Q1 2024 Release' created with start date 01-01-2024 and target date 31-03-2024
+
+3. Create a release with an initial cycle
+\`\`\`json
+{
+  "release": {
+    "name": "Release 3.0",
+    "description": "Major product update"
+  },
+  "cycle": {
+    "name": "Sprint 1",
+    "isLocked": false,
+    "isArchived": false
+  }
+}
+\`\`\`
+Expected Output: Release 'Release 3.0' created with cycle 'Sprint 1' for test execution planning
+
+4. Create a release with all details
+\`\`\`json
+{
+  "release": {
+    "name": "Summer 2024 Release",
+    "description": "Summer product release with new features",
+    "startDate": "01-06-2024",
+    "targetDate": "31-08-2024"
+  },
+  "cycle": {
+    "name": "Beta Testing Cycle",
+    "isLocked": false
+  }
+}
+\`\`\`
+Expected Output: Release 'Summer 2024 Release' created with dates and 'Beta Testing Cycle' for test execution
+
+**Hints:** 1. CRITICAL: release.name is REQUIRED - must provide a name for the release 2. Date format depends on QMetry instance configuration: DD-MM-YYYY or MM-DD-YYYY 3. Check your QMetry instance settings to determine the correct date format 4. If dates are in wrong format, QMetry will return an error - verify format with admin 5. projectID is optional in the release object - it will be auto-resolved from the project key if not provided 6. To explicitly set projectID, first call FETCH_PROJECT_INFO to get the numeric project ID 7. cycle parameter is completely optional - omit it if you only want to create a release 8. If providing cycle, cycle.name is REQUIRED 9. cycle.isLocked defaults to false if not provided - set to true to prevent modifications 10. cycle.isArchived defaults to false if not provided - set to true to archive immediately (rare) 11. Releases can have multiple cycles added later using other tools 12. Use descriptive release names like 'Release 2.0', 'Q1 2024', 'Sprint 15' for better organization 13. startDate and targetDate help with sprint planning and milestone tracking 14. Creating a release with a cycle is useful for immediate test planning after release creation 15. Release hierarchy: Project → Release → Cycle → Test Execution 16. After creating a release, you can associate test suites and test cases with it 17. Use FETCH_RELEASES_CYCLES tool after creation to verify the release was created successfully",
+    "inputSchema": [
+      "baseUrl",
+      "cycle",
+      "projectKey",
+      "release",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Create Release",
+  },
+  "qmetry_create_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Create Test Case",
+    },
+    "description": "Create a new test case in QMetry with steps, metadata, and release/cycle mapping.
+
+**Parameters:**
+- tcFolderID (string) *required*
+- steps (array)
+- name (string) *required*
+- priority (number)
+- component (array)
+- testcaseOwner (number)
+- testCaseState (number)
+- testCaseType (number)
+- estimatedTime (number)
+- testingType (number)
+- description (string)
+- associateRelCyc (boolean)
+- releaseCycleMapping (array)
+
+**Output Description:** JSON object containing the new test case ID, summary, and creation metadata.
+
+**Use Cases:** 1. Create a basic test case with just a name and folder 2. Add detailed steps with custom fields (UDFs) to a test case 3. Associate test case with specific release/cycle for planning 4. Set priority, owner, component, and other metadata using valid IDs from project info 5. Create test cases for automation or manual testing types 6. Add test case to a specific folder using tcFolderID 7. Include estimated execution time and description 8. Map test case to multiple cycles/releases
+
+**Examples:**
+1. Create a test case in the root folder (auto-resolved)
+\`\`\`json
+{
+  "name": "Login Test Case"
+}
+\`\`\`
+Expected Output: Test case created in the root test case folder with ID and summary details
+
+2. Create a simple test case in folder 102653
+\`\`\`json
+{
+  "tcFolderID": "102653",
+  "name": "Login Test Case"
+}
+\`\`\`
+Expected Output: Test case created with ID and summary details
+
+3. Create a test case with steps and metadata
+\`\`\`json
+{
+  "tcFolderID": "102653",
+  "name": "Test Case 1",
+  "steps": [
+    {
+      "orderId": 1,
+      "description": "First Step",
+      "inputData": "First Data",
+      "expectedOutcome": "First Outcome",
+      "UDF": {
+        "customField1": "Custom Field Data A",
+        "customField2": "Custom Field Data B"
+      }
+    }
+  ],
+  "priority": 2025268,
+  "component": [
+    2025328
+  ],
+  "testcaseOwner": 1467,
+  "testCaseState": 2025271,
+  "testCaseType": 2025282,
+  "estimatedTime": 10,
+  "description": "Description",
+  "testingType": 2025275,
+  "associateRelCyc": true,
+  "releaseCycleMapping": [
+    {
+      "release": 14239,
+      "cycle": [
+        21395
+      ],
+      "version": 1
+    }
+  ]
+}
+\`\`\`
+Expected Output: Test case created with steps and metadata
+
+**Hints:** 1. If tcFolderID is not provided, it will be auto-resolved to the root test case folder using project info (rootFolders.TC.id). 2. To get valid values for priority, owner, component, etc., call the project info tool and use the returned customListObjs IDs. 3. If the user provides a priority name (e.g. 'Blocker'), fetch project info, find the matching priority in customListObjs.priority[index].name, and use its ID in the payload. If the name is not found, skip the priority field (it is not required) and show a user-friendly message: 'Test case created without priority, as given priority is not available in the current project.' 4. If the user provides a component name, fetch project info, find the matching component in customListObjs.component[index].name, and use its ID in the payload. If the name is not found, skip the component field (it is not required) and show a user-friendly message: 'Test case created without component, as given component is not available in the current project.' 5. If the user provides an owner name, fetch project info, find the matching owner in customListObjs.owner[index].name, and use its ID in the payload as testcaseOwner. If the name is not found, skip the testcaseOwner field (it is not required) and show a user-friendly message: 'Test case created without owner, as given owner is not available in the current project.' 6. If the user provides a test case state name, fetch project info, find the matching state in customListObjs.testCaseState[index].name, and use its ID in the payload as testCaseState. If the name is not found, skip the testCaseState field (it is not required) and show a user-friendly message: 'Test case created without test case state, as given state is not available in the current project.' 7. If the user provides a test case type name, fetch project info, find the matching type in customListObjs.testCaseType[index].name, and use its ID in the payload as testCaseType. If the name is not found, skip the testCaseType field (it is not required) and show a user-friendly message: 'Test case created without test case type, as given type is not available in the current project.' 8. If the user provides a testing type name, fetch project info, find the matching type in customListObjs.testingType[index].name, and use its ID in the payload as testingType. If the name is not found, skip the testingType field (it is not required) and show a user-friendly message: 'Test case created without testing type, as given testing type is not available in the current project.' 9. Example: If user says 'Create test case with title "High priority test case" and set priority to "Blocker"', first call project info, map 'Blocker' to its ID, and use that ID for the priority field in the create payload. If user says 'set priority to "Urgent"' and 'Urgent' is not found, skip the priority field and show: 'Test case created without priority, as given priority is not available in the current project.' 10. tcFolderID is required; use the root folder ID from project info or a specific folder. 11. Steps are optional but recommended for manual test cases. 12. If the user provides a prompt like 'create test case with steps as step 1 - Go to login page, step 2 - give credential, step 3 - go to test case page, step 4 - create test case', LLM should parse each step and convert it into the steps payload array, mapping each step to an object with orderId, description, and optionally inputData and expectedOutcome. 13. Example mapping: 'step 1 - Go to login page' → { orderId: 1, description: 'Go to login page' }. 14. LLM should increment orderId for each step, use the step text as description, and optionally infer inputData/expectedOutcome if provided in the prompt. 15. Demo steps payload: steps: [ { orderId: 1, description: 'First Step', inputData: 'First Data', expectedOutcome: 'First Outcome', UDF: { customField1: 'Custom Field Data A', customField2: 'Custom Field Data B' } }, ... ] 16. UDF fields in steps must match your QMetry custom field configuration. 17. Release/cycle mapping is optional but useful for planning. 18. If the user wants to link or associate a release and cycle to the test case, set associateRelCyc: true in the payload. 19. If the user provides a release ID, map it from projects.releases[index].releaseID in the project info response, and use that ID in releaseCycleMapping. 20. If the user provides both release and cycle IDs, validate both against the current project's releases and cycles; if valid, use them in releaseCycleMapping. 21. When adding releaseCycleMapping, always include the 'version' field (usually set to 1) in each mapping object. The correct format is: { release: <releaseID>, cycle: [<cycleID>], version: 1 }. If 'version' is missing, the request will fail. 22. If the user provides a release name, map it to its ID from project info; if a cycle name is provided, map it to its ID from the associated release's builds list. 23. Example payload: releaseCycleMapping: [ { release: <releaseID>, cycle: [<cycleID>], version: 1 } ] 24. LLM should ensure that provided release/cycle names or IDs exist in the current project before using them in the payload. If not found, skip and show a user-friendly message: 'Test case created without release/cycle association, as given release/cycle is not available in the current project.' 25. All IDs (priority, owner, etc.) must be valid for your QMetry instance. 26. If a custom field is mandatory, include it in the UDF object. 27. Estimated time is in minutes. 28. Description and testingType are optional but recommended for clarity.",
+    "inputSchema": [
+      "associateRelCyc",
+      "component",
+      "description",
+      "estimatedTime",
+      "name",
+      "priority",
+      "releaseCycleMapping",
+      "steps",
+      "tcFolderID",
+      "testCaseState",
+      "testCaseType",
+      "testcaseOwner",
+      "testingType",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Create Test Case",
+  },
+  "qmetry_create_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Create Test Suite",
+    },
+    "description": "Create a new test suite in QMetry with metadata and release/cycle mapping.
+
+**Parameters:**
+- parentFolderId (string) *required*
+- name (string) *required*
+- isAutomatedFlag (boolean)
+- description (string)
+- testsuiteOwner (number)
+- testSuiteState (number)
+- associateRelCyc (boolean)
+- releaseCycleMapping (array)
+
+**Output Description:** JSON object containing the new test suite ID, summary, and creation metadata.
+
+**Use Cases:** 1. Create a basic test suite with just a name and folder 2. Add detailed metadata like description to a test suite 3. Associate test suite with specific release/cycle for planning 4. Set testsuiteOwner, testSuiteState, and other metadata using valid IDs from project info 5. Create test suites for isAutomatedFlag true or false for automated or manual types, default is false 6. Add test suite to a specific folder using parentFolderId 7. Map test suite to multiple cycles/releases and build ID
+
+**Examples:**
+1. Create a test suite in the root folder (auto-resolved)
+\`\`\`json
+{
+  "name": "Demo Test Suite"
+}
+\`\`\`
+Expected Output: Test suite created in the root test suite folder with ID and summary details
+
+2. Create a simple test suite in folder 102653
+\`\`\`json
+{
+  "parentFolderId": "102653",
+  "name": "Login Test Suite"
+}
+\`\`\`
+Expected Output: Test suite created with ID and summary details
+
+3. Create a test suite with some details and metadata
+\`\`\`json
+{
+  "parentFolderId": "113557",
+  "isAutomatedFlag": false,
+  "name": "Testsuite Summary",
+  "description": "desc",
+  "testsuiteOwner": 6963,
+  "testSuiteState": 505035,
+  "associateRelCyc": true,
+  "releaseCycleMapping": [
+    {
+      "buildID": 18411,
+      "releaseId": 10286
+    }
+  ]
+}
+\`\`\`
+Expected Output: Test suite created with details and metadata. Example uses: parentFolderId=113557 (MAC root TS folder from rootFolders.TS.id), testsuiteOwner=6963 (umang.savaliya from customListObjs.owner[index].id), testSuiteState=505035 (New from customListObjs.testSuiteState[index].id), releaseId=10286 (Air release from projects[index].releases[index].releaseID), buildID=18411 (Air Q1-19 cycle from projects[index].releases[index].builds[index].buildID)
+
+**Hints:** 1. If parentFolderId is not provided, it will be auto-resolved to the root test suite folder using project info (rootFolders.TS.id). 2. To get valid values for testsuiteOwner, testSuiteState, etc., call the 'Admin/Get info Service' API (FETCH_PROJECT_INFO tool) and use the returned customListObjs IDs. 3. CRITICAL: For testsuiteOwner mapping - Call API 'Admin/Get info Service', from the response get value from customListObjs.owner[<index>].id. Match the user by customListObjs.owner[<index>].name. 4. If the user provides an owner name (testsuiteOwner), fetch project info, find the matching owner in customListObjs.owner[index].name or customListObjs.owner[index].uniqueLabel, and use its ID in the payload as testsuiteOwner. If the name is not found, skip the testsuiteOwner field (it is not required) and show a user-friendly message: 'Test suite created without owner, as given owner is not available in the current project.' 5. CRITICAL: For testSuiteState mapping - Call API 'Admin/Get info Service', from the response get value from customListObjs.testSuiteState[<index>].id. Match the state by customListObjs.testSuiteState[<index>].name. 6. If the user provides a test suite state name(testSuiteState), fetch project info, find the matching state in customListObjs.testSuiteState[index].name, and use its ID in the payload as testSuiteState. If the name is not found, skip the testSuiteState field (it is not required) and show a user-friendly message: 'Test suite created without test suite state, as given state is not available in the current project.' 7. parentFolderId is required; use the root folder ID from project info (rootFolders.TS.id) or a specific folder. 8. Release/cycle mapping is optional but useful for planning. 9. If the user wants to link or associate a release and cycle to the test suite, set associateRelCyc: true in the payload. 10. CRITICAL: For releaseCycleMapping.releaseId - Call API 'Release/List' (or use project info projects[<index>].releases[<index>].releaseID), from the response get value from data[<index>].releaseID or projects[<index>].releases[<index>].releaseID. Match the release by name. 11. CRITICAL: For releaseCycleMapping.buildID - Call API 'Cycle/List' (or use project info projects[<index>].releases[<index>].builds[<index>].buildID), from the response get value from data[<index>].buildID or projects[<index>].releases[<index>].builds[<index>].buildID. Match the build/cycle by name. 12. If the user provides a release name, map it to its ID from projects[<index>].releases[<index>].releaseID in the project info response, and use that ID as releaseId in releaseCycleMapping. 13. If the user provides a build/cycle name, map it to its ID from projects[<index>].releases[<index>].builds[<index>].buildID in the project info response, and use that ID as buildID in releaseCycleMapping. 14. Example payload: releaseCycleMapping: [ { releaseId: <releaseID>, buildID: <buildID> } ] 15. Example: For 'Air' release and 'Air Q1-19' cycle in MAC project, use releaseId: 10286 and buildID: 18411 16. LLM should ensure that provided release/cycle names or IDs exist in the current project before using them in the payload. If not found, skip and show a user-friendly message: 'Test suite created without release/cycle association, as given release/cycle is not available in the current project.' 17. All IDs (testSuiteState from customListObjs.testSuiteState[index].id, testsuiteOwner from customListObjs.owner[index].id, releaseId from projects.releases[index].releaseID, buildID from projects.releases.builds[index].buildID) must be valid for your QMetry instance. 18. If a custom field is mandatory, include it in the UDF object.",
+    "inputSchema": [
+      "associateRelCyc",
+      "description",
+      "isAutomatedFlag",
+      "name",
+      "parentFolderId",
+      "releaseCycleMapping",
+      "testSuiteState",
+      "testsuiteOwner",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Create Test Suite",
+  },
+  "qmetry_fetch_automation_status": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Automation Status",
+    },
+    "description": "Fetches the status of an automation import job by request ID.
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- requestID (number) *required*: Numeric request ID from import automation response
+
+**Use Cases:** 1. 1. Check if an automation import job is completed or still in progress. 2. 2. Retrieve status, progress, and details for a specific automation import request. 3. 3. Monitor automation result processing for CI/CD integrations.
+
+**Examples:**
+1. Fetch status for request ID 12345
+\`\`\`json
+{
+  "requestID": 12345
+}
+\`\`\`
+Expected Output: Status, progress, and details of the automation import job for request ID 12345.",
+    "inputSchema": [
+      "baseUrl",
+      "projectKey",
+      "requestID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Automation Status",
+  },
+  "qmetry_fetch_builds": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Builds",
+    },
+    "description": "Fetch QMetry builds from the current project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with builds list and pagination metadata
+
+**Use Cases:** 1. Fetch all from the current project 2. Fetch all available builds for test execution planning 3. Get build metadata for test run assignments 4. List builds for reporting and analytics 5. Filter builds by name or archive status 6. Get paginated build results for large projects 7. Retrieve build information for CI/CD integration 8. Search for specific builds using filters 9. Get build details for test execution history
+
+**Examples:**
+1. Get all builds (default behavior)
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of all builds with default pagination (10 items per page)
+
+2. Get builds with custom pagination
+\`\`\`json
+{
+  "page": 1,
+  "limit": 10,
+  "start": 0
+}
+\`\`\`
+Expected Output: List of builds with custom pagination settings
+
+3. Filter builds by name
+\`\`\`json
+{
+  "filter": "[{\\"value\\":\\"Build 1.0\\",\\"type\\":\\"string\\",\\"field\\":\\"name\\"}]"
+}
+\`\`\`
+Expected Output: Filtered list of builds matching the name criteria
+
+4. Filter builds by archive status
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[1,0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of builds filtered by archive status (archived and non-archived)
+
+**Hints:** 1. Use 'default' project key when user doesn't specify one 2. Default pagination: start=0, page=1, limit=10 3. Filter parameter should be a JSON string with filter criteria 4. Common filter fields: 'name' (string), 'isArchived' (list of 0,1) 5. Empty payload {} is sent when no parameters are provided 6. Builds are also known as 'drops' in QMetry terminology 7. Use builds for associating test executions with specific software versions",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Builds",
+  },
+  "qmetry_fetch_defects_or_issues": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Defects or Issues",
+    },
+    "description": "Fetch QMetry defects or issues - automatically handles viewId resolution based on project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- viewId (number) *required*: ViewId for issues - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.IS.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+- isJiraIntegrated (boolean): Send true if current project is Integrated with Jira (default: false)
+- sort (string): Sort Records - refer json schema, Possible property - entityKey, name, typeAlias, stateAlias, createdDate, createdByAlias, updatedDate, updatedByAlias, priorityAlias, createdSystem, linkedTcrCount, linkedRqCount, dfOwner, attachmentCount, environmentText (default: "[{\\"property\\":\\"name\\",\\"direction\\":\\"ASC\\"}]")
+
+**Output Description:** JSON object with 'data' array containing issues and pagination info
+
+**Use Cases:** 1. List all issues in a project 2. Search for specific issues using filters 3. Get paginated issue results
+
+**Examples:**
+1. Get all issues from default project - system will auto-fetch viewId
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of issues from default project with auto-resolved viewId
+
+2. Get all issues from UT project - system will auto-fetch UT project's viewId
+\`\`\`json
+{
+  "projectKey": "UT"
+}
+\`\`\`
+Expected Output: List of issues from UT project using UT's specific IS viewId
+
+3. Get issues with manual viewId (skip auto-resolution)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "viewId": 166065
+}
+\`\`\`
+Expected Output: Issues using manually specified viewId 166065
+
+4. List issues from specific project (ex: project key can be anything (VT, UT, PROJ1, TEST9)
+\`\`\`json
+{
+  "projectKey": "use specific given project key",
+  "viewId": "fetch specific project given projectKey defects or issues ViewId"
+}
+\`\`\`
+Expected Output: Issues using manually specified viewId 103097 or projectKey
+
+5. Get issues by release/cycle filter
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"},{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Issues associated with Release 8.12 (ID: 55178) and Cycle 8.12.1 (ID: 111577)
+
+6. Get issues by release only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"}]"
+}
+\`\`\`
+Expected Output: All defects or issues associated with Release 8.12 (ID: 55178)
+
+7. Get issues by cycle only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: All defects or issues associated with Cycle 8.12.1 (ID: 111577)
+
+8. Search for specific issue by entity key
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-IS-636\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Issues matching the entity key criteria
+
+9. Search for multiple defects or issues by comma-separated entity keys
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-IS-636,MAC-IS-637,MAC-IS-638\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Issues matching any of the specified entity keys
+
+**Hints:** 1. CRITICAL WORKFLOW: Always use the SAME projectKey for both project info and issues fetching 2. Step 1: If user specifies projectKey (like 'UT', 'MAC'), use that EXACT projectKey for project info 3. Step 2: Get project info using that projectKey, extract latestViews.IS.viewId 4. Step 3: Use the SAME projectKey and the extracted IS viewId for fetching issues 5. Step 4: If user doesn't specify projectKey, use 'default' for both project info and issues fetching 6. NEVER mix project keys - if user says 'MAC project', use projectKey='MAC' for everything 7. For search by issues key (like MAC-IS-1684), use filter: '[{"type":"string","value":"MAC-IS-1684","field":"entityKeyId"}]' 8. RELEASE/CYCLE FILTERING: Use release and cycle IDs, not names, for filtering 9. For release filter: '[{"value":[releaseId],"type":"list","field":"release"}]' 10. For cycle filter: '[{"value":[cycleId],"type":"list","field":"cycle"}]' 11. For combined release+cycle: '[{"value":[releaseId],"type":"list","field":"release"},{"value":[cycleId],"type":"list","field":"cycle"}]' 12. Get release/cycle IDs from FETCH_RELEASES_AND_CYCLES tool before filtering 13. FILTER FIELDS: name, stateAlias, typeAlias, entityKeyId, createdDate, createdByAlias, updatedDate, updatedByAlias, createdSystem, dfOwner, priorityAlias, linkedTcrCount, linkedRqCount, attachmentCount, componentAlias, environmentText 14. SORT FIELDS: entityKey, name, typeAlias, stateAlias, createdDate, createdByAlias, updatedDate, updatedByAlias, priorityAlias, createdSystem, linkedTcrCount, linkedRqCount, dfOwner, attachmentCount, environmentText 15. For multiple entity keys, use comma-separated values in filter 16. Use pagination for large result sets (start, page, limit parameters) 17. This tool is essential for defect management and issue tracking 18. Critical for quality assurance and defect lifecycle analysis 19. Use for compliance reporting and issue traceability 20. Helps maintain visibility into project defects and issues",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "isJiraIntegrated",
+      "limit",
+      "page",
+      "projectKey",
+      "sort",
+      "start",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Defects or Issues",
+  },
+  "qmetry_fetch_executions_by_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Executions by Test Suite",
+    },
+    "description": "Get executions for a given test suite in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tsID (number) *required*: Test Suite numeric ID (required for fetching test cases linked to test suite). This is the internal numeric identifier, not the entity key. NOTE: To get the tsID - Call API 'Testsuite/Fetch Testsuite' From the response, get value of following attribute -> data[<index>].id
+- tsFolderID (number): Test Suite folder ID (required for fetching test suites). This is the numeric identifier for the test suite folder. IMPORTANT: Get from project info response → rootFolders.TS.id (e.g., 113557 for MAC project). Use FETCH_PROJECT_INFO tool first to get this ID if not provided by user. For root folder: use rootFolders.TS.id, for sub-folders: use specific folder IDs.
+- gridName (string): Grid Name to be displayed (default 'TESTEXECUTIONLIST')
+- viewId (number): ViewId for test execution - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.TE.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with executions array containing execution details, status, platforms, releases, and execution metadata
+
+**Use Cases:** 1. Get all executions for a specific test suite for reporting purposes 2. Analyze test execution results and trends within a test suite 3. Filter executions by release, cycle, platform, or automation status 4. Monitor test suite execution performance across different environments 5. Generate execution reports for specific test suites 6. Track execution history and patterns for test suite optimization 7. Validate test suite execution coverage across releases and cycles 8. Audit test execution data for compliance and quality assurance 9. Export execution data for external reporting and analytics
+
+**Examples:**
+1. Get all executions for test suite ID 194955
+\`\`\`json
+{
+  "tsID": 194955
+}
+\`\`\`
+Expected Output: List of executions for the test suite with execution details, status, and metadata
+
+2. Get executions with test suite folder and view ID
+\`\`\`json
+{
+  "tsID": 194955,
+  "tsFolderID": 126554,
+  "viewId": 41799
+}
+\`\`\`
+Expected Output: Executions filtered by test suite folder and specific view configuration
+
+3. Filter executions by release and cycle
+\`\`\`json
+{
+  "tsID": 194955,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[55178],\\"field\\":\\"releaseID\\"},{\\"type\\":\\"list\\",\\"value\\":[111577],\\"field\\":\\"cycleID\\"}]"
+}
+\`\`\`
+Expected Output: Executions filtered by specific release (55178) and cycle (111577)
+
+4. Filter executions by platform and automation status
+\`\`\`json
+{
+  "tsID": 194955,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[12345],\\"field\\":\\"platformID\\"},{\\"type\\":\\"boolean\\",\\"value\\":true,\\"field\\":\\"isAutomatedFlag\\"}]"
+}
+\`\`\`
+Expected Output: Automated executions filtered by specific platform (12345)
+
+5. Get only active (non-archived) executions
+\`\`\`json
+{
+  "tsID": 194955,
+  "filter": "[{\\"value\\":[0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: Active executions that are not archived
+
+6. Get executions with custom pagination and grid name
+\`\`\`json
+{
+  "tsID": 194955,
+  "gridName": "TESTEXECUTIONLIST",
+  "page": 1,
+  "limit": 25
+}
+\`\`\`
+Expected Output: Paginated list of executions with 25 items per page using specific grid configuration
+
+**Hints:** 1. !MOST IMPORTANT HOW TO GET viewId: 2. CRITICAL: Always resolve and use the correct test execution viewId for the current project when calling this tool. 3. The viewId parameter must be fetched from the active project's info (latestViews.TEL.viewId). 4. Each QMetry project may have a different test execution list viewId, so using a stale or incorrect viewId will result in incomplete or invalid executions list data by test suite id. 5. Usage workflow: 6. 1. Fetch project info for the current project (Admin/Get info Service). 7. 2. Extract latestViews.TEL.viewId from the response. 8. 3. Use this viewId in the Fetch Test Case Runs by Test Suite Run API call. 9. Example: 10.    { 11.      tsID: 1533730, 12.      viewId: 94194, 13.      gridName: 'TESTEXECUTIONLIST' 14.    } 15. CRITICAL: tsID parameter is REQUIRED - this is the Test Suite numeric ID 16. HOW TO GET tsID: 17. 1. Call API 'Testsuite/Fetch Testsuite' to get available test suites 18. 2. From the response, get value of following attribute -> data[<index>].id 19. 3. Example: Test Suite 'Regression Suite' might have ID 194955 20. HOW TO GET tsFolderID (optional): 21. 1. Call API 'Testsuite/List of folders' to get test suite folders 22. 2. From the response, get value of following attribute -> data[<index>].id 23. 3. Example: Test Suite folder might have ID 126554 24. FILTER CAPABILITIES: Extensive filtering by execution properties 25. FILTER FIELDS: releaseID (list), cycleID (list), platformID (list), isAutomatedFlag (boolean), isArchived (list) 26. RELEASE/CYCLE FILTERING: Use numeric IDs in list format (get from FETCH_RELEASES_AND_CYCLES) 27. PLATFORM FILTERING: Use numeric platform IDs (get from FETCH_PLATFORMS) 28. AUTOMATION STATUS: Use boolean true/false for isAutomatedFlag field 29. ARCHIVE STATUS: 0=Active executions, 1=Archived executions 30. GRID NAME: Default is 'TESTEXECUTIONLIST' - used for execution list display configuration 31. VIEW ID: Optional numeric identifier for specific execution view configurations 32. Multiple filter conditions are combined with AND logic 33. Use pagination for large execution result sets (start, page, limit parameters) 34. This tool is essential for test execution analysis and reporting 35. Critical for monitoring test suite performance and execution trends 36. Use for compliance reporting and execution audit trails 37. Essential for test execution planning and resource optimization",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "gridName",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tsFolderID",
+      "tsID",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Executions by Test Suite",
+  },
+  "qmetry_fetch_issues_linked_to_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Issues Linked to Test Case",
+    },
+    "description": "Get issues that are linked (or not linked) to a specific test case in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tcID (number) *required*: Test Case numeric ID. This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results or by using filters.
+- getLinked (boolean): True to get only those issues that are linked with this Test case Run, False to get those issues which are not linked with this Test case Run. Default value true (get linked issues). (default: true)
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with issues array containing issue details, priorities, status, and linkage information
+
+**Use Cases:** 1. Get all issues linked to a specific test case for defect tracking 2. Find issues that are NOT linked to a test case (gap analysis) 3. Generate traceability reports between test cases and issues 4. Filter issues by type, priority, status, or owner 5. Monitor issue resolution progress for specific test cases 6. Audit issue-test case relationships for compliance 7. Filter issues by summary content or execution version 8. Get issue details for test execution planning 9. Track linkage level (Test Case vs Test Step level) 10. Quality assurance - ensure proper issue tracking
+
+**Examples:**
+1. Get all issues linked to test case ID 4495658 (default behavior)
+\`\`\`json
+{
+  "tcID": 4495658
+}
+\`\`\`
+Expected Output: List of issues linked to the test case with issue details, status, and metadata
+
+2. Get all issues linked to test case ID 4495658 (explicit)
+\`\`\`json
+{
+  "tcID": 4495658,
+  "getLinked": true
+}
+\`\`\`
+Expected Output: List of issues linked to the test case with issue details, status, and metadata
+
+3. Get issues NOT linked to test case (gap analysis)
+\`\`\`json
+{
+  "tcID": 4495658,
+  "getLinked": false
+}
+\`\`\`
+Expected Output: List of issues that are NOT linked to the test case
+
+4. Get linked issues with pagination
+\`\`\`json
+{
+  "tcID": 4495658,
+  "getLinked": true,
+  "limit": 25,
+  "page": 1
+}
+\`\`\`
+Expected Output: Paginated list of issues linked to the test case
+
+5. Filter linked issues by summary content (using default getLinked=true)
+\`\`\`json
+{
+  "tcID": 4495658,
+  "filter": "[{\\"value\\":\\"login\\",\\"type\\":\\"string\\",\\"field\\":\\"summary\\"}]"
+}
+\`\`\`
+Expected Output: Issues linked to test case that contain 'login' in their summary
+
+6. Filter linked issues by status and priority
+\`\`\`json
+{
+  "tcID": 4495658,
+  "getLinked": true,
+  "filter": "[{\\"value\\":[1,2],\\"type\\":\\"list\\",\\"field\\":\\"issueState\\"},{\\"value\\":[1],\\"type\\":\\"list\\",\\"field\\":\\"issuePriority\\"}]"
+}
+\`\`\`
+Expected Output: High priority issues in Open or In Progress status
+
+7. Filter issues by execution version
+\`\`\`json
+{
+  "tcID": 4495658,
+  "getLinked": true,
+  "filter": "[{\\"value\\":\\"2\\",\\"type\\":\\"string\\",\\"field\\":\\"executedVersion\\"}]"
+}
+\`\`\`
+Expected Output: Issues linked to version 2 of the test case execution
+
+**Hints:** 1. CRITICAL: tcID parameter is REQUIRED - this is the Test Case numeric ID 2. getLinked parameter is OPTIONAL - defaults to true if not provided 3. HOW TO GET tcID: 4. 1. Call FETCH_TEST_CASES with filter on entityKeyId to resolve test case key to numeric ID 5. 2. From response, use data[index].tcID field 6. 3. Example: MAC-TC-1684 → tcID: 4495658 7. getLinked=true (default): Returns issues that ARE linked to the test case 8. getLinked=false: Returns issues that are NOT linked to the test case (useful for gap analysis) 9. If getLinked is not specified, it defaults to true (linked issues) 10. FILTER CAPABILITIES: Extensive filtering by issue properties 11. FILTER FIELDS: summary (string), executedVersion (string), linkageLevel (string), issueType (list), issuePriority (list), issueState (list), owner (list) 12. LINKAGE LEVEL: 'Test Case' for test case level links, 'Test Step' for step level links 13. ISSUE TYPE IDs: Typically 1=Bug, 2=Enhancement, 3=Task (verify with your QMetry instance) 14. ISSUE PRIORITY IDs: Typically 1=High, 2=Medium, 3=Low (verify with your QMetry instance) 15. ISSUE STATUS IDs: Typically 1=Open, 2=In Progress, 3=Resolved, 4=Closed (verify with your QMetry instance) 16. OWNER IDs: Use numeric user IDs from QMetry user management 17. Multiple filter conditions are combined with AND logic 18. Use pagination for large issue result sets (start, page, limit parameters) 19. This tool is essential for defect tracking and traceability audits 20. Helps establish relationships between test failures and reported issues 21. Critical for impact analysis when test cases change 22. Use for compliance reporting and quality metrics",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "getLinked",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tcID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Issues Linked to Test Case",
+  },
+  "qmetry_fetch_linked_issues_of_test_case_run": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Linked Issues of Test Case Run",
+    },
+    "description": "Get issues that are linked (or not linked) to a specific test case run in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- entityId (number) *required*: Id of Test case run (required for fetching linked issues). This is the internal numeric identifier for the test case run execution. NOTE: To get the entityId - Call API 'Execution/Fetch Testcase Run ID' From the response, get value of following attribute -> data[<index>].tcRunID
+- getLinked (boolean): True to get only those issues that are linked with this Test case Run, False to get those issues which are not linked with this Test case Run. Default value true (get linked issues). (default: true)
+- getColumns (boolean): Whether to get column information in response. (default: true)
+- istcrFlag (boolean): Set True for test case run operations (default: true)
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with issues array containing issue details, priorities, status, owner information, and linkage metadata
+
+**Use Cases:** 1. Get all issues linked to a specific test case run for defect tracking 2. Find issues that are NOT linked to a test case run (gap analysis) 3. Generate defect reports and traceability matrix for test case runs 4. Monitor issue resolution progress for specific test case executions 5. Analyze test execution quality by examining linked defects 6. Filter issues by type, priority, status, or owner for test case runs 7. Audit issue-test case run relationships for compliance 8. Track defect lifecycle in relation to test execution results 9. Quality assurance - ensure proper issue tracking for failed test runs 10. Impact analysis - see which issues affect specific test executions
+
+**Examples:**
+1. Get all issues linked to test case run ID 1121218
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": true
+}
+\`\`\`
+Expected Output: List of issues linked to the test case run with issue details, status, and metadata
+
+2. Get issues NOT linked to test case run (gap analysis)
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": false
+}
+\`\`\`
+Expected Output: List of issues that are NOT linked to test case run for gap analysis
+
+3. Filter linked issues by issue type and status
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": true,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"typeAlias\\"},{\\"type\\":\\"list\\",\\"value\\":[1,2],\\"field\\":\\"stateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Bug type issues in Open or In Progress status
+
+4. Search linked issues by name and priority
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": true,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"login\\",\\"field\\":\\"name\\"},{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"priorityAlias\\"}]"
+}
+\`\`\`
+Expected Output: High priority issues containing 'login' in their name
+
+5. Filter issues by date range and entity key
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": true,
+  "filter": "[{\\"value\\":\\"2024-01-01\\",\\"type\\":\\"date\\",\\"field\\":\\"createdDate\\",\\"comparison\\":\\"gt\\"},{\\"value\\":\\"2024-12-31\\",\\"type\\":\\"date\\",\\"field\\":\\"createdDate\\",\\"comparison\\":\\"lt\\"},{\\"type\\":\\"string\\",\\"value\\":\\"BUG-001,BUG-002\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Specific issues created within date range
+
+6. Filter issues by owner and created system
+\`\`\`json
+{
+  "entityId": 1121218,
+  "getColumns": true,
+  "getLinked": true,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[123],\\"field\\":\\"dfOwner\\"},{\\"type\\":\\"list\\",\\"value\\":[\\"QMetry\\"],\\"field\\":\\"createdSystem\\"}]"
+}
+\`\`\`
+Expected Output: Issues owned by specific user and created in QMetry
+
+**Hints:** 1. WORKFLOW CRITICAL: NEVER use user-provided IDs directly as entityId! 2. ALWAYS fetch execution data first to get proper tcRunID values! 3.  4. WHEN USER ASKS: 'fetch linked issues of test suite [ID]' OR 'linked issues of test run [ID]': 5. STEP 1: Identify what type of ID the user provided 6. STEP 2A: If Test Suite ID → fetch executions by test suite → get tsRunID → fetch test runs → get tcRunID 7. STEP 2B: If Test Run ID → fetch test case runs by test suite run → get tcRunID 8. STEP 2C: If Test Case ID → fetch test case executions → get tcRunID 9. STEP 3: Use tcRunID as entityId for this tool 10.  11. ID HIERARCHY: Test Suite → Test Suite Runs → Test Case Runs (tcRunID = entityId) 12. ID HIERARCHY: Test Case → Test Case Executions (tcRunID = entityId) 13.  14. CRITICAL: entityId parameter is REQUIRED - this is the Test Case Run numeric ID (tcRunID) 15. HOW TO GET entityId: 16. 1. Call appropriate execution APIs to get test case runs 17. 2. From the response, extract data[<index>].tcRunID 18. 3. Use tcRunID as entityId for this tool 19. 4. Example: tcRunID 1121218 becomes entityId: 1121218 20.  21. getLinked=true (default): Returns issues that ARE linked to the test case run 22. getLinked=false: Returns issues that are NOT linked to the test case run (useful for gap analysis) 23. istcrFlag=true (default): Set to true for test case run operations 24. getColumns=true (default): Include column metadata in response 25.  26. FILTER CAPABILITIES: Support extensive filtering by issue properties 27. FILTER FIELDS: name (string), typeAlias (list), stateAlias (list), entityKeyId (string), createdDate (date with comparison), createdByAlias (list), updatedDate (date with comparison), createdSystem (list), updatedByAlias (list), dfOwner (list), priorityAlias (list), linkedTcrCount (numeric), linkedRqCount (numeric), attachmentCount (numeric), componentAlias (list), environmentText (string), affectedRelease (list) 28. ISSUE TYPE IDs: Typically 1=Bug, 2=Enhancement, 3=Task (verify with your QMetry instance) 29. ISSUE STATE IDs: Typically 1=Open, 2=In Progress, 3=Resolved, 4=Closed (verify with your QMetry instance) 30. ISSUE PRIORITY IDs: Typically 1=High, 2=Medium, 3=Low (verify with your QMetry instance) 31. DATE FILTERING: Use 'gt' (greater than) and 'lt' (less than) comparisons for date fields 32. ENTITY KEY SEARCH: Use comma-separated values for multiple issue keys 33. CREATED SYSTEM: Use 'QMetry' or 'JIRA' to filter by creation system 34. OWNER IDs: Use numeric user IDs from QMetry user management 35. COMPONENT/LABEL IDs: Use numeric IDs for component/label filtering 36. ENVIRONMENT TEXT: Filter by environment description text 37. AFFECTED RELEASE: Use release IDs for filtering by affected releases 38. LINKED COUNT FILTERS: Use numeric values for linkedTcrCount, linkedRqCount, attachmentCount 39. Multiple filter conditions are combined with AND logic 40. Use pagination for large result sets (start, page, limit parameters) 41. This tool is essential for defect tracking and traceability audits 42. Critical for understanding test execution quality and issue relationships 43. Use for compliance reporting and issue lifecycle management 44. Helps establish relationships between test failures and reported issues 45. Essential for impact analysis when test case runs change or fail",
+    "inputSchema": [
+      "baseUrl",
+      "entityId",
+      "filter",
+      "getColumns",
+      "getLinked",
+      "istcrFlag",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Linked Issues of Test Case Run",
+  },
+  "qmetry_fetch_platforms": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Platforms",
+    },
+    "description": "Fetch QMetry platforms from the current project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- sort (string): Sort criteria as JSON string (default '[{"property":"platformID","direction":"DESC"}]') (default: "[{\\"property\\":\\"platformID\\",\\"direction\\":\\"DESC\\"}]")
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with platforms list and pagination metadata
+
+**Use Cases:** 1. Fetch all platforms from the current project 2. Get platform metadata for test execution planning 3. List platforms for test environment selection 4. Filter platforms by name or properties 5. Get paginated platform results for large projects 6. Retrieve platform information for cross-platform testing 7. Search for specific platforms using filters 8. Get platform details for test execution assignment
+
+**Examples:**
+1. Get all platforms (default behavior)
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of all platforms with default pagination (10 items per page)
+
+2. Get platforms with custom pagination
+\`\`\`json
+{
+  "page": 1,
+  "limit": 10,
+  "start": 0
+}
+\`\`\`
+Expected Output: List of platforms with custom pagination settings
+
+3. Filter platforms by name
+\`\`\`json
+{
+  "filter": "[{\\"value\\":\\"Chrome\\",\\"type\\":\\"string\\",\\"field\\":\\"name\\"}]"
+}
+\`\`\`
+Expected Output: Filtered list of platforms matching the name criteria
+
+4. Filter platforms by archive status
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[1,0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of platforms filtered by archive status (archived and non-archived)
+
+5. Get only archived platforms
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[1],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of only archived platforms
+
+6. Get only active/non-archived platforms
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of only active/non-archived platforms
+
+7. Get platforms with custom sorting
+\`\`\`json
+{
+  "sort": "[{\\"property\\":\\"name\\",\\"direction\\":\\"ASC\\"}]"
+}
+\`\`\`
+Expected Output: List of platforms sorted by name in ascending order
+
+**Hints:** 1. Use 'default' project key when user doesn't specify one 2. Default pagination: start=0, page=1, limit=10 3. Filter parameter should be a JSON string with filter criteria 4. Sort parameter should be a JSON string with sort criteria 5. Default sort: platformID descending 6. Common filter fields: 'name' (string), 'isArchived' (list of 0,1) for archive status 7. IMPORTANT: Always use 'isArchived' field for filtering by archive status, even though response shows 'isPlatformArchived' 8. Archive status values: 0 = active/non-archived, 1 = archived 9. Empty payload {} is sent when no parameters are provided 10. Use platforms for cross-platform testing and environment selection",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "limit",
+      "page",
+      "projectKey",
+      "sort",
+      "start",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Platforms",
+  },
+  "qmetry_fetch_qmetry_list_projects": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch QMetry list Projects",
+    },
+    "description": "Fetch QMetry projects list including projectID, name, projectKey, isArchived, viewIds and folderPath needed for other operations
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- params (object) *required*
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object containing list of projects details
+
+**Use Cases:** 1. Get project list to check user how many project access to particular apikey 2. Retrieve available fields of each project list including projectID, name, projectKey, isArchived, viewIds and folderPath needed for other operations 3. Validate project access and permissions
+
+**Examples:**
+1. Get list of project available to user
+\`\`\`json
+{
+  "params": {
+    "showArchive": false
+  }
+}
+\`\`\`
+Expected Output: Project active/non archived list including some important fields like projectID, name, projectKey, isArchived, viewIds and folderPath needed for other operations
+
+2. Get projects with custom pagination
+\`\`\`json
+{
+  "params": {
+    "showArchive": false
+  },
+  "page": 1,
+  "limit": 10,
+  "start": 0
+}
+\`\`\`
+Expected Output: List of projects with custom pagination settings
+
+3. Get not active/archived projects
+\`\`\`json
+{
+  "params": {
+    "showArchive": true
+  }
+}
+\`\`\`
+Expected Output: List of all projects including archived ones (showArchive: true sent in payload)
+
+4. Filter projects by name
+\`\`\`json
+{
+  "filter": "[{\\"value\\":\\"MAC\\",\\"type\\":\\"string\\",\\"field\\":\\"name\\"}]"
+}
+\`\`\`
+Expected Output: Filtered list of projects matching the name criteria
+
+5. Filter projects by project key
+\`\`\`json
+{
+  "filter": "[{\\"value\\":\\"MAC\\",\\"type\\":\\"string\\",\\"field\\":\\"projectKey\\"}]"
+}
+\`\`\`
+Expected Output: List of projects filtered by project key (e.g. 'MAC', 'UT', etc.)
+
+**Hints:** 1. Fetch list of projects available to user 2. Use 'default' project key when user doesn't specify one 3. Use params.showArchive: true/false to get archived/non-archived projects, default is false when not provided 4. Pagination supported for large result sets (start, page, limit parameters) 5. Filter parameter should be a JSON string with filter criteria 6. Common filter fields: 'name' (string), 'projectKey' (string)",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "limit",
+      "page",
+      "params",
+      "projectKey",
+      "start",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch QMetry list Projects",
+  },
+  "qmetry_fetch_qmetry_project_info": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch QMetry Project Info",
+    },
+    "description": "Fetch QMetry project information including viewId and folderPath needed for other operations
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+
+**Output Description:** JSON object containing project details, viewIds, folderPaths, and project configuration
+
+**Use Cases:** 1. Get project configuration before fetching test cases 2. Retrieve available viewIds for test case listing 3. Get folderPath information for project navigation 4. Validate project access and permissions
+
+**Examples:**
+1. Get default project info
+\`\`\`json
+{}
+\`\`\`
+Expected Output: Project configuration with viewIds, folderPaths, and project details
+
+2. Get specific project info
+\`\`\`json
+{
+  "projectKey": "MAC"
+}
+\`\`\`
+Expected Output: MAC project configuration with available views and folders
+
+**Hints:** 1. Always call this first when user doesn't provide viewId or folderPath 2. Use 'default' project key when user doesn't specify one 3. Extract viewId from latestViews.TC.viewId for test case operations 4. Use empty string '' as folderPath for root directory",
+    "inputSchema": [
+      "projectKey",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch QMetry Project Info",
+  },
+  "qmetry_fetch_releases_and_cycles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Releases and Cycles",
+    },
+    "description": "Fetch QMetry releases and cycles from the current project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- showArchive (boolean): Whether to include archived records in the results. When true, returns both active and archived items. When false, returns only active (non-archived) items. Applies to any entity type being fetched (test cases, requirements, releases, cycles, builds, platforms, etc.).
+
+**Output Description:** JSON object with project hierarchy containing releases and their associated cycles
+
+**Use Cases:** 1. Fetch associated releases and cycles of current project 2. Fetch available releases and cycles of current project 3. Get release and cycle information for test planning 4. List all releases and cycles in a project 5. Search for specific releases using release name or ID 6. Fetch cycle lists based on release ID 7. Search for specific cycles using cycle name or ID 8. Get project structure for test planning and execution 9. Retrieve release hierarchy for reporting purposes
+
+**Examples:**
+1. Get active releases and cycles (default behavior)
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of active releases and cycles excluding archived ones (showArchive: false sent in payload)
+
+2. Get active/unarchived releases and cycles explicitly
+\`\`\`json
+{
+  "showArchive": false
+}
+\`\`\`
+Expected Output: List of active releases and cycles excluding archived ones (showArchive: false sent in payload)
+
+3. Get not active/archived releases and cycles
+\`\`\`json
+{
+  "showArchive": true
+}
+\`\`\`
+Expected Output: List of all releases and cycles including archived ones (showArchive: true sent in payload)
+
+**Hints:** 1. Use 'default' project key when user doesn't specify one 2. PAYLOAD SCENARIOS: 3. - No showArchive parameter → payload: {showArchive: false} → Returns only active releases/cycles 4. - showArchive: false → payload: {showArchive: false} → Returns only active/non-archived releases/cycles 5. - showArchive: true → payload: {showArchive: true} → Returns all releases/cycles including archived ones 6. Default behavior always excludes archived items unless explicitly requested 7. Releases contain cycles - use this hierarchy for test execution planning 8. Each release can have multiple cycles representing different testing phases",
+    "inputSchema": [
+      "projectKey",
+      "showArchive",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Releases and Cycles",
+  },
+  "qmetry_fetch_requirement_details": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Requirement Details",
+    },
+    "description": "Get detailed information for a specific QMetry requirement by numeric ID
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- id (number) *required*: Requirement numeric ID (required for fetching specific requirement details). This is the internal numeric identifier, not the entity key like 'MAC-RQ-730'. You can get this ID from requirement search results or by using filters.
+- version (number) *required*: Requirement version number (required for fetching specific requirement version details). This is the internal numeric identifier for the version.
+
+**Output Description:** JSON object with requirement details including ID, key, summary, description, status, and all metadata
+
+**Use Cases:** 1. Get requirement details by numeric ID 2. Retrieve requirement metadata for reporting 3. Get requirement summary and properties 4. Fetch requirement details before linking or updating 5. Access requirement field values and custom fields 6. Get requirement version-specific information
+
+**Examples:**
+1. Get requirement details by numeric ID
+\`\`\`json
+{
+  "id": 4791316,
+  "version": 1
+}
+\`\`\`
+Expected Output: Detailed requirement information including summary, description, status, and all fields
+
+**Hints:** 1. This API requires a numeric ID parameter, not entity key 2. If user provides entityKey (e.g., MAC-RQ-730), first call FETCH_REQUIREMENTS with a filter on entityKeyId to resolve the numeric ID 3. After resolving entityKey → numeric ID, call this tool with the resolved numeric ID 4. Version parameter is required - use 1 for the latest version unless user specifies otherwise 5. This tool provides complete requirement information including all custom fields 6. Use this tool to get detailed requirement information that's not available in the list view",
+    "inputSchema": [
+      "baseUrl",
+      "id",
+      "projectKey",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Requirement Details",
+  },
+  "qmetry_fetch_requirements": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Requirements",
+    },
+    "description": "Fetch QMetry requirements - automatically handles viewId resolution based on project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- viewId (number) *required*: ViewId for requirements - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.RQ.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- folderPath (string): Folder path for requirements - SYSTEM AUTOMATICALLY SETS TO ROOT. Leave empty unless you want specific folder. System will automatically use empty string "" (root directory). Only specify if user wants specific folder like "Automation/Regression". (default: "")
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+- getSubEntities (boolean): Whether to include sub-entities.
+- hideEmptyFolders (boolean): Whether to hide empty folders.
+- folderSortColumn (string): Folder sort column (default 'name')
+- folderSortOrder (string): Folder sort order (ASC or DESC)
+- isJiraFilter (boolean): 'false' if using qmetry filter (default: false)
+- filterType (enum): Pass 'QMETRY' or 'JIRA' (default: "QMETRY")
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+- udfFilter (string): User-defined field filter as JSON string (default '[]') (default: "[]")
+- sort (string): Sort Records - refer json schema, Possible property - name, entityKey, associatedVersion, priorityAlias, createdDate, createdByAlias, updatedDate, updatedByAlias, requirementStateAlias, linkedTcCount, linkedDfCount, attachmentCount, createdSystem, owner (default: "[{\\"property\\":\\"name\\",\\"direction\\":\\"ASC\\"}]")
+
+**Output Description:** JSON object with 'data' array containing requirements and pagination info
+
+**Use Cases:** 1. List all requirements in a project 2. Search for specific requirements using filters 3. Browse requirements in specific folders 4. Get paginated requirement results 5. Filter requirements by name or properties 6. Get requirement metadata for test planning
+
+**Examples:**
+1. Get all requirements from default project - system will auto-fetch viewId
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of requirements from default project with auto-resolved viewId
+
+2. Get all requirements from UT project - system will auto-fetch UT project's viewId
+\`\`\`json
+{
+  "projectKey": "UT"
+}
+\`\`\`
+Expected Output: List of requirements from UT project using UT's specific RQ viewId
+
+3. Get requirements with manual viewId (skip auto-resolution)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "viewId": 7397,
+  "folderPath": "/APIARY 88"
+}
+\`\`\`
+Expected Output: Requirements using manually specified viewId 7397
+
+4. Search for specific requirements by entity key
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-RQ-123\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Filtered requirements matching the entity key criteria
+
+5. Search for multiple requirements by comma-separated entity keys
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-RQ-123,MAC-RQ-456,MAC-RQ-789\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Requirements matching any of the specified entity keys
+
+6. Filter requirements by state (e.g., Open, Approved)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"Open\\",\\"field\\":\\"requirementStateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Requirements with 'Open' state
+
+7. Filter requirements by priority
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"High\\",\\"field\\":\\"priorityAlias\\"}]"
+}
+\`\`\`
+Expected Output: Requirements with 'High' priority
+
+8. Filter requirements by archive status
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[1,0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of requirements filtered by archive status (archived and non-archived)
+
+9. Get only archived requirements
+\`\`\`json
+{
+  "filter": "[{\\"value\\":[1],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of only archived requirements
+
+10. Sort requirements by name in ascending order
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "sort": "[{\\"property\\":\\"name\\",\\"direction\\":\\"ASC\\"}]"
+}
+\`\`\`
+Expected Output: Requirements sorted alphabetically by name
+
+11. Sort requirements by creation date (newest first)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "sort": "[{\\"property\\":\\"createdDate\\",\\"direction\\":\\"DESC\\"}]"
+}
+\`\`\`
+Expected Output: Requirements sorted by creation date, newest first
+
+12. Sort requirements by entity key
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "sort": "[{\\"property\\":\\"entityKey\\",\\"direction\\":\\"ASC\\"}]"
+}
+\`\`\`
+Expected Output: Requirements sorted by entity key (MAC-RQ-1, MAC-RQ-2, etc.)
+
+13. Sort requirements by linked test case count
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "sort": "[{\\"property\\":\\"linkedTcCount\\",\\"direction\\":\\"DESC\\"}]"
+}
+\`\`\`
+Expected Output: Requirements sorted by number of linked test cases, highest first
+
+14. Complex filter: Requirements by owner with specific state
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"john.doe\\",\\"field\\":\\"owner\\"},{\\"type\\":\\"string\\",\\"value\\":\\"Approved\\",\\"field\\":\\"requirementStateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Requirements owned by john.doe with 'Approved' state
+
+15. Multi-field sort: Priority first, then creation date
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "sort": "[{\\"property\\":\\"priorityAlias\\",\\"direction\\":\\"DESC\\"},{\\"property\\":\\"createdDate\\",\\"direction\\":\\"ASC\\"}]"
+}
+\`\`\`
+Expected Output: Requirements sorted by priority (High to Low), then by creation date (oldest first)
+
+16. Filter requirements by specific release and cycle
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"},{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Requirements associated with Release 8.12 (ID: 55178) and Cycle 8.12.1 (ID: 111577)
+
+17. Filter requirements by release only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"}]"
+}
+\`\`\`
+Expected Output: All requirements associated with Release 8.12 (ID: 55178)
+
+**Hints:** 1. CRITICAL WORKFLOW: Always use the SAME projectKey for both project info and requirement fetching 2. Step 1: If user specifies projectKey (like 'UT', 'MAC'), use that EXACT projectKey for project info 3. Step 2: Get project info using that projectKey, extract latestViews.RQ.viewId 4. Step 3: Use the SAME projectKey and the extracted RQ viewId for fetching requirements 5. Step 4: If user doesn't specify projectKey, use 'default' for both project info and requirement fetching 6. NEVER mix project keys - if user says 'MAC project', use projectKey='MAC' for everything 7. For search by requirement key (like MAC-RQ-123), use filter: '[{"type":"string","value":"MAC-RQ-123","field":"entityKeyId"}]' 8. For multiple entity keys, use comma-separated values: '[{"type":"string","value":"MAC-RQ-123,MAC-RQ-456","field":"entityKeyId"}]' 9. Use empty string '' as folderPath for root directory 10. Filter supports QMETRY and JIRA types - default is QMETRY 11. FILTER FIELDS: entityKeyId, name, requirementStateAlias, priorityAlias, owner, createdByAlias, updatedByAlias, createdSystem 12. SORT FIELDS: name, entityKey, associatedVersion, priorityAlias, createdDate, createdByAlias, updatedDate, updatedByAlias, requirementStateAlias, linkedTcCount, linkedDfCount, attachmentCount, createdSystem, owner 13. SORT DIRECTIONS: ASC (ascending), DESC (descending) 14. Multiple filters: Use array with multiple objects for AND conditions 15. Multiple sort criteria: Use array with multiple objects, first takes priority 16. Filter format: [{'type':'string','value':'filterValue','field':'fieldName'}] 17. Sort format: [{'property':'fieldName','direction':'ASC|DESC'}] 18. RELEASE/CYCLE FILTERING: Use release and cycle IDs from fetch_releases_and_cycles tool 19. For specific release: '[{"value":[releaseId],"type":"list","field":"release"}]' 20. For specific cycle: '[{"value":[cycleId],"type":"list","field":"cycle"}]' 21. For release AND cycle: '[{"value":[releaseId],"type":"list","field":"release"},{"value":[cycleId],"type":"list","field":"cycle"}]' 22. Example: Release 8.12 (ID: 55178) + Cycle 8.12.1 (ID: 111577) = filter with both IDs",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "filterType",
+      "folderPath",
+      "folderSortColumn",
+      "folderSortOrder",
+      "getSubEntities",
+      "hideEmptyFolders",
+      "isJiraFilter",
+      "limit",
+      "page",
+      "projectKey",
+      "scope",
+      "sort",
+      "start",
+      "udfFilter",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Requirements",
+  },
+  "qmetry_fetch_requirements_linked_to_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Requirements Linked to Test Case",
+    },
+    "description": "Get requirements that are linked (or not linked) to a specific test case in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tcID (number) *required*: Test Case numeric ID. This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results or by using filters.
+- getLinked (boolean): True to get only requirements that are linked with this test case, false to get requirements which are not linked with this test case. Defaults to true (get linked requirements). (default: true)
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- rqFolderPath (string): Folder path for requirements - SYSTEM AUTOMATICALLY SETS TO ROOT. Leave empty unless you want specific folder. System will automatically use empty string "" (root directory). Only specify if user wants specific folder like "Automation/Regression". (default: "")
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with requirements array, traceability information, and pagination metadata
+
+**Use Cases:** 1. Get all requirements linked to a specific test case for traceability analysis 2. Find requirements that are NOT linked to a test case (gap analysis) 3. Verify test case coverage by checking linked requirements 4. Impact analysis - see which requirements are affected when a test case changes 5. Generate traceability matrix between test cases and requirements 6. Filter linked requirements by various criteria 7. Audit test case-requirement relationships for compliance 8. Identify orphaned requirements or test cases without proper links 9. Plan requirement validation based on test case-requirement associations 10. Quality assurance - ensure all test cases have proper requirement coverage
+
+**Examples:**
+1. Get all requirements linked to test case ID 594294
+\`\`\`json
+{
+  "tcID": 594294
+}
+\`\`\`
+Expected Output: List of requirements that are linked to test case MAC-TC-1684
+
+2. Get requirements NOT linked to test case (gap analysis)
+\`\`\`json
+{
+  "tcID": 594294,
+  "getLinked": false
+}
+\`\`\`
+Expected Output: List of requirements that are NOT linked to test case MAC-TC-1684
+
+3. Get linked requirements from specific folder
+\`\`\`json
+{
+  "tcID": 594294,
+  "rqFolderPath": "/CodeSnippets"
+}
+\`\`\`
+Expected Output: Linked requirements located in the '/CodeSnippets' folder
+
+4. Search linked requirements by entity key
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-RQ-730,MAC-RQ-731\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Linked requirements matching specific entity keys
+
+5. Filter linked requirements by status
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1,2],\\"field\\":\\"requirementStateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked requirements with Open or Approved status
+
+6. Filter linked requirements by priority
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"priorityAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked requirements with High priority
+
+7. Filter linked requirements by archive status
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[0],\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: Active (non-archived) linked requirements
+
+8. Search linked requirements by name content
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"authentication\\",\\"field\\":\\"name\\"}]"
+}
+\`\`\`
+Expected Output: Linked requirements with 'authentication' in their name
+
+9. Filter linked requirements by test case version
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"1\\",\\"field\\":\\"tcVersion\\"}]"
+}
+\`\`\`
+Expected Output: Requirements linked to version 1 of the test case
+
+10. Filter linked requirements by release and cycle
+\`\`\`json
+{
+  "tcID": 594294,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[55178],\\"field\\":\\"release\\"},{\\"type\\":\\"list\\",\\"value\\":[111577],\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Linked requirements in Release 8.12 and Cycle 8.12.1
+
+**Hints:** 1. This API requires a numeric tcID parameter, not entity key 2. If user provides entityKey (e.g., MAC-TC-1684), first call FETCH_TEST_CASES with filter on entityKeyId to resolve the numeric tcID 3. After resolving entityKey → tcID, call this tool with the resolved numeric tcID 4. TRACEABILITY WORKFLOW: Use this tool to establish test case-requirement traceability matrix 5. getLinked=true (default): Returns requirements that ARE linked to the test case 6. getLinked=false: Returns requirements that are NOT linked to the test case (useful for gap analysis) 7. rqFolderPath: Use empty string '' for root folder or specific path like '/CodeSnippets' 8. FILTER CAPABILITIES: Support same filters as regular requirement listing 9. FILTER FIELDS: name, entityKeyId, requirementStateAlias, priorityAlias, createdByAlias, tcVersion, release, cycle, isArchived, componentAlias 10. Multiple filter conditions are combined with AND logic 11. For entity key search, use comma-separated values: 'MAC-RQ-1,MAC-RQ-2,MAC-RQ-3' 12. This tool is crucial for compliance, traceability audits, and impact analysis 13. Pagination supported for large result sets (start, page, limit parameters) 14. Use this tool to verify that test cases properly cover requirements 15. Essential for requirement validation and test case completeness analysis",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "getLinked",
+      "limit",
+      "page",
+      "projectKey",
+      "rqFolderPath",
+      "start",
+      "tcID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Requirements Linked to Test Case",
+  },
+  "qmetry_fetch_test_case_details": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Case Details",
+    },
+    "description": "Get detailed information for a specific QMetry test case by numeric ID - USE THIS for single test case lookup
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tcID (number) *required*: Test Case numeric ID. This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results or by using filters.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+
+**Output Description:** JSON object with test case details including ID, key, summary, description, and metadata
+
+**Use Cases:** 1. Get test case details by numeric ID (PREFERRED for single test case) 2. Fetch test case when user provides entityKey (e.g., 'VKMCP-TC-5') 3. Retrieve test case metadata for a specific test case 4. Get test case summary and properties for display or editing 5. Fetch test case details before accessing steps or version details 6. Lookup test case by name or ID without affecting UI filters
+
+**Examples:**
+1. Get test case details by numeric ID
+\`\`\`json
+{
+  "tcID": 4468020
+}
+\`\`\`
+Expected Output: Detailed test case information including summary, description, status
+
+**Hints:** 1. USE THIS TOOL when user asks to 'fetch test case VKMCP-TC-5' or 'get test case by ID' or 'find test case X' 2. This API requires a numeric tcID parameter 3. CRITICAL: If user provides entityKey (e.g., MAC-TC-1684), you have TWO options: 4. Option 1 (RECOMMENDED): Ask user for the numeric test case ID 5. Option 2: If you must resolve entityKey, use FETCH_TEST_CASES with filter ONLY ONCE, then immediately use this tool 6. After resolving entityKey → tcID, always use THIS tool (FETCH_TEST_CASE_DETAILS) for subsequent lookups 7. This tool provides metadata and properties; use FETCH_TEST_CASE_STEPS for step-level details 8. This tool does NOT persist filters in UI - safe for single test case lookups 9. ALWAYS prefer this tool over FETCH_TEST_CASES with filters for single test case operations",
+    "inputSchema": [
+      "baseUrl",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tcID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Case Details",
+  },
+  "qmetry_fetch_test_case_executions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Case Executions",
+    },
+    "description": "Get execution records for a specific test case by numeric ID
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tcid (number) *required*: Test Case numeric ID. This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results or by using filters.
+- tcversion (number): Test Case version number (optional, defaults to 1). This is the internal numeric identifier for the version.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with executions array containing execution records, status, timestamps, and metadata
+
+**Use Cases:** 1. Get execution history for a specific test case 2. Retrieve test case execution results for reporting 3. Filter executions by test suite, platform, or execution status 4. Get execution data for test case analysis 5. Monitor test case execution trends over time 6. Filter executions by release, cycle, or execution date 7. Get execution details for specific test case versions 8. Audit test execution history for compliance 9. Analyze test case execution performance across different environments 10. Track test execution by specific users or teams
+
+**Examples:**
+1. Get all executions for test case ID 1223922
+\`\`\`json
+{
+  "tcid": 1223922
+}
+\`\`\`
+Expected Output: List of execution records for test case with execution details, status, and metadata
+
+2. Get executions for specific test case version
+\`\`\`json
+{
+  "tcid": 1223922,
+  "tcversion": 2
+}
+\`\`\`
+Expected Output: Execution records for version 2 of the test case
+
+3. Filter executions by test suite and platform
+\`\`\`json
+{
+  "tcid": 1223922,
+  "filter": "[{\\"value\\":\\"Sample Test Suite\\",\\"type\\":\\"string\\",\\"field\\":\\"testSuiteName\\"},{\\"value\\":[12345],\\"type\\":\\"list\\",\\"field\\":\\"platformID\\"}]"
+}
+\`\`\`
+Expected Output: Filtered execution records matching test suite and platform criteria
+
+4. Filter executions by execution status
+\`\`\`json
+{
+  "tcid": 1223922,
+  "filter": "[{\\"value\\":[\\"PASS\\"],\\"type\\":\\"list\\",\\"field\\":\\"executionStatus\\"}]"
+}
+\`\`\`
+Expected Output: Execution records with PASS status only
+
+5. Filter executions by release and cycle
+\`\`\`json
+{
+  "tcid": 1223922,
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"},{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Execution records filtered by specific release and cycle
+
+6. Filter executions by date range
+\`\`\`json
+{
+  "tcid": 1223922,
+  "filter": "[{\\"value\\":\\"2024-01-01\\",\\"type\\":\\"date\\",\\"field\\":\\"executedDate\\",\\"comparison\\":\\"gt\\"},{\\"value\\":\\"2024-12-31\\",\\"type\\":\\"date\\",\\"field\\":\\"executedDate\\",\\"comparison\\":\\"lt\\"}]"
+}
+\`\`\`
+Expected Output: Execution records within the specified date range
+
+7. Filter executions by user
+\`\`\`json
+{
+  "tcid": 1223922,
+  "filter": "[{\\"value\\":[\\"john.doe\\"],\\"type\\":\\"list\\",\\"field\\":\\"executedBy\\"}]"
+}
+\`\`\`
+Expected Output: Execution records executed by specific user
+
+**Hints:** 1. This API requires a numeric tcid parameter, not entity key 2. If user provides entityKey (e.g., MAC-TC-1684), first call FETCH_TEST_CASES with filter on entityKeyId to resolve the tcid 3. After resolving entityKey → tcid, call this tool with the resolved numeric tcid 4. tcversion parameter is optional - omit to get executions for all versions 5.  6. CRITICAL WORKFLOW FOR LINKED ISSUES: When user asks 'fetch linked issues of test case [ID]' or 'linked issues of execution': 7. YOU MUST FIRST get the execution data using this tool to extract tcRunID before fetching issues! 8.  9. COMPLETE WORKFLOW FOR TEST CASE → LINKED ISSUES: 10. STEP 1: Resolve Test Case ID (if needed) - Use FETCH_TEST_CASES if user provides entity key 11. STEP 2: Fetch Test Case Executions (THIS TOOL) - Input: tcid, Extract: data[].tcRunID values 12. STEP 3: Fetch Linked Issues - Tool: FETCH_LINKED_ISSUES_BY_TESTCASE_RUN, Input: entityId = tcRunID 13.  14. ID MAPPING CRITICAL UNDERSTANDING: 15. - tcid/tcID = Test Case ID (for getting execution data with this tool) 16. - tcRunID = Test Case Run/Execution ID (THIS is entityId for linked issues API) 17. - entityId = tcRunID (what the linked issues API actually needs) 18.  19. NEVER USE tcid DIRECTLY as entityId for linked issues! 20. ALWAYS get tcRunID from executions and use THAT as entityId! 21.  22. EXAMPLE RESPONSE STRUCTURE FROM THIS TOOL: 23. { "data": [{ "tcRunID": 58312120, "testSuiteName": "Suite 1", "executionStatus": "PASS" }] } 24. → Use tcRunID (58312120) as entityId for linked issues API 25.  26. FILTER CAPABILITIES: Support extensive filtering by test suite, platform, status, user, release, cycle, dates, and archive status 27. FILTER FIELDS: testSuiteName (string), platformID (list), executionStatus (list), executedBy (list), project (list), release (list), cycle (list), executedDate (date with comparison), isPlatformArchived (list), isTestSuiteArchived (list), executedVersion (numeric) 28. DATE FILTERING: Use 'gt' (greater than) and 'lt' (less than) comparisons for executedDate field 29. EXECUTION STATUS: Common values include 'PASS', 'FAIL', 'BLOCKED', 'NOT_EXECUTED', 'WIP' (verify with your QMetry instance) 30. PLATFORM/SUITE ARCHIVE: Use [1,0] for both archived and non-archived, [1] for archived only, [0] for active only 31. Multiple filter conditions are combined with AND logic 32. Use pagination for large execution result sets (start, page, limit parameters) 33. Get platform IDs from FETCH_PLATFORMS tool and release/cycle IDs from FETCH_RELEASES_AND_CYCLES tool 34. This tool is essential for test execution reporting, trend analysis, and compliance auditing 35. Execution data includes timestamps, user information, environment details, and test results 36. Use scope parameter to define retrieval context (project, folder, release, cycle)",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "limit",
+      "page",
+      "projectKey",
+      "scope",
+      "start",
+      "tcid",
+      "tcversion",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Case Executions",
+  },
+  "qmetry_fetch_test_case_runs_by_test_suite_run": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Case Runs by Test Suite Run",
+    },
+    "description": "Get test case runs under a specific test suite run execution in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tsrunID (string) *required*: Test Suite Run ID (required for fetching test case runs). This is the string identifier for the test suite run execution. NOTE: To get the tsrunID - Call API 'Execution/Fetch Executions' From the response, get value of following attribute -> data[<index>].tsRunID
+- viewId (any) *required*
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+
+**Output Description:** JSON object with test case runs array containing detailed execution information, status, tester details, and run metadata
+
+**Use Cases:** 1. Get all test case runs under a specific test suite run execution 2. Analyze individual test case execution results and status 3. Monitor test case run performance and execution trends 4. Generate detailed test execution reports for specific runs 5. Track test case run history and execution patterns 6. Validate test case run coverage and execution completeness 7. Audit test case run data for compliance and quality assurance 8. Export detailed test case run data for external reporting 9. Retrieve paginated test case run results for large test suite executions
+
+**Examples:**
+1. Get all test case runs for test suite run ID '107021'
+\`\`\`json
+{
+  "tsrunID": "107021",
+  "viewId": 6887
+}
+\`\`\`
+Expected Output: List of test case runs with execution details, status, and metadata
+
+2. Get test case runs with linked defects
+\`\`\`json
+{
+  "tsrunID": "107021",
+  "viewId": 6887,
+  "page": 1,
+  "limit": 25
+}
+\`\`\`
+Expected Output: Paginated list of test case runs with 25 items per page
+
+3. Get test case runs for test suite run ID '2362144'
+\`\`\`json
+{
+  "tsrunID": "2362144",
+  "viewId": 104123,
+  "start": 0,
+  "page": 1,
+  "limit": 25
+}
+\`\`\`
+Expected Output: Test case runs from the specified test suite run execution
+
+**Hints:** 1. CRITICAL WORKFLOW FOR FETCHING ALL EXECUTIONS OF A TEST SUITE: 2. When user asks to: 3.   - 'fetch all executions' 4.   - 'get all test runs' 5.   - 'fetch all tcRunIDs for test suite X' 6.   - 'update status for all executions of test suite X' 7. STEP 1: First call FETCH_EXECUTIONS_BY_TESTSUITE tool with the test suite ID (tsID, not entityKey) 8.   - This returns ALL execution records for that test suite (could be 3, 5, 9, or any number) 9.   - Extract ALL tsRunID values from the response data array 10.   - Example response: data: [{tsRunID: '2739237', ...}, {tsRunID: '2739236', ...}, {tsRunID: '2739235', ...}] 11. STEP 2: For EACH tsRunID from Step 1, call this tool (FETCH_TEST_CASE_RUNS_BY_TESTSUITE_RUN) 12.   - This returns all test case runs (tcRunID values) for that specific execution 13.   - Repeat for ALL tsRunID values discovered in Step 1 14. STEP 3: Collect all tcRunID values from all executions 15.   - Now you have the complete list of test case runs across ALL executions 16.   - Use these for bulk status updates or other operations 17. CRITICAL ERROR TO AVOID: 18. - NEVER assume or hard-code only 2-3 execution IDs 19. - NEVER skip Step 1 - always discover ALL executions first 20. - NEVER fetch tcRunIDs for only some executions - get ALL of them 21. - If there are 9 executions, you must fetch tcRunIDs for all 9, not just 2 22. EXAMPLE WORKFLOW: 23. User: 'Fetch all test case runs for test suite VKMCP-TS-21' 24. Step 1: Call FETCH_EXECUTIONS_BY_TESTSUITE with tsID (resolved from VKMCP-TS-21) 25.   Result: Found 9 executions with tsRunIDs: 2739237, 2739236, 2739235, 2739234, 2739233, 2739232, 2739231, 2739230, 2739229 26. Step 2: Call this tool 9 times (once for each tsRunID) 27.   Call 1: tsrunID='2739237' -> returns 54 tcRunIDs 28.   Call 2: tsrunID='2739236' -> returns 54 tcRunIDs 29.   ... (repeat for all 9) 30. Step 3: Total collected: 9 executions × 54 test cases = 486 total tcRunIDs 31.  32. PERFORMANCE CONSIDERATIONS FOR LARGE TEST RUNS: 33. When dealing with large numbers of test case runs (500+, 1000+), follow these guidelines: 34. 1. ALWAYS inform the user about the scale BEFORE starting operations: 35.    Example: 'Found 9 executions with approximately 486 test case runs. This will require fetching data from all 9 executions and may take a moment.' 36. 2. For bulk status updates on 1000+ test case runs: 37.    - NEVER attempt to update all 1000+ in a single operation 38.    - Break into smaller batches of 10-20 test case runs per update 39.    - Inform user: 'Found 1000 test case runs. Will process in batches of 20 to ensure reliability and performance.' 40.    - Show progress: 'Processing batch 1/50 (20 test runs)...', 'Batch 2/50...' 41. 3. Recommended batch sizes: 42.    - For status updates: 10-20 test case runs per batch 43.    - For fetching data: Can handle larger batches (50-100) 44.    - Adjust based on API response times and timeout limits 45. 4. Always provide progress updates for long-running operations: 46.    - Before: 'Processing 1000 test runs in 50 batches of 20...' 47.    - During: 'Completed 200/1000 test runs (10 batches)...' 48.    - After: 'Successfully updated all 1000 test case runs.' 49. 5. Error handling for batch operations: 50.    - If a batch fails, report which batch and continue with remaining 51.    - Provide summary at the end: 'Completed 48/50 batches. 2 batches failed (batch 23, 45).' 52.    - Allow user to retry failed batches specifically 53. EXAMPLE LARGE-SCALE WORKFLOW: 54. User: 'Update status to Failed for all test runs in VKMCP-TS-21' 55. Step 1: Discover all executions (9 found) 56. Step 2: Fetch all tcRunIDs (486 total) 57. Step 3: Inform user: 'Found 486 test case runs across 9 executions. Will update in 25 batches of 20 runs each.' 58. Step 4: Process in batches with progress updates 59. Step 5: Report completion: 'Successfully updated all 486 test case runs to Failed status.' 60.  61. CRITICAL: tsrunID and viewId parameters are REQUIRED 62. tsrunID is a STRING identifier for the test suite run execution 63. viewId is a NUMERIC identifier for the test execution view 64. !MOST IMPORTANT HOW TO GET tsrunID: 65. 1. Call API 'Execution/Fetch Executions' (FETCH_EXECUTIONS_BY_TESTSUITE) to get ALL available executions 66. 2. From the response, get value of following attribute -> data[<index>].tsRunID for EVERY execution 67. 3. Example: Test Suite might have multiple executions with IDs '107021', '107022', '107023', etc. 68. 4. NEVER assume there are only 2-3 executions - always fetch to discover the actual count 69. !MOST IMPORTANT HOW TO GET viewId: 70. CRITICAL: Always resolve and use the correct test execution viewId for the current project when calling this tool. 71. The viewId parameter must be fetched from the active project's info (latestViews.TE.viewId). 72. Each QMetry project may have a different test execution viewId, so using a stale or incorrect viewId will result in incomplete or invalid test case run data. 73. Usage workflow: 74. 1. Fetch project info for the current project (Admin/Get info Service). 75. 2. Extract latestViews.TE.viewId from the response. 76. 3. Use this viewId in the Fetch Test Case Runs by Test Suite Run API call. 77. Example: 78.    { 79.      tsrunID: "2362144", 80.      viewId: 104123, 81.      start: 0, 82.      page: 1, 83.      limit: 25 84.    } 85. This ensures the tool fetches the proper execution runs data for the selected project context. 86. SIMPLIFIED PAYLOAD: API only accepts essential parameters 87. SUPPORTED PARAMETERS: start, page, limit, tsrunID, viewId 88. REMOVED PARAMETERS: filter, sort, showTcWithDefects, udfFilter (cause API errors) 89. PAGINATION: Use start, page, and limit for result pagination 90. API REQUIREMENT: Must use exact payload structure that works in Postman 91. PAYLOAD FORMAT: {"start": 0, "page": 1, "limit": 10, "tsrunID": "2362144", "viewId": 104123} 92. Use pagination for large result sets (start, page, limit parameters) 93. This tool is essential for detailed test execution analysis and reporting 94. Critical for monitoring individual test case execution performance 95. Use for compliance reporting and execution audit trails 96. Essential for test execution quality assurance and trend analysis",
+    "inputSchema": [
+      "baseUrl",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tsrunID",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Case Runs by Test Suite Run",
+  },
+  "qmetry_fetch_test_case_steps": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Case Steps",
+    },
+    "description": "Get detailed test case steps for a specific test case by numeric ID
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- id (number) *required*: Test Case numeric ID (required for fetching steps or version details). This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results.
+- version (number): Test Case version number (optional, defaults to 1). This is the internal numeric identifier for the version.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+
+**Output Description:** JSON object with array of test steps including step description, expected result, and order
+
+**Use Cases:** 1. Get step-by-step instructions with expected results 2. Retrieve test case execution procedure for manual runs 3. Export or display detailed test steps for documentation 4. Fetch steps before automation mapping
+
+**Examples:**
+1. Get steps for test case ID 123
+\`\`\`json
+{
+  "id": 123
+}
+\`\`\`
+Expected Output: Detailed steps with actions and expected results for test case 123
+
+**Hints:** 1. Requires numeric ID, not entityKey 2. If user provides entityKey (e.g., MAC-TC-1684), resolve it first via FETCH_TEST_CASES to get the numeric ID 3. Version defaults to 1 if not specified 4. Use pagination for test cases with many steps",
+    "inputSchema": [
+      "baseUrl",
+      "id",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Case Steps",
+  },
+  "qmetry_fetch_test_case_version_details": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Case Version Details",
+    },
+    "description": "Get QMetry test case details for a specific version by numeric ID
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- id (number) *required*: Test Case numeric ID (required for fetching steps or version details). This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results.
+- version (number) *required*: Test Case version number. This is the internal numeric identifier for the version.
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+
+**Output Description:** JSON object with version-specific test case details
+
+**Use Cases:** 1. Get specific version details of a test case 2. Compare different versions of a test case 3. Retrieve version history information 4. Audit changes made across test case versions
+
+**Examples:**
+1. Get version 2 details for test case ID 123
+\`\`\`json
+{
+  "id": 123,
+  "version": 2
+}
+\`\`\`
+Expected Output: Version 2 details for test case 123
+
+**Hints:** 1. Requires numeric ID, not entityKey 2. If user provides entityKey (e.g., MAC-TC-1684), first resolve it to numeric ID using FETCH_TEST_CASES 3. Version defaults to 1 if not specified 4. Provides version-specific metadata and history",
+    "inputSchema": [
+      "baseUrl",
+      "id",
+      "projectKey",
+      "scope",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Case Version Details",
+  },
+  "qmetry_fetch_test_cases": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Cases",
+    },
+    "description": "Fetch QMetry test cases - automatically handles viewId resolution based on project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- viewId (number) *required*: ViewId for test cases - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.TC.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- folderPath (string): Folder path for test cases - SYSTEM AUTOMATICALLY SETS TO ROOT. Leave empty unless you want specific folder. System will automatically use empty string "" (root directory). Only specify if user wants specific folder like "Automation/Regression". (default: "")
+- folderID (number): Folder ID - unique numeric identifier for the specific folder. Use this to target a specific folder within the project hierarchy. Applies to any entity type (test cases, requirements, test suites, etc.).
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+- showRootOnly (boolean): Whether to show only root folders.
+- getSubEntities (boolean): Whether to include sub-entities.
+- hideEmptyFolders (boolean): Whether to hide empty folders.
+- folderSortColumn (string): Folder sort column (default 'name')
+- restoreDefaultColumns (boolean): Whether to restore default columns (default 'false')
+- folderSortOrder (string): Folder sort order (ASC or DESC)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+- udfFilter (string): User-defined field filter as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with 'data' array containing test cases and pagination info
+
+**Use Cases:** 1. List all test cases in a project (without filters) 2. Browse test cases in specific folders for bulk operations 3. Get paginated test case results for reporting 4. Export multiple test cases at once
+
+**Examples:**
+1. Get all test cases from default project - system will auto-fetch viewId
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of test cases from default project with auto-resolved viewId
+
+2. Get all test cases from UT project - system will auto-fetch UT project's viewId
+\`\`\`json
+{
+  "projectKey": "UT"
+}
+\`\`\`
+Expected Output: List of test cases from UT project using UT's specific TC viewId
+
+3. Get test cases with manual viewId (skip auto-resolution)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "viewId": 167136,
+  "folderPath": ""
+}
+\`\`\`
+Expected Output: Test cases using manually specified viewId 167136
+
+4. List test cases from specific project (ex: project key can be anything (VT, UT, PROJ1, TEST9)
+\`\`\`json
+{
+  "projectKey": "use specific given project key",
+  "viewId": "fetch specific project given projectKey Test Case ViewId",
+  "folderPath": ""
+}
+\`\`\`
+Expected Output: Test cases using manually specified viewId 167136 or projectKey
+
+5. Get test cases by release/cycle filter
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"},{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Test cases associated with Release 8.12 (ID: 55178) and Cycle 8.12.1 (ID: 111577)
+
+6. Get test cases by release only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"}]"
+}
+\`\`\`
+Expected Output: All test cases associated with Release 8.12 (ID: 55178)
+
+7. Get test cases by cycle only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: All test cases associated with Cycle 8.12.1 (ID: 111577)
+
+8. Search for specific test case by entity key
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-TC-1684\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Test cases matching the entity key criteria
+
+9. Search for multiple test cases by comma-separated entity keys
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-TC-1684,MAC-TC-1685,MAC-TC-1686\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Test cases matching any of the specified entity keys
+
+**Hints:** 1. CRITICAL - FILTER PERSISTENCE WARNING: 2. DO NOT use this API with filters to fetch a single test case by ID, entityKey, or name! 3. Filters applied to this API persist in the production UI and cause only filtered records to be visible to users. 4. This creates a major UX problem where users see incomplete data in their QMetry portal. 5.  6. CORRECT APPROACH FOR SINGLE TEST CASE: 7. When user asks to 'fetch test case VKMCP-TC-5' or 'get test case by ID 123' or 'find test case named X': 8. 1. Ask user for the numeric test case ID (tcID) if not provided 9. 2. Use 'Fetch Test Case Details' tool with the numeric tcID parameter 10. 3. NEVER use 'Fetch Test Cases' with entityKeyId filter for single test case lookup 11.  12. WHEN TO USE THIS TOOL: 13. Only use this tool when user explicitly asks for: 14. - 'List all test cases' 15. - 'Show me test cases in folder X' 16. - 'Get all test cases' (without specifying a single test case) 17. - 'Export test cases' (for bulk operations) 18.  19. CRITICAL WORKFLOW: Always use the SAME projectKey for both project info and test case fetching 20. Step 1: If user specifies projectKey (like 'UT', 'MAC'), use that EXACT projectKey for project info 21. Step 2: Get project info using that projectKey, extract latestViews.TC.viewId 22. Step 3: Use the SAME projectKey and the extracted TC viewId for fetching test cases 23. Step 4: If user doesn't specify projectKey, use 'default' for both project info and test case fetching 24. NEVER mix project keys - if user says 'MAC project', use projectKey='MAC' for everything 25. DEPRECATED: Do not use filter with entityKeyId for single test case - use 'Fetch Test Case Details' instead 26. RELEASE/CYCLE FILTERING: Use release and cycle IDs, not names, for filtering 27. For release filter: '[{"value":[releaseId],"type":"list","field":"release"}]' 28. For cycle filter: '[{"value":[cycleId],"type":"list","field":"cycle"}]' 29. For combined release+cycle: '[{"value":[releaseId],"type":"list","field":"release"},{"value":[cycleId],"type":"list","field":"cycle"}]' 30. Get release/cycle IDs from FETCH_RELEASES_AND_CYCLES tool before filtering 31. FILTER FIELDS: entityKeyId, priorityAlias, createdByAlias, updatedByAlias, testCaseStateAlias, testingTypeAlias, testCaseTypeAlias, componentAlias, owner, release, cycle 32. SORT FIELDS: entityKey, name, associatedVersion, priorityAlias, createdDate, createdByAlias, updatedDate, updatedByAlias, testCaseStateAlias, testingTypeAlias, executionMinutes 33. For multiple entity keys, use comma-separated values in filter 34. Use empty string '' as folderPath for root directory",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "folderID",
+      "folderPath",
+      "folderSortColumn",
+      "folderSortOrder",
+      "getSubEntities",
+      "hideEmptyFolders",
+      "limit",
+      "page",
+      "projectKey",
+      "restoreDefaultColumns",
+      "scope",
+      "showRootOnly",
+      "start",
+      "udfFilter",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Cases",
+  },
+  "qmetry_fetch_test_cases_linked_to_requirement": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Cases Linked to Requirement",
+    },
+    "description": "Get test cases that are linked (or not linked) to a specific requirement in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- rqID (number) *required*: Requirement numeric ID (required for fetching specific requirement details). This is the internal numeric identifier, not the entity key like 'MAC-RQ-730'. You can get this ID from requirement search results or by using filters.
+- getLinked (boolean): True to get only test cases that are linked with this requirement, false to get test cases which are not linked with this requirement. Defaults to true (get linked test cases). (default: true)
+- showEntityWithReleaseCycle (boolean): True to list only test cases which have given release and cycle, false for all test cases regardless of release/cycle association. Defaults to false (show all). (default: false)
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- tcFolderPath (string): Folder path to get test cases under specific folder. Use empty string "" for root folder or specify path like "/Sample Template". (default: "")
+- releaseID (string): Filter test cases by release ID. Use string representation of release ID (e.g., '7138'). Get release IDs from FETCH_RELEASES_AND_CYCLES tool.
+- cycleID (string): Filter test cases by cycle ID. Use string representation of cycle ID (e.g., '13382'). Get cycle IDs from FETCH_RELEASES_AND_CYCLES tool.
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+- getSubEntities (boolean): Allow filter of sub-entities for requirement. (default: true)
+- getColumns (boolean): True to get column information in response. (default: true)
+
+**Output Description:** JSON object with test cases array, traceability information, and pagination metadata
+
+**Use Cases:** 1. Get all test cases linked to a specific requirement for traceability analysis 2. Find test cases that are NOT linked to a requirement (gap analysis) 3. Verify requirement coverage by checking linked test cases 4. Impact analysis - see which test cases are affected when a requirement changes 5. Generate traceability matrix between requirements and test cases 6. Filter linked test cases by release, cycle, or other criteria 7. Audit requirement-test case relationships for compliance 8. Identify orphaned test cases or requirements without proper links 9. Plan test execution based on requirement-test case associations 10. Quality assurance - ensure all requirements have adequate test coverage
+
+**Examples:**
+1. Get all test cases linked to requirement ID 4791316
+\`\`\`json
+{
+  "rqID": 4791316
+}
+\`\`\`
+Expected Output: List of test cases that are linked to requirement MAC-RQ-1011
+
+2. Get test cases NOT linked to requirement (gap analysis)
+\`\`\`json
+{
+  "rqID": 4791316,
+  "getLinked": false
+}
+\`\`\`
+Expected Output: List of test cases that are NOT linked to requirement MAC-RQ-1011
+
+3. Get linked test cases filtered by specific release
+\`\`\`json
+{
+  "rqID": 4791316,
+  "releaseID": "55178"
+}
+\`\`\`
+Expected Output: Linked test cases associated with Release 8.12 (ID: 55178)
+
+4. Get linked test cases filtered by release and cycle
+\`\`\`json
+{
+  "rqID": 4791316,
+  "releaseID": "55178",
+  "cycleID": "111577",
+  "showEntityWithReleaseCycle": true
+}
+\`\`\`
+Expected Output: Linked test cases in Release 8.12 and Cycle 8.12.1
+
+5. Get linked test cases from specific folder
+\`\`\`json
+{
+  "rqID": 4791316,
+  "tcFolderPath": "/Sample Template"
+}
+\`\`\`
+Expected Output: Linked test cases located in the '/Sample Template' folder
+
+6. Search linked test cases by entity key
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-TC-1684,MAC-TC-1685\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Linked test cases matching specific entity keys
+
+7. Filter linked test cases by priority
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1,2],\\"field\\":\\"priorityAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked test cases with High or Medium priority
+
+8. Filter linked test cases by status
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1,2],\\"field\\":\\"testCaseStateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked test cases with Active or Review status
+
+9. Filter linked test cases by test case type
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"testCaseTypeAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked functional test cases
+
+10. Filter linked test cases by testing type (automation)
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[2],\\"field\\":\\"testingTypeAlias\\"}]"
+}
+\`\`\`
+Expected Output: Linked automated test cases
+
+11. Get only parameterized linked test cases
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"isParameterized\\"}]"
+}
+\`\`\`
+Expected Output: Linked test cases that are parameterized (data-driven)
+
+12. Filter linked test cases by archive status
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[0],\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: Active (non-archived) linked test cases
+
+13. Search linked test cases by summary content
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"login\\",\\"field\\":\\"summary\\"}]"
+}
+\`\`\`
+Expected Output: Linked test cases with 'login' in their summary
+
+14. Filter linked test cases by requirement version
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"1\\",\\"field\\":\\"rqVersion\\"}]"
+}
+\`\`\`
+Expected Output: Test cases linked to version 1 of the requirement
+
+15. Complex filter: Active, high priority, automated test cases
+\`\`\`json
+{
+  "rqID": 4791316,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[0],\\"field\\":\\"isArchived\\"},{\\"type\\":\\"list\\",\\"value\\":[1],\\"field\\":\\"priorityAlias\\"},{\\"type\\":\\"list\\",\\"value\\":[2],\\"field\\":\\"testingTypeAlias\\"}]"
+}
+\`\`\`
+Expected Output: Active, high priority, automated test cases linked to requirement
+
+**Hints:** 1. This API requires a numeric rqID parameter, not entity key 2. If user provides entityKey (e.g., MAC-RQ-1011), first call FETCH_REQUIREMENTS with filter on entityKeyId to resolve the numeric rqID 3. After resolving entityKey → rqID, call this tool with the resolved numeric rqID 4. TRACEABILITY WORKFLOW: Use this tool to establish requirement-test case traceability matrix 5. getLinked=true (default): Returns test cases that ARE linked to the requirement 6. getLinked=false: Returns test cases that are NOT linked to the requirement (useful for gap analysis) 7. showEntityWithReleaseCycle=true: Only show test cases that have the specified release and cycle 8. showEntityWithReleaseCycle=false (default): Show all test cases regardless of release/cycle 9. RELEASE/CYCLE FILTERING: Use string IDs, not numeric (e.g., releaseID: '55178', cycleID: '111577') 10. Get release/cycle IDs from FETCH_RELEASES_AND_CYCLES tool before filtering 11. tcFolderPath: Use empty string '' for root folder or specific path like '/Sample Template' 12. FILTER CAPABILITIES: Support same filters as regular test case listing 13. FILTER FIELDS: summary, rqVersion, priorityAlias, testCaseStateAlias, createdByAlias, testCaseTypeAlias, testingTypeAlias, release, cycle, isArchived, isParameterized, componentAlias, entityKeyId 14. PRIORITY IDs: Typically 1=High, 2=Medium, 3=Low (verify with your QMetry instance) 15. STATUS IDs: Typically 1=Active, 2=Review, 3=Deprecated (verify with your QMetry instance) 16. TYPE IDs: Typically 1=Functional, 2=Integration, 3=System (verify with your QMetry instance) 17. TESTING TYPE IDs: Typically 1=Manual, 2=Automated (verify with your QMetry instance) 18. PARAMETERIZED: 1=Yes (parameterized), 0=No (non-parameterized) 19. ARCHIVED: 1=Archived, 0=Active (non-archived) 20. Multiple filter conditions are combined with AND logic 21. For entity key search, use comma-separated values: 'MAC-TC-1,MAC-TC-2,MAC-TC-3' 22. This tool is crucial for compliance, traceability audits, and impact analysis 23. Use getColumns=true to get column metadata for better result interpretation 24. Pagination supported for large result sets (start, page, limit parameters)",
+    "inputSchema": [
+      "baseUrl",
+      "cycleID",
+      "filter",
+      "getColumns",
+      "getLinked",
+      "getSubEntities",
+      "limit",
+      "page",
+      "projectKey",
+      "releaseID",
+      "rqID",
+      "showEntityWithReleaseCycle",
+      "start",
+      "tcFolderPath",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Cases Linked to Requirement",
+  },
+  "qmetry_fetch_test_cases_linked_to_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Cases Linked to Test Suite",
+    },
+    "description": "Get test cases that are linked (or not linked) to a specific test suite in QMetry
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tsID (number) *required*: Test Suite numeric ID (required for fetching test cases linked to test suite). This is the internal numeric identifier, not the entity key. NOTE: To get the tsID - Call API 'Testsuite/Fetch Testsuite' From the response, get value of following attribute -> data[<index>].id
+- getLinked (boolean): True to get only those issues that are linked with this Test case Run, False to get those issues which are not linked with this Test case Run. Default value true (get linked issues). (default: true)
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with test cases array containing test case details, properties, and suite linkage information
+
+**Use Cases:** 1. Get all test cases linked to a specific test suite for execution planning 2. Find test cases that are NOT linked to a test suite (gap analysis) 3. Analyze test suite composition and coverage 4. Filter linked test cases by various criteria 5. Plan test execution based on test suite structure 6. Generate test suite reports and documentation 7. Validate test suite contents before execution 8. Manage test case organization within test suites 9. Export test suite details for external reporting 10. Verify test case assignments in test suites
+
+**Examples:**
+1. Get all test cases linked to test suite ID 1497291 (default behavior)
+\`\`\`json
+{
+  "tsID": 1497291
+}
+\`\`\`
+Expected Output: List of test cases linked to the test suite with test case details and metadata
+
+2. Get all test cases linked to test suite ID 1497291 (explicit)
+\`\`\`json
+{
+  "tsID": 1497291,
+  "getLinked": true
+}
+\`\`\`
+Expected Output: List of test cases linked to the test suite with test case details and metadata
+
+3. Get test cases NOT linked to test suite (gap analysis)
+\`\`\`json
+{
+  "tsID": 1497291,
+  "getLinked": false
+}
+\`\`\`
+Expected Output: List of test cases that are NOT linked to the test suite
+
+4. Get linked test cases with custom pagination
+\`\`\`json
+{
+  "tsID": 1497291,
+  "getLinked": true,
+  "page": 1,
+  "limit": 25
+}
+\`\`\`
+Expected Output: Paginated list of linked test cases with 50 items per page
+
+5. Filter linked test cases by priority (using default getLinked=true)
+\`\`\`json
+{
+  "tsID": 1497291,
+  "filter": "[{\\"value\\":[1,2],\\"type\\":\\"list\\",\\"field\\":\\"priorityAlias\\"}]"
+}
+\`\`\`
+Expected Output: High and medium priority test cases linked to the suite
+
+6. Filter linked test cases by status
+\`\`\`json
+{
+  "tsID": 1497291,
+  "getLinked": true,
+  "filter": "[{\\"value\\":[1],\\"type\\":\\"list\\",\\"field\\":\\"testCaseStateAlias\\"}]"
+}
+\`\`\`
+Expected Output: Active test cases linked to the test suite
+
+**Hints:** 1. CRITICAL: tsID parameter is REQUIRED - this is the Test Suite numeric ID 2. getLinked parameter is OPTIONAL - defaults to true if not provided 3. HOW TO GET tsID: 4. 1. Call API 'Testsuite/Fetch Testsuite' to get available test suites 5. 2. From the response, get value of following attribute -> data[<index>].id 6. 3. Example: Test Suite 'Regression Suite' might have ID 1497291 7. tsID is NOT the same as tsFolderID - tsID refers to a specific test suite, not a folder 8. getLinked=true (default): Returns test cases that ARE linked to the test suite 9. getLinked=false: Returns test cases that are NOT linked to the test suite (useful for gap analysis) 10. If getLinked is not specified, it defaults to true (linked test cases) 11. FILTER CAPABILITIES: Support filtering by test case properties 12. FILTER FIELDS: priorityAlias (list), testCaseStateAlias (list), testingTypeAlias (list), testCaseTypeAlias (list), componentAlias (list), owner (list) 13. PRIORITY IDs: Typically 1=High, 2=Medium, 3=Low (verify with your QMetry instance) 14. STATUS IDs: Typically 1=Active, 2=Review, 3=Deprecated (verify with your QMetry instance) 15. TESTING TYPE IDs: Typically 1=Manual, 2=Automated (verify with your QMetry instance) 16. TYPE IDs: Typically 1=Functional, 2=Integration, 3=System (verify with your QMetry instance) 17. Multiple filter conditions are combined with AND logic 18. Use pagination for large result sets (start, page, limit parameters) 19. This tool is essential for test suite management and execution planning 20. Helps verify test suite composition before test runs 21. Critical for understanding test coverage within specific suites 22. Use for test suite analysis and optimization",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "getLinked",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tsID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Cases Linked to Test Suite",
+  },
+  "qmetry_fetch_test_suites": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Suites",
+    },
+    "description": "Fetch QMetry test suites - automatically handles viewId resolution based on project
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- viewId (number) *required*: ViewId for test suites - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.TS.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- folderPath (string): Folder path for test suites - SYSTEM AUTOMATICALLY SETS TO ROOT. Leave empty unless you want specific folder. System will automatically use empty string "" (root directory). Only specify if user wants specific folder like "Automation/Regression". (default: "")
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+- getSubEntities (boolean): Whether to include sub-entities.
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+- udfFilter (string): User-defined field filter as JSON string (default '[]') (default: "[]")
+- sort (string): Sort Records - refer json schema, Possible property - entityKey, name, testsuiteStatus, linkedPlatformCount, linkedTcCount, createdDate, createdByAlias, updatedDate, updatedByAlias, attachmentCount, owner, remExecutionTime, totalExecutionTime (default: "[{\\"property\\":\\"name\\",\\"direction\\":\\"ASC\\"}]")
+
+**Output Description:** JSON object with 'data' array containing test suites and pagination info
+
+**Use Cases:** 1. List all test suites in a project 2. Search for specific test suites using filters 3. Browse test suites in specific folders 4. Get paginated test suite results
+
+**Examples:**
+1. Get all test suites from default project - system will auto-fetch viewId
+\`\`\`json
+{}
+\`\`\`
+Expected Output: List of test suites from default project with auto-resolved viewId
+
+2. Get all test suites from UT project - system will auto-fetch UT project's viewId
+\`\`\`json
+{
+  "projectKey": "UT"
+}
+\`\`\`
+Expected Output: List of test suites from UT project using UT's specific TS viewId
+
+3. Get test suites with manual viewId (skip auto-resolution)
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "viewId": 103097,
+  "folderPath": ""
+}
+\`\`\`
+Expected Output: Test suites using manually specified viewId 103097
+
+4. List test suites from specific project (ex: project key can be anything (VT, UT, PROJ1, TEST9)
+\`\`\`json
+{
+  "projectKey": "use specific given project key",
+  "viewId": "fetch specific project given projectKey Test Suite ViewId",
+  "folderPath": ""
+}
+\`\`\`
+Expected Output: Test suites using manually specified viewId 103097 or projectKey
+
+5. Get test suites by release/cycle filter
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"},{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Test suites associated with Release 8.12 (ID: 55178) and Cycle 8.12.1 (ID: 111577)
+
+6. Get test suites by release only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[55178],\\"type\\":\\"list\\",\\"field\\":\\"release\\"}]"
+}
+\`\`\`
+Expected Output: All test suites associated with Release 8.12 (ID: 55178)
+
+7. Get test suites by cycle only
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"value\\":[111577],\\"type\\":\\"list\\",\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: All test suites associated with Cycle 8.12.1 (ID: 111577)
+
+8. Search for specific test suite by entity key
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-TS-1684\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Test suites matching the entity key criteria
+
+9. Search for multiple test suites by comma-separated entity keys
+\`\`\`json
+{
+  "projectKey": "MAC",
+  "filter": "[{\\"type\\":\\"string\\",\\"value\\":\\"MAC-TS-1684,MAC-TS-1685,MAC-TS-1686\\",\\"field\\":\\"entityKeyId\\"}]"
+}
+\`\`\`
+Expected Output: Test suites matching any of the specified entity keys
+
+**Hints:** 1. CRITICAL WORKFLOW: Always use the SAME projectKey for both project info and test suite fetching 2. Step 1: If user specifies projectKey (like 'UT', 'MAC'), use that EXACT projectKey for project info 3. Step 2: Get project info using that projectKey, extract latestViews.TS.viewId 4. Step 3: Use the SAME projectKey and the extracted TS viewId for fetching test suites 5. Step 4: If user doesn't specify projectKey, use 'default' for both project info and test suite fetching 6. NEVER mix project keys - if user says 'MAC project', use projectKey='MAC' for everything 7. For search by test suite key (like MAC-TS-1684), use filter: '[{"type":"string","value":"MAC-TS-1684","field":"entityKeyId"}]' 8. RELEASE/CYCLE FILTERING: Use release and cycle IDs, not names, for filtering 9. For release filter: '[{"value":[releaseId],"type":"list","field":"release"}]' 10. For cycle filter: '[{"value":[cycleId],"type":"list","field":"cycle"}]' 11. For combined release+cycle: '[{"value":[releaseId],"type":"list","field":"release"},{"value":[cycleId],"type":"list","field":"cycle"}]' 12. Get release/cycle IDs from FETCH_RELEASES_AND_CYCLES tool before filtering 13. FILTER FIELDS: name, release, cycle, platform, isArchived, testsuiteStatus, createdByAlias, createdDate, entityKeyId, attachmentCount, linkedPlatformCount, linkedTcCount, updatedByAlias, updatedDate, owner, remExecutionTime, and totalExecutionTime 14. SORT FIELDS: entityKey, name, testsuiteStatus, linkedPlatformCount, linkedTcCount, createdDate, createdByAlias, updatedDate, updatedByAlias, attachmentCount, remExecutionTime, and totalExecutionTime 15. For multiple entity keys, use comma-separated values in filter 16. Use empty string '' as folderPath for root directory",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "folderPath",
+      "getSubEntities",
+      "limit",
+      "page",
+      "projectKey",
+      "scope",
+      "sort",
+      "start",
+      "udfFilter",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Suites",
+  },
+  "qmetry_fetch_test_suites_for_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Fetch Test Suites for Test Case",
+    },
+    "description": "Get test suites that can be linked to test cases in QMetry with automatic viewId resolution
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tsFolderID (number) *required*: Test Suite folder ID (required for fetching test suites). This is the numeric identifier for the test suite folder. IMPORTANT: Get from project info response → rootFolders.TS.id (e.g., 113557 for MAC project). Use FETCH_PROJECT_INFO tool first to get this ID if not provided by user. For root folder: use rootFolders.TS.id, for sub-folders: use specific folder IDs.
+- viewId (number): ViewId for test suite folders - SYSTEM AUTOMATICALLY RESOLVES THIS. Leave empty unless you have a specific viewId. System will fetch project info using the projectKey and extract latestViews.TSFS.viewId automatically. Manual viewId only needed if you want to override the automatic resolution.
+- start (number): Start index for pagination - defaults to 0 (default: 0)
+- page (number): Page number to return (starts from 1) (default: 1)
+- limit (number): Number of records (default 10). (default: 10)
+- getColumns (boolean): Whether to get column information in response. (default: true)
+- filter (string): Filter criteria as JSON string (default '[]') (default: "[]")
+
+**Output Description:** JSON object with test suites array and pagination metadata
+
+**Use Cases:** 1. Get test suites available for linking with test cases 2. Find appropriate test suites for test case organization 3. Browse test suites in specific folders for better management 4. Filter test suites by release, cycle, or archive status 5. Organize test execution by grouping test cases into test suites 6. Plan test suite structure for comprehensive test coverage 7. Manage test case categorization for reporting purposes 8. Search for existing test suites before creating new ones 9. Get root test suite folder contents using project info
+
+**Examples:**
+1. Get test suites from root folder using auto-resolved viewId
+\`\`\`json
+{
+  "tsFolderID": 113557
+}
+\`\`\`
+Expected Output: List of test suites available in the root test suite folder with auto-resolved viewId
+
+2. Get test suites with custom pagination and auto-resolved viewId
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "page": 1,
+  "limit": 25
+}
+\`\`\`
+Expected Output: Paginated list of test suites with 20 items per page
+
+3. Filter test suites by release with auto-resolved viewId
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[55178],\\"field\\":\\"release\\"}]"
+}
+\`\`\`
+Expected Output: Test suites associated with Release 8.12 (ID: 55178)
+
+4. Filter test suites by cycle with auto-resolved viewId
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[111577],\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Test suites associated with Cycle 8.12.1 (ID: 111577)
+
+5. Get only active (non-archived) test suites
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "filter": "[{\\"value\\":[0],\\"type\\":\\"list\\",\\"field\\":\\"isArchived\\"}]"
+}
+\`\`\`
+Expected Output: List of active test suites (not archived)
+
+6. Filter test suites by release and cycle
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "filter": "[{\\"type\\":\\"list\\",\\"value\\":[55178],\\"field\\":\\"release\\"},{\\"type\\":\\"list\\",\\"value\\":[111577],\\"field\\":\\"cycle\\"}]"
+}
+\`\`\`
+Expected Output: Test suites associated with both Release 8.12 (ID: 55178) and Cycle 8.12.1 (ID: 111577)
+
+7. Get test suites with column information
+\`\`\`json
+{
+  "tsFolderID": 113557,
+  "getColumns": true
+}
+\`\`\`
+Expected Output: Test suites list with detailed column metadata for better interpretation
+
+8. Search test suites from specific sub-folder with manual viewId
+\`\`\`json
+{
+  "tsFolderID": 42,
+  "viewId": 104316
+}
+\`\`\`
+Expected Output: Test suites available in specific folder ID 42 for test case linking
+
+**Hints:** 1. CRITICAL: tsFolderID is REQUIRED - Test Suite folder ID will be auto-resolved if not provided 2. viewId will be AUTOMATICALLY RESOLVED from project info if not provided 3. HOW TO GET tsFolderID: 4. 1. Call FETCH_PROJECT_INFO tool first to get project configuration 5. 2. From the response, use rootFolders.TS.id for the root test suite folder 6. 3. Example: rootFolders.TS.id = 113557 (MAC project root TS folder) 7. 4. If user doesn't specify tsFolderID, automatically use rootFolders.TS.id from project info 8. VIEWID AUTO-RESOLUTION: 9. 1. System automatically fetches project info using the projectKey 10. 2. Extracts latestViews.TSFS.viewId automatically 11. 3. Example: latestViews.TSFS.viewId = 104316 (MAC project TSFS view) 12. 4. Manual viewId only needed if you want to override the automatic resolution 13. WORKFLOW: System automatically handles project info if tsFolderID or viewId is not provided 14. PROJECT INFO STRUCTURE: clientData.rootFolders.TS.id contains the root test suite folder ID 15. PROJECT INFO STRUCTURE: latestViews.TSFS.viewId contains the test suite folder view ID 16. For sub-folders: Use specific folder IDs if you know them, or call folder listing APIs 17. FILTER CAPABILITIES: Same as other QMetry list operations 18. FILTER FIELDS: release, cycle, isArchived, name, status, priority 19. RELEASE/CYCLE FILTERING: Use numeric IDs in list format (get from FETCH_RELEASES_AND_CYCLES) 20. ARCHIVE FILTERING: 0=Active, 1=Archived 21. getColumns=true provides additional metadata for result interpretation 22. Multiple filter conditions are combined with AND logic 23. Pagination supported for large result sets (start, page, limit parameters) 24. This tool helps organize test cases into logical test suites 25. Essential for test execution planning and test case management 26. Use this before creating new test suites to check existing ones",
+    "inputSchema": [
+      "baseUrl",
+      "filter",
+      "getColumns",
+      "limit",
+      "page",
+      "projectKey",
+      "start",
+      "tsFolderID",
+      "viewId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Fetch Test Suites for Test Case",
+  },
+  "qmetry_import_automation_test_results": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QMetry: Import Automation Test Results",
+    },
+    "description": "Import/Publish automation test results from TestNG, JUnit, Cucumber, Robot, HPUFT, or QAF frameworks into QMetry
+
+**Parameters:**
+- file (string) *required*: Base64 encoded file content or file path. User must upload result file (.json, .xml, .zip up to 30 MB)
+- fileName (string) *required*: Original filename with extension (.json, .xml, or .zip)
+- entityType (enum) *required*: Format of result file: TESTNG, CUCUMBER, JUNIT, HPUFT, QAF, or ROBOT
+- automationHierarchy (enum): TestNG/JUnit hierarchy: 1=Test Case-Test Step, 2=Test Case only, 3=Test Suite-Test Case. Default: 1
+- testsuiteName (string): Custom test suite name. Ignored if automationHierarchy=3 for JUnit or =2 for ROBOT
+- testsuiteId (string): Reuse existing Test Suite by ID or Entity Key. Ignored if automationHierarchy=3 for JUnit or =2 for ROBOT
+- tsFolderPath (string): Test suite folder path. Creates folder if doesn't exist. Ignored if reusing test suite
+- tcFolderPath (string): Test case folder path. Creates folder if doesn't exist. Ignored if reusing test case
+- platformID (string): Platform ID or Platform Name. Default: 'No Platform'
+- projectID (string): Project ID, Project Key, or Project name. Overrides project in header
+- releaseID (string): Release ID or Release name. Requires projectID if provided
+- cycleID (string): Cycle ID or Cycle name. Requires releaseID and projectID if provided
+- buildID (string): Build ID or Build name
+- testcase_fields (string): JSON string with test case system fields and UDFs. Ignored if reusing test case. Example: {"component":["com1"], "priority":"High"}
+- testsuite_fields (string): JSON string with test suite system fields and UDFs. Ignored if reusing test suite. Example: {"testSuiteState":"Open", "testsuiteOwner":"user"}
+- skipWarning (enum): 0=Fail if summary >255 chars, 1=Truncate summary to 255 chars. Default: 0
+- is_matching_required (string): True=Create new TC if summary/steps don't match, False=Reuse linked TC. Default: True
+
+**Use Cases:** 1. 1. Import TestNG XML results after CI/CD pipeline execution 2. 2. Publish JUnit test results to QMetry for tracking and reporting 3. 3. Upload Cucumber JSON results with custom test suite organization 4. 4. Import Robot Framework results with specific release/cycle mapping 5. 5. Link automation results to existing test suites for version tracking 6. 6. Create new test suites with custom names and folder structures 7. 7. Map test results to specific platforms (browsers, OS, devices) 8. 8. Associate imported results with releases, cycles, and builds 9. 9. Bulk import multiple test results from ZIP archive 10. 10. Configure test case/suite fields and user-defined fields during import
+
+**Examples:**
+1. Basic TestNG result import
+\`\`\`json
+{
+  "file": "<base64_encoded_testng_xml_content>",
+  "fileName": "testng-results.xml",
+  "entityType": "TESTNG"
+}
+\`\`\`
+Expected Output: Auto-generated test suite created with UTC timestamp, test cases auto-linked, execution results updated, 'No Platform' linked
+
+2. JUnit results with custom test suite name
+\`\`\`json
+{
+  "file": "<base64_encoded_junit_xml_content>",
+  "fileName": "junit-results.xml",
+  "entityType": "JUNIT",
+  "testsuiteName": "Regression Suite - Build 123",
+  "automationHierarchy": "1"
+}
+\`\`\`
+Expected Output: Test suite 'Regression Suite - Build 123' created with Test Case-Test Step hierarchy
+
+3. Cucumber results with platform and release mapping
+\`\`\`json
+{
+  "file": "<base64_encoded_cucumber_json_content>",
+  "fileName": "cucumber-results.json",
+  "entityType": "CUCUMBER",
+  "platformID": "Chrome 120",
+  "releaseID": "Release 2.0",
+  "cycleID": "Sprint 15",
+  "testsuiteName": "API Automation Tests"
+}
+\`\`\`
+Expected Output: Test suite created, linked to Chrome platform, Release 2.0, and Sprint 15 cycle
+
+4. Reuse existing test suite
+\`\`\`json
+{
+  "file": "<base64_encoded_testng_xml_content>",
+  "fileName": "testng-regression.xml",
+  "entityType": "TESTNG",
+  "testsuiteId": "PROJ-TS-42"
+}
+\`\`\`
+Expected Output: Test cases auto-linked to existing test suite PROJ-TS-42, execution results updated
+
+5. Import with folder organization
+\`\`\`json
+{
+  "file": "<base64_encoded_junit_xml_content>",
+  "fileName": "junit-results.xml",
+  "entityType": "JUNIT",
+  "tsFolderPath": "/Automation/Regression",
+  "tcFolderPath": "/Automation/API Tests",
+  "testsuiteName": "API Regression Suite"
+}
+\`\`\`
+Expected Output: Test suite created in '/Automation/Regression' folder, test cases in '/Automation/API Tests' folder
+
+6. Import with test case custom fields
+\`\`\`json
+{
+  "file": "<base64_encoded_testng_xml_content>",
+  "fileName": "testng-results.xml",
+  "entityType": "TESTNG",
+  "testcase_fields": "{\\"priority\\":\\"High\\",\\"testCaseType\\":\\"Automated\\",\\"component\\":[\\"API\\",\\"Backend\\"],\\"testcaseOwner\\":\\"john.doe\\",\\"estimatedTime\\":\\"2h:30m:0s\\"}"
+}
+\`\`\`
+Expected Output: Test cases created with High priority, Automated type, API and Backend components
+
+7. Import ZIP file with multiple results
+\`\`\`json
+{
+  "file": "<base64_encoded_zip_content>",
+  "fileName": "test-results.zip",
+  "entityType": "JUNIT",
+  "testsuiteName": "Full Regression Suite",
+  "skipWarning": "1"
+}
+\`\`\`
+Expected Output: Multiple test results imported from ZIP, summaries truncated if >255 chars
+
+8. Import with custom hierarchy for JUnit
+\`\`\`json
+{
+  "file": "<base64_encoded_junit_xml_content>",
+  "fileName": "junit-results.xml",
+  "entityType": "JUNIT",
+  "automationHierarchy": "3",
+  "projectID": "PROJ"
+}
+\`\`\`
+Expected Output: Multiple test suites created per <testsuite> tag, test cases per <testcase> tag
+
+9. Import with build and platform mapping
+\`\`\`json
+{
+  "file": "<base64_encoded_testng_xml_content>",
+  "fileName": "testng-results.xml",
+  "entityType": "TESTNG",
+  "buildID": "Build-1.2.3",
+  "platformID": "Safari 17",
+  "releaseID": "Release 1.2",
+  "cycleID": "QA Cycle"
+}
+\`\`\`
+Expected Output: Results linked to Build 1.2.3, Safari 17 platform, Release 1.2, QA Cycle
+
+10. Import with test suite and test case fields
+\`\`\`json
+{
+  "file": "<base64_encoded_cucumber_json_content>",
+  "fileName": "cucumber-results.json",
+  "entityType": "CUCUMBER",
+  "testsuite_fields": "{\\"testSuiteState\\":\\"In Progress\\",\\"testsuiteOwner\\":\\"jane.smith\\",\\"description\\":\\"Sprint 15 automation results\\"}",
+  "testcase_fields": "{\\"priority\\":\\"Medium\\",\\"component\\":[\\"UI\\",\\"Frontend\\"],\\"userDefinedFields\\":{\\"reviewedDate\\":\\"11-20-2024\\",\\"environment\\":\\"Staging\\"}}"
+}
+\`\`\`
+Expected Output: Test suite and test cases created with custom fields and UDFs
+
+**Hints:** 1. 1. CRITICAL: User MUST upload a valid result file before calling this tool 2. 2. USER FILE UPLOAD REQUIRED: Ask user to provide file in chat - system will convert to base64 3. 3. FILE REQUIREMENTS: 4.    - Supported extensions: .json, .xml, .zip 5.    - Maximum size: 30 MB 6.    - ZIP files must contain files matching the specified entityType format 7. 4. REQUIRED PARAMETERS: 8.    - file: Base64 encoded content or file path 9.    - fileName: Original filename with extension 10.    - entityType: TESTNG, CUCUMBER, JUNIT, HPUFT, QAF, or ROBOT 11. 5. ENTITY TYPES: 12.    - TESTNG: TestNG XML format 13.    - JUNIT: JUnit XML format 14.    - CUCUMBER: Cucumber JSON format 15.    - ROBOT: Robot Framework XML format 16.    - HPUFT: HP UFT format 17.    - QAF: QAF format 18. 6. AUTOMATION HIERARCHY (TestNG/JUnit only): 19.    - TestNG: 20.      * 1 (default): <class name> = Test Case, <test-method> = Test Step 21.      * 2: <test-method> = Test Case only 22.      * 3: <name> under <test> = Test Case, <test-method> = Test Step 23.    - JUnit: 24.      * 1 (default): <testsuite> = Test Case, <testcase> = Test Step 25.      * 2: <testcase> = Test Case only 26.      * 3: <testsuite> = Test Suite, <testcase> = Test Case (creates multiple test suites) 27. 7. TEST SUITE OPTIONS: 28.    - testsuiteName: Custom name for new test suite 29.    - testsuiteId: Reuse existing test suite by ID or Entity Key (e.g., 'PROJ-TS-42') 30.    - tsFolderPath: Create test suite in specific folder (e.g., '/Automation/Regression') 31.    - Note: testsuiteName/testsuiteId ignored if automationHierarchy=3 for JUnit or =2 for ROBOT 32. 8. TEST CASE OPTIONS: 33.    - tcFolderPath: Create test cases in specific folder (e.g., '/Automation/API Tests') 34.    - Folders created automatically if they don't exist 35. 9. LINKING OPTIONS: 36.    - platformID: Platform ID or name (e.g., 'Chrome 120', 'Safari 17') 37.    - projectID: Project ID, key, or name (overrides header project) 38.    - releaseID: Release ID or name (requires projectID) 39.    - cycleID: Cycle ID or name (requires releaseID and projectID) 40.    - buildID: Build ID or name 41. 10. GET IDs FROM OTHER TOOLS: 42.     - Platform IDs: Use 'Platform/List' API (FETCH_PLATFORMS tool) 43.     - Project IDs: Use 'Project/List' API (FETCH_PROJECTS tool) 44.     - Release IDs: Use 'Release/List' API (FETCH_RELEASES_CYCLES tool) 45.     - Cycle IDs: Use 'Cycle/List' API (FETCH_RELEASES_CYCLES tool) 46.     - Build IDs: Use 'Build/List' API (FETCH_BUILDS tool) 47.     - Test Suite IDs: Use 'Testsuite/Fetch' API (FETCH_TEST_SUITES tool) 48. 11. CUSTOM FIELDS (testcase_fields): 49.     - JSON string with system fields and UDFs 50.     - System fields: component, priority, testCaseState, testCaseType, testcaseOwner, estimatedTime, description 51.     - Example: {"component":["API"], "priority":"High", "testcaseOwner":"user"} 52.     - Ignored if reusing existing test case 53. 12. CUSTOM FIELDS (testsuite_fields): 54.     - JSON string with system fields and UDFs 55.     - System fields: testSuiteState, testsuiteOwner, description 56.     - Example: {"testSuiteState":"Open", "testsuiteOwner":"user"} 57.     - Ignored if reusing existing test suite 58. 13. USER DEFINED FIELDS (UDFs): 59.     - Include in testcase_fields or testsuite_fields under 'userDefinedFields' key 60.     - Example: {"userDefinedFields": {"reviewedDate": "11-20-2024", "environment": "Staging"}} 61.     - UDF types: STRING, LARGETEXT, LOOKUPLIST, MULTILOOKUPLIST, DATEPICKER, NUMBER 62.     - See tool metadata for UDF validation rules and auto-create behavior 63. 14. SKIP WARNING OPTIONS: 64.     - skipWarning='0' (default): Fail import if test case summary >255 characters 65.     - skipWarning='1': Truncate summary to 255 characters and continue import 66. 15. MATCHING BEHAVIOR: 67.     - is_matching_required='true' (default): Create new TC/version if summary/steps don't match 68.     - is_matching_required='false': Reuse existing TC version if entity key or summary matches 69. 16. IMPORT BEHAVIOR EXAMPLES: 70.     - Only file + entityType → Auto-generated test suite, 'No Platform', test cases auto-linked 71.     - file + entityType + platformID → Auto-generated test suite with specified platform 72.     - file + entityType + testsuiteId → Results updated in existing test suite 73.     - file + entityType + platformID + testsuiteId → Results updated in existing test suite with platform 74. 17. FOLDER CREATION: 75.     - If tsFolderPath or tcFolderPath specified and doesn't exist, it will be created automatically 76.     - Use forward slashes for folder paths (e.g., '/Parent/Child') 77. 18. ESTIMATED TIME FORMAT: 78.     - Format: '2h:30m:15s' or '4h' or '7m' or '0s' 79.     - Range: 0 to 99999 minutes 80. 19. OWNER FIELDS: 81.     - Use userAlias (username) not display name 82.     - testcaseOwner: User must have Test Case module rights 83.     - testsuiteOwner: User must have Test Suite module rights 84.     - Owner not set if user not found or lacks permissions 85. 20. LOOKUPLIST/MULTILOOKUPLIST BEHAVIOR: 86.     - If value doesn't exist and auto-create is ON: Value added to list 87.     - If value doesn't exist and auto-create is OFF: Field blank or default value 88.     - MULTILOOKUPLIST: New values added, old values persist 89. 21. MANDATORY FIELD VALIDATION: 90.     - If mandatory system/UDF field missing: 91.       * Auto-create OFF + value doesn't exist = Import FAIL 92.       * Auto-create ON + value doesn't exist = Import SUCCESS (value created) 93.       * Value exists = Import SUCCESS 94. 22. ERROR HANDLING: 95.     - Check file size before upload (must be ≤30 MB) 96.     - Validate file extension matches entityType 97.     - Ensure required dependencies: cycleID requires releaseID and projectID 98.     - If import fails, check QMetry UI for detailed error messages 99. 23. WORKFLOW: 100.     Step 1: Ask user to upload result file in chat 101.     Step 2: System converts file to base64 102.     Step 3: Collect entityType and optional parameters 103.     Step 4: Call this tool with file data and configuration 104.     Step 5: QMetry processes file and creates/updates test artifacts 105.     Step 6: Return import results with test suite and execution details 106. 24. USER INTERACTION REQUIRED: 107.     - ALWAYS ask user to upload file before calling this tool 108.     - Display supported formats: .json, .xml, .zip (up to 30 MB) 109.     - Ask for entityType (framework used) 110.     - Ask for optional parameters based on user's needs 111. 25. PERFORMANCE TIPS: 112.     - For large imports, consider using ZIP files 113.     - Reusing existing test suites is faster than creating new ones 114.     - Use automationHierarchy wisely to control test case/suite structure",
+    "inputSchema": [
+      "automationHierarchy",
+      "buildID",
+      "cycleID",
+      "entityType",
+      "file",
+      "fileName",
+      "is_matching_required",
+      "platformID",
+      "projectID",
+      "releaseID",
+      "skipWarning",
+      "tcFolderPath",
+      "testcase_fields",
+      "testsuiteId",
+      "testsuiteName",
+      "testsuite_fields",
+      "tsFolderPath",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Import Automation Test Results",
+  },
+  "qmetry_link_issues_to_testcase_run": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Link Issues to Testcase Run",
+    },
+    "description": "Link one or more issues to a QMetry Testcase Run (execution).
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- issueIds (array) *required*: ID of issues to be linked to Testcase Run
+- tcrId (number) *required*: ID of Testcase Run to link issues with
+
+**Output Description:** JSON object with linkage status and details.
+
+**Use Cases:** 1. Link a single issue to a testcase run 2. Link multiple issues to a testcase run 3. Automate defect association during test execution 4. Maintain traceability between defects and test runs
+
+**Examples:**
+1. Link one issue to a testcase run
+\`\`\`json
+{
+  "issueIds": [
+    "5054834"
+  ],
+  "tcrId": 567890
+}
+\`\`\`
+Expected Output: Issue 5054834 linked to testcase run 567890 successfully.
+
+2. Link multiple issues to a testcase run
+\`\`\`json
+{
+  "issueIds": [
+    "5054834",
+    "5054835"
+  ],
+  "tcrId": 567890
+}
+\`\`\`
+Expected Output: Issues 5054834, 5054835 linked to testcase run 567890 successfully.
+
+**Hints:** 1. if you have pass issue key (VT-IS-5, MAC-IS-10 etc.) then first fetch issue by issue key to get issue id. 2. To get the issueIds, call the Fetch issues linked with testcases tool and use data[<index>].defectID from the response. 3. To get the tcrId, call the Execution/Fetch Testcase Run ID tool and use data[<index>].tcRunID from the response. 4. Both issueIds and tcrId are required. 5. You can link multiple issues at once by providing an array of IDs.",
+    "inputSchema": [
+      "baseUrl",
+      "issueIds",
+      "projectKey",
+      "tcrId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Link Issues to Testcase Run",
+  },
+  "qmetry_link_platforms_to_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Link Platforms to Test Suite",
+    },
+    "description": "Link one or more platforms to a QMetry Test Suite.
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- qmTsId (number) *required*: Id of Test Suite (required). To get the qmTsId - Call API 'Testsuite/Fetch Testsuite' From the response, get value of following attribute -> data[<index>].id
+- qmPlatformId (string) *required*: Comma-separated value of PlatformId (required). To get the qmPlatformId - Call API 'Platform/List' From the response, get value of following attribute -> data[<index>].platformID
+
+**Output Description:** JSON object with linkage status, success message, and details.
+
+**Use Cases:** 1. Link a single platform to a test suite 2. Link multiple platforms to a test suite for cross-platform testing 3. Define execution environments for a test suite 4. Organize test suites by supported platforms 5. Set up platform-specific test suite configurations
+
+**Examples:**
+1. Link single platform to a test suite
+\`\`\`json
+{
+  "qmTsId": 1511970,
+  "qmPlatformId": "63004"
+}
+\`\`\`
+Expected Output: Platform 63004 linked to test suite 1511970 successfully.
+
+2. Link multiple platforms to a test suite
+\`\`\`json
+{
+  "qmTsId": 1511970,
+  "qmPlatformId": "63004,63005,63006"
+}
+\`\`\`
+Expected Output: Platforms 63004, 63005, 63006 linked to test suite 1511970 successfully.
+
+**Hints:** 1. CRITICAL: qmTsId and qmPlatformId are REQUIRED parameters 2. To get the qmTsId (Test Suite ID): 3.   1. Call 'Testsuite/Fetch Testsuite' API 4.   2. From response, use data[<index>].id 5.   3. Example: Test Suite 'Login Tests' might have ID 1511970 6. To get the qmPlatformId (Platform ID): 7.   1. Call 'Platform/List' API (Fetch Platforms tool) 8.   2. From response, use data[<index>].platformID 9.   3. Example: Platform 'Chrome' might have ID 63004 10. qmPlatformId accepts comma-separated values for multiple platforms 11. Format for multiple platforms: '63004,63005,63006' 12. No spaces in the comma-separated list 13. If test suite entity key (e.g., VT-TS-12) is provided, first fetch test suites to resolve numeric ID 14. Platforms represent browsers, operating systems, devices, or custom environments 15. This tool helps organize cross-platform test execution 16. Essential for comprehensive platform coverage testing",
+    "inputSchema": [
+      "baseUrl",
+      "projectKey",
+      "qmPlatformId",
+      "qmTsId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Link Platforms to Test Suite",
+  },
+  "qmetry_link_requirements_to_testcase": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Link Requirements to Testcase",
+    },
+    "description": "Link one or more requirements to a test case by entityKey and version IDs.
+
+**Parameters:**
+- tcID (string) *required*: EntityKey of Testcase (e.g. 'COD-TC-29')
+- tcVersionId (number) *required*: Test Case version number. This is the internal numeric identifier for the version.
+- rqVersionIds (string) *required*: Comma-separated values of versionId of the Requirement (e.g. '236124,236125')
+
+**Output Description:** JSON object with success status and linkage details.
+
+**Use Cases:** 1. Link requirements to a test case for traceability 2. Bulk link multiple requirements to a single test case 3. Automate requirement coverage mapping
+
+**Examples:**
+1. Link requirements to test case VT-TC-26
+\`\`\`json
+{
+  "tcID": "VT-TC-26",
+  "tcVersionId": 5448515,
+  "rqVersionIds": "5009939,5009937,4970699"
+}
+\`\`\`
+Expected Output: Requirements linked to test case VT-TC-26 successfully.
+
+**Hints:** 1. To get the tcID, call the Testcase/Fetch List for Bulk Operation API and use data[<index>].entityKey. 2. To get the tcVersionId, call the Testcase/Fetch Versions API and use data[<index>].tcVersionID. 3. To get the rqVersionIds, call the requirement/List Versions API and use data[<index>].rqVersionID. 4. If user provides requirement entityKey (e.g., VT-RQ-18), first call requirements list with a filter on entityKeyId to resolve the rqVersionIds 5. If user provides testcase entityKey (e.g., VT-TC-26), first call testcase list with a filter on entityKeyId to resolve the tcVersionId and tcID. 6. rqVersionIds must be a comma-separated string of requirement version IDs.",
+    "inputSchema": [
+      "rqVersionIds",
+      "tcID",
+      "tcVersionId",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Link Requirements to Testcase",
+  },
+  "qmetry_link_test_cases_to_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Link Test Cases to Test Suite",
+    },
+    "description": "Link test cases to a test suite in QMetry.
+
+**Parameters:**
+- tsID (number) *required*: Id of Test Suite (required)
+- tcvdIDs (array) *required*: Array of Test Case Version IDs (required if fromReqs is false)
+- fromReqs (boolean): Link TestCases from Requirements (optional, default false)
+
+**Output Description:** JSON object with linkage status and details.
+
+**Use Cases:** 1. Link test cases to a test suite by entity keys 2. Bulk link multiple test cases to a suite 3. Automate test suite composition from test cases
+
+**Examples:**
+1. Link test cases to a test suite
+\`\`\`json
+{
+  "tsID": 8674,
+  "tcvdIDs": [
+    5448504,
+    5448503
+  ],
+  "fromReqs": false
+}
+\`\`\`
+Expected Output: Test cases QTM-TC-32 and QTM-TC-35 linked to test suite 8674.
+
+2. Link test cases directly to test suites with test cases entityKeys VT-TC-9, VT-TC-10 to test suite id 1487397
+\`\`\`json
+{
+  "tsID": 1487397,
+  "tcvdIDs": [
+    5448504,
+    5448503
+  ],
+  "fromReqs": false
+}
+\`\`\`
+Expected Output: Test cases VT-TC-9 and VT-TC-10 linked to test suite 1487397.
+
+3. Link test case VT-TC-4, VT-TC-1,VT-TC-101, VT-TC-22 to test suite VT-TS-3
+\`\`\`json
+{
+  "tsID": 1487397,
+  "tcvdIDs": [
+    5448504,
+    5448503,
+    5448505,
+    5448506
+  ],
+  "fromReqs": false
+}
+\`\`\`
+Expected Output: Test cases VT-TC-4, VT-TC-1, VT-TC-101, and VT-TC-22 linked to test suite VT-TS-3.
+
+**Hints:** 1. To get the tsID, call the Fetch Test Suites for Test Case API with rootFolderId otherwise if given folderid so use that and from response get the id. 2. To get the tcvdIDs by testcase entityKey, call the Testcase/Fetch Versions API and use data[<index>].tcVersionID. 3. Set fromReqs to false to direct test case linkage.",
+    "inputSchema": [
+      "fromReqs",
+      "tcvdIDs",
+      "tsID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Link Test Cases to Test Suite",
+  },
+  "qmetry_requirements_linked_test_cases_to_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Requirements Linked Test Cases to Test Suite",
+    },
+    "description": "Link test cases (including those linked to requirements) to a test suite in QMetry.
+
+**Parameters:**
+- tsID (number) *required*: Id of Test Suite (required)
+- tcvdIDs (array) *required*: Array of Test Case Version IDs (required if fromReqs is true)
+- fromReqs (boolean): Link TestCases from Requirements (optional, default true)
+
+**Output Description:** JSON object with linkage status and details.
+
+**Use Cases:** 1. Link requirements linked test cases to a test suite 2. Bulk link multiple requirements linked test cases to a suite 3. Automate test suite composition from requirements linked test cases
+
+**Examples:**
+1. VT-RQ-18 Requirements Linked test cases to a test suite
+\`\`\`json
+{
+  "tsID": 8674,
+  "tcvdIDs": [
+    5448504,
+    5448503
+  ],
+  "fromReqs": true
+}
+\`\`\`
+Expected Output: Test cases QTM-TC-32 and QTM-TC-35 linked to test suite 8674.
+
+2. VT-RQ-19 Requirements Linked test cases to test suites id 1487397
+\`\`\`json
+{
+  "tsID": 1487397,
+  "tcvdIDs": [
+    5448504,
+    5448503
+  ],
+  "fromReqs": true
+}
+\`\`\`
+Expected Output: Test cases VT-TC-9 and VT-TC-10 linked to test suite 1487397.
+
+3. VT-RQ-20 Requirements Linked test case to test suite VT-TS-3
+\`\`\`json
+{
+  "tsID": 1487397,
+  "tcvdIDs": [
+    5448504,
+    5448503,
+    5448505,
+    5448506
+  ],
+  "fromReqs": true
+}
+\`\`\`
+Expected Output: Test cases VT-TC-4, VT-TC-1, VT-TC-101, and VT-TC-22 linked to test suite VT-TS-3.
+
+**Hints:** 1. To get the tsID, call the Fetch Test Suites for Test Case API with rootFolderId otherwise if given folderid so use that and from response get the id. 2. To get the requirement linked tcvdIDs by requirement entityKey, call the Fetch Test Cases Linked to Requirement API by <requirementEntityKey> to fetch If user provides entityKey (e.g., MAC-RQ-1011), first call FETCH_REQUIREMENTS with filter on entityKeyId to resolve the numeric rqID and get the linked test cases version ids. 3. Set fromReqs to true to link requirements linked test cases instead of direct test case linkage.",
+    "inputSchema": [
+      "fromReqs",
+      "tcvdIDs",
+      "tsID",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Requirements Linked Test Cases to Test Suite",
+  },
+  "qmetry_set_qmetry_project_info": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Set QMetry Project Info",
+    },
+    "description": "Set current QMetry project for your account
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+
+**Output Description:** JSON object containing project configuration details, confirmation of project switch, and available project metadata
+
+**Use Cases:** 1. Switch to a specific project before performing test case operations 2. Set project context for batch operations on test cases 3. Configure the default project for the current session 4. Validate access to a specific project before proceeding with operations
+
+**Examples:**
+1. Set default project as active
+\`\`\`json
+{
+  "projectKey": "default"
+}
+\`\`\`
+Expected Output: Project context set to 'default' with confirmation of project details
+
+2. Switch to UT project
+\`\`\`json
+{
+  "projectKey": "UT"
+}
+\`\`\`
+Expected Output: Project context switched to 'UT' project with available configurations
+
+3. Set MAC project as active for test case operations
+\`\`\`json
+{
+  "projectKey": "MAC"
+}
+\`\`\`
+Expected Output: Project context set to 'MAC' with viewIds and folder structure
+
+**Hints:** 1. Always set the project context before performing test case operations in multi-project environments 2. Use the same project key that you'll use in subsequent test case operations 3. Common project keys include 'default', 'UT', 'MAC', 'VT' - check with your QMetry admin for available projects 4. This operation must be performed before fetching test cases if working with non-default projects 5. The project context persists for the current session until changed again",
+    "inputSchema": [
+      "projectKey",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Set QMetry Project Info",
+  },
+  "qmetry_update_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Update Cycle",
+    },
+    "description": "Update an existing cycle in QMetry for test execution planning
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- cycle (object) *required*
+
+**Output Description:** JSON object containing the updated cycle details and confirmation of update
+
+**Use Cases:** 1. Update cycle name for better organization 2. Modify cycle dates to reflect schedule changes 3. Adjust testing phase timelines within a release 4. Update cycle metadata for sprint tracking 5. Revise milestone dates for test execution planning 6. Rename cycles to match updated sprint naming conventions
+
+**Examples:**
+1. Update cycle name
+\`\`\`json
+{
+  "cycle": {
+    "name": "Alpha_v1_Updated",
+    "buildID": 1494,
+    "releaseID": 3729
+  }
+}
+\`\`\`
+Expected Output: Cycle updated successfully with new name 'Alpha_v1_Updated'
+
+2. Update cycle dates
+\`\`\`json
+{
+  "cycle": {
+    "startDate": "10-10-2018",
+    "targetDate": "11-11-2018",
+    "buildID": 1494,
+    "releaseID": 3729
+  }
+}
+\`\`\`
+Expected Output: Cycle dates updated successfully with new start date 10-10-2018 and target date 11-11-2018
+
+3. Update cycle name and dates together
+\`\`\`json
+{
+  "cycle": {
+    "name": "Sprint 2 - Updated",
+    "startDate": "15-01-2024",
+    "targetDate": "31-01-2024",
+    "buildID": 1494,
+    "releaseID": 3729
+  }
+}
+\`\`\`
+Expected Output: Cycle updated with new name and dates successfully
+
+**Hints:** 1. CRITICAL: cycle.buildID is REQUIRED - must provide the build ID to identify the cycle to update 2. CRITICAL: cycle.releaseID is REQUIRED - must provide the release ID to identify the cycle to update 3. HOW TO GET buildID and releaseID: 4. 1. Call FETCH_RELEASES_CYCLES tool (API: 'Cycle/List') to get all cycles 5. 2. From the response, get buildID from projects.releases[<index>].builds[<index>].buildID 6. 3. From the response, get releaseID from projects.releases[<index>].releaseID 7. 4. Use those numeric IDs in cycle.buildID and cycle.releaseID parameters 8. Example: Cycle 'Sprint 2' might have buildID: 1494 and releaseID: 3729 9. CRITICAL WORKFLOW - IF USER PROVIDES CYCLE NAME: 10. 1. User says: 'Update cycle Sprint 2 to change dates' 11. 2. You MUST first call FETCH_RELEASES_CYCLES tool to get all cycles 12. 3. Search the response for cycle with matching name 'Sprint 2' 13. 4. Extract buildID and releaseID from the matching cycle 14. 5. Use those IDs in cycle.buildID and cycle.releaseID parameters 15. 6. If cycle name not found, inform user and list available cycles 16. Example workflow: 17. - User request: 'Update cycle Alpha_v1 name to Alpha_v1_Updated' 18. - Step 1: Call FETCH_RELEASES_CYCLES 19. - Step 2: Find cycle where name = 'Alpha_v1', get its buildID (e.g., 1494) and releaseID (e.g., 3729) 20. - Step 3: Call UPDATE_CYCLE with cycle.buildID = 1494 and cycle.releaseID = 3729 21. CYCLE IDENTIFICATION: 22. - NEVER assume or guess buildID or releaseID - always fetch from API 23. - Cycle names are user-defined strings (e.g., 'Sprint 2', 'Alpha_v1', 'Regression Cycle') 24. - buildID and releaseID are numeric identifiers assigned by QMetry 25. - Match cycle names case-insensitively when searching 26. - If multiple cycles match the name, ask user to clarify or use the most recent one 27. - FETCH_RELEASES_CYCLES returns: projects.releases[].builds[] array with name, buildID, and releaseID 28. Date format depends on QMetry instance configuration: DD-MM-YYYY or MM-DD-YYYY 29. Check your QMetry instance settings to determine the correct date format 30. NOTE: To verify/update the Date Format - Go to QMetry -> User Profile 31. If dates are in wrong format, QMetry will return an error - verify format with admin 32. You can update name, startDate, or targetDate independently or together 33. Only include the fields you want to update - other fields will remain unchanged 34. startDate and targetDate help with sprint planning and milestone tracking 35. Cycle hierarchy: Project → Release → Cycle → Test Execution 36. After updating a cycle, you can verify changes using FETCH_RELEASES_CYCLES tool 37. DIFFERENCE FROM CREATE_CYCLE: This tool updates an EXISTING cycle, while CREATE_CYCLE creates a new one",
+    "inputSchema": [
+      "baseUrl",
+      "cycle",
+      "projectKey",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Update Cycle",
+  },
+  "qmetry_update_issue": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Update Issue",
+    },
+    "description": "Update an existing QMetry issue by DefectId and/or entityKey.
+
+**Parameters:**
+- DefectId (number) *required*: ID of the defect/issue to be updated
+- entityKey (string): Entity Key of the defect/issue to be updated
+- issueType (number): Issue type ID (e.g. Bug, Enhancement, etc.)
+- issuePriority (number): Issue priority ID (e.g. High, Medium, Low, etc.)
+- summary (string): Summary or title of the defect/issue
+- description (string): Detailed description of the defect/issue
+- issueOwner (number): Owner/user ID for the issue
+- affectedRelease (number): Release IDs affected by this issue
+- affectedCycles (number): Cycle IDs affected by this issue
+
+**Output Description:** JSON object with update status and details.
+
+**Use Cases:** 1. Update issue summary (title) 2. Change issue priority, type, or owner 3. Update affected release or cycles 4. Update description or environment 5. Bulk update using DefectId and/or entityKey
+
+**Examples:**
+1. Update issue summary
+\`\`\`json
+{
+  "DefectId": 118150,
+  "summary": "Money withdrawal is success even if insufficient amount_updated"
+}
+\`\`\`
+Expected Output: Issue summary updated successfully.
+
+2. Update issue priority
+\`\`\`json
+{
+  "DefectId": 118150,
+  "issuePriority": 189340
+}
+\`\`\`
+Expected Output: Issue priority updated successfully.
+
+3. Update issue type
+\`\`\`json
+{
+  "DefectId": 118150,
+  "issueType": 189337
+}
+\`\`\`
+Expected Output: Issue type updated successfully.
+
+4. Update affected release
+\`\`\`json
+{
+  "DefectId": 118150,
+  "affectedRelease": 3730
+}
+\`\`\`
+Expected Output: Affected release updated successfully.
+
+**Hints:** 1. To get the DefectId, call the Issue/Fetch issue tool and use data[<index>].id from the response. 2. if you have pass issue key (VT-IS-5, MAC-IS-10 etc.) then first fetch issue by issue key to get issue id. 3. Along with DefectId, pass only those fields which are to be updated. 4. Refer to the Create Issue tool for valid field mappings and values. 5. You can update summary, priority, type, affectedRelease, affectedCycles, description, sync_with, issueOwner, component, environment, tcRunID, etc. 6. If you provide entityKey, it will be used for additional validation but DefectId is required.",
+    "inputSchema": [
+      "DefectId",
+      "affectedCycles",
+      "affectedRelease",
+      "description",
+      "entityKey",
+      "issueOwner",
+      "issuePriority",
+      "issueType",
+      "summary",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Update Issue",
+  },
+  "qmetry_update_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Update Test Case",
+    },
+    "description": "Update an existing QMetry test case OR create a new version by tcID and tcVersionID, with auto-resolution from entityKey.
+
+**Parameters:**
+- projectKey (string): Project key - unique identifier for the project (default: "default")
+- baseUrl (string): The base URL for the QMetry instance (must be a valid URL) (default: "https://testmanagement.qmetry.com")
+- tcID (number) *required*: Test Case numeric ID. This is the internal numeric identifier, not the entity key like 'MAC-TC-1684'. You can get this ID from test case search results or by using filters.
+- tcVersionID (number) *required*: Test Case version number. This is the internal numeric identifier for the version.
+- tcVersion (number): Test Case version number (required when withVersion=true for creating new version). This is the current version number from which a new version will be created.
+- withVersion (boolean): Pass 'true' if you want to create a new version of the test case with incremented version number. When true, a new version is created (e.g., if current version is 2, new version 3 is created). When false or omitted, updates the existing version specified by tcVersionID. IMPORTANT: Always send proper tcVersionID to identify which version the request is for.
+- versionComment (string): Comment or description for the new version (used only when withVersion=true). Helps track what changed in this new version. Example: 'Updated test steps for new requirements'
+- notruncurrent (boolean): Flag to control execution behavior for current version when creating a new version. Used in conjunction with withVersion=true.
+- notrunall (boolean): Flag to control execution behavior for all versions when creating a new version. Used in conjunction with withVersion=true.
+- folderPath (string): Folder path for test suites - SYSTEM AUTOMATICALLY SETS TO ROOT. Leave empty unless you want specific folder. System will automatically use empty string "" (root directory). Only specify if user wants specific folder like "Automation/Regression". (default: "")
+- scope (string): Scope of the operation - defines the context for data retrieval. Common values: 'project' (default), 'folder', 'release', 'cycle'. Applies to any entity type being fetched or operated upon. (default: "project")
+- isStepUpdated (boolean): Set to true when steps are being added, updated, or removed. Required when including 'steps' or 'removeSteps' arrays.
+- steps (array)
+- removeSteps (array)
+- name (string)
+- priority (number)
+- component (array)
+- owner (number)
+- testCaseState (number)
+- testCaseType (number)
+- estimatedTime (number): Estimated execution time in seconds. Example: 7200 for 2 hours
+- executionMinutes (number)
+- testingType (number)
+- description (string)
+- updateOnlyMetadata (boolean): Set to true to update only metadata fields without touching test steps. When true, steps and removeSteps are ignored.
+
+**Output Description:** JSON object containing the test case ID, version ID, summary, update/creation metadata. When withVersion=true (version creation), response includes new version number and version ID. When withVersion=false/omitted (existing version update), response includes updated fields confirmation.
+
+**Use Cases:** 1. Update test case summary (name) 2. Change priority, owner, or state of a test case 3. Edit, add, or remove test steps 4. Update only metadata (no steps) 5. Create a new version of a test case (withVersion=true) 6. Update a specific version of a test case (without withVersion flag) 7. Bulk update using entityKey auto-resolution 8. Modify test case description or estimated time 9. Change test case type or component 10. Update testing type or custom fields 11. Update, add and remove test case steps 12. Version control for test case evolution tracking
+
+**Examples:**
+1. Update test case summary (existing version update)
+\`\`\`json
+{
+  "tcID": 4519260,
+  "tcVersionID": 5448492,
+  "name": "MAC Test11"
+}
+\`\`\`
+Expected Output: Test case summary updated. tcID and tcVersionID auto-resolved from entityKey. Only 'name' field changed. Version remains the same.
+
+2. Create NEW VERSION with updated summary and description
+\`\`\`json
+{
+  "tcID": 4572654,
+  "tcVersionID": 5514384,
+  "tcVersion": 1,
+  "name": "Add two numbers 2 v2",
+  "description": "Test Description version 2",
+  "withVersion": true,
+  "versionComment": "version 2 comment add",
+  "notruncurrent": true,
+  "notrunall": true
+}
+\`\`\`
+Expected Output: New version created (version 2). Test case now has incremental version with updated summary and description. Original version 1 remains unchanged.
+
+3. Create NEW VERSION with all metadata fields (release, cycle, priority, owner, etc.)
+\`\`\`json
+{
+  "tcID": 4572654,
+  "tcVersionID": 5514384,
+  "tcVersion": 1,
+  "name": "Facebook Login Validation Failed update from MCP V2",
+  "description": "Existing description V2",
+  "priority": 2355751,
+  "testcaseOwner": 6963,
+  "testCaseState": 2355753,
+  "testCaseType": 2355762,
+  "estimatedTime": 7200,
+  "withVersion": true,
+  "versionComment": "Created version 2 with updated metadata",
+  "notruncurrent": true,
+  "notrunall": true,
+  "folderPath": 602290,
+  "scope": "project"
+}
+\`\`\`
+Expected Output: New test case version 2 created with updated summary, description, priority (High), owner (umang.savaliya), state, type, and estimated time (2 hours). Version comment added for tracking.
+
+4. Update EXISTING VERSION 2 (not creating new version)
+\`\`\`json
+{
+  "tcID": 4572654,
+  "tcVersionID": 5514385,
+  "name": "Updated version 2 name",
+  "priority": 2355752
+}
+\`\`\`
+Expected Output: Version 2 updated with new name and priority. No new version created because withVersion flag is not set. This is a normal update of existing version.
+
+5. Update priority to High and owner to john.doe (existing version)
+\`\`\`json
+{
+  "tcID": 4519260,
+  "tcVersionID": 5448492,
+  "priority": 505015,
+  "testcaseOwner": 6963
+}
+\`\`\`
+Expected Output: Priority and owner updated. Field IDs auto-resolved from project info. tcID/tcVersionID resolved from entityKey. Existing version modified.
+
+6. Update steps (edit, add, remove) - existing version
+\`\`\`json
+{
+  "tcID": 4519260,
+  "tcVersionID": 5448492,
+  "steps": [
+    {
+      "orderId": 1,
+      "description": "Step 22",
+      "inputData": "Input 22",
+      "expectedOutcome": "Outcome 22",
+      "tcStepID": 3014032
+    },
+    {
+      "orderId": 2,
+      "description": "Step3",
+      "inputData": "Input 3",
+      "expectedOutcome": "Outcome 3"
+    }
+  ],
+  "removeSteps": [
+    {
+      "tcStepID": 3014031,
+      "description": "Step 1",
+      "orderId": 1
+    }
+  ],
+  "isStepUpdated": true
+}
+\`\`\`
+Expected Output: Steps updated: Step 22 edited (tcStepID preserved), Step3 added (no tcStepID), Step 1 removed. tcID/tcVersionID auto-resolved. Existing version modified.
+
+7. Create NEW VERSION with updated steps
+\`\`\`json
+{
+  "tcID": 4572654,
+  "tcVersionID": 5514384,
+  "tcVersion": 1,
+  "name": "Add two numbers 2 v2",
+  "steps": [
+    {
+      "orderId": 1,
+      "description": "I and u have a calculator",
+      "inputData": "",
+      "expectedOutcome": "",
+      "tcStepID": 38001791
+    },
+    {
+      "orderId": 2,
+      "description": "I add 41 and 31",
+      "inputData": "",
+      "expectedOutcome": "",
+      "tcStepID": 38001793
+    },
+    {
+      "orderId": 3,
+      "description": "the result should be 72",
+      "inputData": "",
+      "expectedOutcome": "",
+      "tcStepID": 38001792
+    }
+  ],
+  "withVersion": true,
+  "versionComment": "version 2 with preserved steps",
+  "notruncurrent": true,
+  "notrunall": true,
+  "isStepUpdated": true
+}
+\`\`\`
+Expected Output: New version 2 created with all steps from version 1 preserved. Steps carry forward with their tcStepID values. Version comment added for tracking.
+
+8. Update only metadata (no steps) - existing version
+\`\`\`json
+{
+  "tcID": 4519260,
+  "tcVersionID": 5448492,
+  "updateOnlyMetadata": true,
+  "name": "New Name"
+}
+\`\`\`
+Expected Output: Metadata updated only. Steps unchanged. tcID/tcVersionID auto-resolved. Existing version modified.
+
+9. Create NEW VERSION from existing version 2 with updated steps (working payload for linked test cases)
+\`\`\`json
+{
+  "tcID": 4594145,
+  "tcVersionID": 5536706,
+  "tcVersion": 2,
+  "name": "Mock Test Case - E-commerce Checkout Flow - v3",
+  "steps": [
+    {
+      "orderId": 1,
+      "description": "Open browser and navigate to e-commerce website",
+      "expectedOutcome": "Homepage loads successfully with product catalog",
+      "inputData": "URL: https://example-shop.com",
+      "tcStepID": 38129471
+    },
+    {
+      "orderId": 2,
+      "description": "Search for product",
+      "expectedOutcome": "Search results display relevant products",
+      "inputData": "Search term: 'wireless headphones'",
+      "tcStepID": 38129475
+    },
+    {
+      "orderId": 3,
+      "description": "Select product and add to cart",
+      "expectedOutcome": "Product added to cart, cart counter increments",
+      "inputData": "Click 'Add to Cart' button",
+      "tcStepID": 38129472
+    },
+    {
+      "orderId": 4,
+      "description": "Proceed to checkout",
+      "expectedOutcome": "Checkout page displays with cart summary",
+      "inputData": "Click cart icon and 'Proceed to Checkout'",
+      "tcStepID": 38129473
+    },
+    {
+      "orderId": 5,
+      "description": "Complete payment",
+      "expectedOutcome": "Order confirmation page displayed",
+      "inputData": "Fill payment details and submit",
+      "tcStepID": 38129474
+    },
+    {
+      "orderId": 6,
+      "description": "Verify order confirmation email received",
+      "expectedOutcome": "Email with order details received in inbox",
+      "inputData": "Check email account for confirmation"
+    },
+    {
+      "orderId": 7,
+      "description": "Check order status in account dashboard",
+      "expectedOutcome": "Order status shows as 'Processing' with tracking information",
+      "inputData": "Navigate to My Orders section"
+    }
+  ],
+  "withVersion": true,
+  "versionComment": "Created version 3: Added 2 new verification steps (email and order status check)",
+  "notrunall": false,
+  "notruncurrent": false,
+  "scope": "project"
+}
+\`\`\`
+Expected Output: New version 3 created successfully from version 2. Test case now has 7 steps (5 preserved + 2 new). Key: tcVersion=2 was used because version 2 already existed in system. notrunall and notruncurrent both false (not true). Result shows tcVersion: 3 in response with new tcVersionID.
+
+**Hints:** 1. CRITICAL - VERSION CREATION vs UPDATE DISTINCTION: 2. This tool supports TWO MODES using the SAME API endpoint: 3.  4. MODE 1: CREATE NEW VERSION (withVersion=true) 5. - Purpose: Create an incremental version of the test case (e.g., v1 → v2, v2 → v3) 6. - When to use: User explicitly asks to 'create new version', 'create version 2', 'increment version' 7. - Required fields: tcID, tcVersionID (of source version), tcVersion (current version number), withVersion=true 8. - Optional but recommended: versionComment (track what changed), notruncurrent, notrunall 9. - Behavior: Creates a NEW test case version with incremented version number. Source version remains unchanged. 10. - Example: If current version is 1, setting withVersion=true creates version 2 11. - Use cases: Updating test case for new requirements, creating variants for different scenarios, version control 12.  13. MODE 2: UPDATE EXISTING VERSION (withVersion=false or omitted) 14. - Purpose: Modify fields of an EXISTING version without creating a new version 15. - When to use: User asks to 'update test case', 'modify version X', 'change summary' (without mentioning new version) 16. - Required fields: tcID, tcVersionID (of version to update) 17. - Do NOT include: withVersion flag, versionComment, tcVersion 18. - Behavior: Updates the specified version in-place. No new version is created. 19. - Example: Updating version 2's summary - only version 2 is modified, no version 3 is created 20. - Use cases: Fixing typos, updating metadata, modifying steps in existing version 21.  22. CRITICAL FIELD UNDERSTANDING: 23. - tcVersionID: The VERSION ID (numeric identifier) of the version you're working with 24. - tcVersion: The VERSION NUMBER (1, 2, 3, etc.) - only needed when withVersion=true 25. - tcID: The TEST CASE ID (remains same across all versions) 26. - Example: Test case VKMCP-TC-10 (tcID: 4572654) has version 1 (tcVersionID: 5514384, tcVersion: 1) 27. - When creating version 2 from version 1: Send tcVersionID=5514384 (source), tcVersion=1 (current), withVersion=true 28.  29. HOW TO DETERMINE WHICH MODE: 30. - User says 'create new version' → MODE 1 (withVersion=true) 31. - User says 'create version 2' → MODE 1 (withVersion=true) 32. - User says 'update test case with new version' → MODE 1 (withVersion=true) 33. - User says 'update test case VKMCP-TC-10 summary' → MODE 2 (no withVersion, update existing version) 34. - User says 'update version 2 summary' → MODE 2 (no withVersion, update existing version 2) 35. - User says 'change priority of version 1' → MODE 2 (no withVersion, update version 1) 36. - If ambiguous, ask user: 'Do you want to create a new version or update the existing version?' 37.  38. VERSION CREATION WORKFLOW (withVersion=true): 39. Step 1: Fetch test case details to get current tcID, tcVersionID, and tcVersion 40. Step 2: Optionally fetch current steps if they need to be preserved/modified 41. Step 3: Prepare payload with: 42.   - tcID (test case ID) 43.   - tcVersionID (source version ID to create from) 44.   - tcVersion (current version number) 45.   - withVersion: true (CRITICAL flag) 46.   - versionComment (recommended: describe what changed) 47.   - Updated fields (name, description, priority, steps, etc.) 48.   - notruncurrent: true (recommended) 49.   - notrunall: true (recommended) 50. Step 4: Call update API - a new version will be created with incremented version number 51. Step 5: New version inherits all fields from source version, with your specified updates applied 52.  53. EXISTING VERSION UPDATE WORKFLOW (no withVersion): 54. Step 1: Fetch test case details to get tcID and tcVersionID of the version to update 55. Step 2: Prepare payload with: 56.   - tcID (test case ID) 57.   - tcVersionID (version ID to update) 58.   - DO NOT include withVersion, versionComment, or tcVersion 59.   - Only include fields you want to change 60. Step 3: Call update API - specified version is updated in-place 61. Step 4: No new version is created, only specified fields are modified 62.  63. FIELD MAPPING FOR VERSION CREATION: 64. When creating a new version, include ALL fields you want the new version to have: 65. - name: Test case summary (required if different from source) 66. - description: Test case description (required if different from source) 67. - priority: Priority ID (get from project info customListObjs.priority[index].id) 68. - testcaseOwner: Owner ID (get from project info customListObjs.owner[index].id) 69. - testCaseState: State ID (get from project info customListObjs.testCaseState[index].id) 70. - testCaseType: Type ID (get from project info customListObjs.testCaseType[index].id) 71. - testingType: Testing type ID (get from project info customListObjs.testingType[index].id) 72. - component: Array of component IDs (get from project info customListObjs.component[index].id) 73. - estimatedTime: Time in seconds (e.g., 7200 for 2 hours) 74. - steps: Array of step objects (include tcStepID from source version to preserve steps) 75. - folderPath: Folder path or folder ID 76. - scope: Usually 'project' 77.  78. STEPS HANDLING IN VERSION CREATION: 79. When creating a new version WITH steps: 80. - To PRESERVE existing steps: Include them with their original tcStepID values 81. - To ADD new steps: Include them WITHOUT tcStepID 82. - To MODIFY steps: Include them with tcStepID and updated description/data 83. - To REMOVE steps: Include them in removeSteps array 84. - Set isStepUpdated: true if any steps are modified, added, or removed 85. - If no steps are included, new version may inherit steps from source (verify with QMetry docs) 86.  87. If user provides entityKey (e.g., MAC-TC-1684), first call FETCH_TEST_CASES with a filter on entityKeyId to resolve the tcID and tcVersionID. 88. To get valid values for priority, owner, component, etc., call the project info tool and use the returned customListObjs IDs. 89. If the user provides a priority name (e.g. 'Blocker'), fetch project info, find the matching priority in customListObjs.priority[index].name, and use its ID in the payload. If the name is not found, skip the priority field (it is not required) and show a user-friendly message: 'Test case updated without priority, as given priority is not available in the current project.' 90. If the user provides a component name, fetch project info, find the matching component in customListObjs.component[index].name, and use its ID in the payload. If the name is not found, skip the component field (it is not required) and show a user-friendly message: 'Test case updated without component, as given component is not available in the current project.' 91. If the user provides an owner name, fetch project info, find the matching owner in customListObjs.owner[index].name, and use its ID in the payload as testcaseOwner. If the name is not found, skip the testcaseOwner field (it is not required) and show a user-friendly message: 'Test case updated without owner, as given owner is not available in the current project.' 92. If the user provides a test case state name, fetch project info, find the matching state in customListObjs.testCaseState[index].name, and use its ID in the payload as testCaseState. If the name is not found, skip the testCaseState field (it is not required) and show a user-friendly message: 'Test case updated without test case state, as given state is not available in the current project.' 93. If the user provides a test case type name, fetch project info, find the matching type in customListObjs.testCaseType[index].name, and use its ID in the payload as testCaseType. If the name is not found, skip the testCaseType field (it is not required) and show a user-friendly message: 'Test case updated without test case type, as given type is not available in the current project.' 94. If the user provides a testing type name, fetch project info, find the matching type in customListObjs.testingType[index].name, and use its ID in the payload as testingType. If the name is not found, skip the testingType field (it is not required) and show a user-friendly message: 'Test case updated without testing type, as given testing type is not available in the current project.' 95. Example: If user says 'Update test case with title "High priority test case" and set priority to "Blocker"', first call project info, map 'Blocker' to its ID, and use that ID for the priority field in the update payload. If user says 'set priority to "Urgent"' and 'Urgent' is not found, skip the priority field and show: 'Test case updated without priority, as given priority is not available in the current project.' 96. CRITICAL: To update test case steps without **Duplication**, use the following rules: 97. - ANTI-DUPLICATION RULE: The tcStepID field is THE KEY to prevent duplication: 98.   * WITH tcStepID = UPDATE existing step (QMetry modifies the existing step in place) 99.   * WITHOUT tcStepID = CREATE new step (QMetry adds a brand new step) 100. - For steps to be UPDATED: ALWAYS fetch existing steps first using FETCH_TEST_CASE_STEPS, then include the tcStepID in the step object. 101. - For steps to be ADDED: omit tcStepID completely in the step object. 102. - For steps to be REMOVED: add a full removeSteps object for each step to be deleted, matching the removeTestCaseStep interface. 103. - CRITICAL WARNING - DO NOT ADD UNSOLICITED STEPS: 104.   * ONLY add, edit, or remove steps that the user EXPLICITLY requested 105.   * DO NOT invent, create, or add extra steps based on assumptions or best practices 106.   * DO NOT add 'helpful' steps that the user did not ask for 107.   * When user says 'remove step 1', the result should have (N-1) steps, not N steps with extras 108.   * When user says 'add 1 step', ONLY add that 1 step, nothing more 109.   * When user says 'update step 2', ONLY update step 2, do not add or modify other steps 110.   * If unsure what user wants, ASK first rather than adding steps autonomously 111. - WORKFLOW TO AVOID DUPLICATION: 112.   1. Call FETCH_TEST_CASE_STEPS to get all existing steps with their tcStepID values 113.   2. For steps you want to KEEP/UPDATE: Include them in steps[] WITH their original tcStepID 114.   3. For steps you want to ADD: Include them in steps[] WITHOUT tcStepID (ONLY if user requested) 115.   4. For steps you want to REMOVE: Include them in removeSteps[] with full details 116.   5. Always set isStepUpdated: true if steps are added, updated, or removed 117.   6. VERIFY your steps array matches user's explicit request (count and content) 118. - Example: If user says 'Edit step 1 to say ...', FIRST fetch steps to get tcStepID for step 1, THEN include it in the steps array with updated fields and the ORIGINAL tcStepID. 119. - Example: If user says 'Add a new step after step 2', add EXACTLY ONE new object to steps array with no tcStepID (not multiple steps). 120. - Example: If user says 'Remove step 3', add the full step object to removeSteps array, including tcStepID and all required fields. Do NOT add replacement steps. 121. - Example: If test case has 3 steps and user says 'remove step 1', result should have 2 steps (step 2 and step 3 with updated orderIds), NOT 3 steps with extras. 122. - Example: If user says 'add one mock step', add EXACTLY ONE step (not 2 or 3 steps even if they seem related). 123. - COMPLETE PAYLOAD EXAMPLE: { tcID: 123, tcVersionID: 456, steps: [{tcStepID: 1001, orderId: 1, description: 'Updated'}, {orderId: 2, description: 'New'}], removeSteps: [{tcStepID: 1002, orderId: 3, ...}], isStepUpdated: true } 124. - If only metadata is updated (no steps), set updateOnlyMetadata: true and do not include steps/removeSteps. 125. - Always preserve orderId sequence for proper step ordering. 126. - If user prompt is ambiguous, ask for clarification or show a user-friendly error. 127. - WARNING: Omitting tcStepID for existing steps will cause DUPLICATION - the API will create duplicates instead of updating! 128. - FINAL VERIFICATION BEFORE SENDING REQUEST: 129.   * Count steps in your payload vs what user requested 130.   * If user said 'add 1 step', steps array should have (existing_count + 1) items total 131.   * If user said 'remove 1 step', steps array should have (existing_count - 1) items total, removeSteps should have 1 item 132.   * If user said 'update step X', steps array should have same count as before, with step X's tcStepID preserved 133.   * NEVER include steps the user did not explicitly mention or request 134. Steps are optional but recommended for manual test cases. 135. If the user provides a prompt like 'update test case with steps as step 1 - Go to login page, step 2 - give credential, step 3 - go to test case page, step 4 - create test case', LLM should parse each step and convert it into the steps payload array, mapping each step to an object with orderId, description, and optionally inputData and expectedOutcome. 136. Example mapping: 'step 1 - Go to login page' → { orderId: 1, description: 'Go to login page' }. 137. LLM should increment orderId for each step, use the step text as description, and optionally infer inputData/expectedOutcome if provided in the prompt. 138. Demo steps payload: steps: [ { orderId: 1, description: 'First Step', inputData: 'First Data', expectedOutcome: 'First Outcome', UDF: { customField1: 'Custom Field Data A', customField2: 'Custom Field Data B' } }, ... ] 139. UDF fields in steps must match your QMetry custom field configuration. 140. All IDs (priority, owner, etc.) must be valid for your QMetry instance. 141. If a custom field is mandatory, include it in the UDF object. 142.  143. ADDITIONAL VERSION CREATION GUIDANCE: 144. - versionComment field: STRONGLY RECOMMENDED when withVersion=true. Helps track why version was created. 145.   Example comments: 'Updated for Sprint 5 requirements', 'Fixed test steps based on code review', 'Version 2 for production environment' 146. - notruncurrent and notrunall flags: Control execution behavior when creating versions. Set both to true as best practice. 147. - folderPath: Can be string path or numeric folder ID. Usually inherited from source version if not specified. 148. - attachments: Use ADD/REMOVE arrays to manage attachments when creating new version or updating existing version. 149. - estimatedTime vs executionMinutes: Use estimatedTime (in seconds) for version creation. executionMinutes (in minutes) is legacy field. 150.  151. REAL-WORLD VERSION CREATION EXAMPLES: 152. Example 1: User says 'create a new version of test case VKMCP-TC-10 with summary = "Facebook Login Validation Failed update from MCP V2", description = used existing description by at last add V2 text, release = default, cycle = default' 153. → Workflow: 154.   1. Fetch VKMCP-TC-10 details to get tcID, tcVersionID, tcVersion, current description 155.   2. Fetch project info to get default release ID and cycle ID 156.   3. Append ' V2' to current description 157.   4. Send payload with: tcID, tcVersionID (source), tcVersion (current), withVersion=true, name='...V2', description='...V2', versionComment='Created version 2', release/cycle IDs 158. → Result: New incremental version created (e.g., version 1 → version 2) with updated summary, modified description, associated with default release/cycle 159.  160. Example 2: User says 'update version 2 summary, release, cycle, priority' 161. → Workflow: 162.   1. Fetch test case details to get version 2's tcVersionID 163.   2. Fetch project info to get priority, release, cycle IDs 164.   3. Send payload with: tcID, tcVersionID (of version 2), WITHOUT withVersion flag, with updated summary, release, cycle, priority 165. → Result: Version 2 updated in-place. No new version created. Only specified fields modified. 166.  167. COMMON PITFALLS TO AVOID: 168. - Pitfall 1: Setting withVersion=true when user wants to update existing version → Creates unwanted new version 169. - Pitfall 2: Omitting versionComment when creating new version → Lost tracking of why version was created 170. - Pitfall 3: Not fetching current tcVersionID before update → Updating wrong version or causing error 171. - Pitfall 4: Using tcVersion for normal updates → tcVersion only needed when withVersion=true 172. - Pitfall 5: Not including tcStepID for steps when creating version → Steps may duplicate instead of preserving 173. - Pitfall 6: Confusing tcVersionID (version identifier) with tcVersion (version number) → Wrong API payload 174.  175. CRITICAL ERROR HANDLING: TC.VERSION_NOT_SYNCED FOR LINKED TEST CASES 176.  177. PROBLEM: Test cases linked to test suites or with existing executions cannot be updated directly 178. TRIGGERS: 179.   ✓ Test case is linked to one or more test suites 180.   ✓ Test case has execution history (test runs exist) 181.   ✓ Test case is part of a release/cycle with test runs 182.   ✓ Any step modification when test case has associations 183.  184. ERROR CODE: TC.VERSION_NOT_SYNCED 185. ERROR MESSAGE: 'This Test Case has been associated. Create a new version to save modifications.' 186.  187. AUTOMATIC RETRY STRATEGY (IMPLEMENT THIS PATTERN): 188. When you receive TC.VERSION_NOT_SYNCED error, AUTOMATICALLY retry with version creation: 189. DO NOT ask user for confirmation - this is expected behavior for associated test cases 190.  191. 1. FIRST ATTEMPT (Normal Update): 192.    - Try updating with isStepUpdated=true (for step changes) or without withVersion flag 193.    - If error code is TC.VERSION_NOT_SYNCED, proceed to step 2 194.    - If error is different, report the error to user 195.  196. 2. AUTOMATIC RETRY (Version Creation): 197.    - Use the SAME tcID, tcVersionID, and steps array from first attempt 198.    - Add these flags to payload: 199.      * withVersion: true (CRITICAL - enables version creation) 200.      * tcVersion: <current version number> (get from test case details or executions) 201.      * notrunall: false (use false, not true) 202.      * notruncurrent: false (use false, not true) 203.      * scope: 'project' (always required) 204.      * versionComment: 'Auto-created version due to test suite association' (or custom message) 205.    - Set isStepUpdated: true whenever you modify steps (including when withVersion=true) 206.    - IMPORTANT: Include ALL existing steps with tcStepID + new steps without tcStepID 207.  208. 3. VERIFICATION: 209.    - Check response for new tcVersionID (will be different from source) 210.    - Verify tcVersion incremented (e.g., 1→2, 2→3) 211.    - Confirm success message: 'Test Case <entityKey> updated successfully' 212.  213. UI BEHAVIOR COMPARISON: 214. QMetry UI shows a popup: 'Save as new version?' with optional comment field 215. API equivalent: Automatic retry with withVersion=true after detecting TC.VERSION_NOT_SYNCED 216.  217. REAL-WORLD EXAMPLE FROM UI PAYLOADS: 218.  219. First Attempt (FAILS with TC.VERSION_NOT_SYNCED): 220. \`\`\`pseudo 221. { 222.   "tcID": 4594140, 223.   "tcVersionID": 5536696, 224.   "withVersion": false, 225.   "notrunall": false, 226.   "steps": [ 227.     // ... 5 existing steps with tcStepID ... 228.     // ... 1 new step without tcStepID (orderId: 6) ... 229.   ], 230.   "removeSteps": [], 231.   "isStepUpdated": true 232. } 233. \`\`\` 234. Response: 400 - TC.VERSION_NOT_SYNCED error 235.  236. Second Attempt (SUCCEEDS - Creates Version 2): 237. \`\`\`pseudo 238. { 239.   "withVersion": true,          // NEW: Version creation flag 240.   "notrunall": false, 241.   "notruncurrent": false, 242.   "steps": [ 243.     // SAME steps array as first attempt 244.     // ... 5 existing steps with tcStepID ... 245.     // ... 1 new step without tcStepID ... 246.   ], 247.   "removeSteps": [], 248.   "scope": "project", 249.   "tcID": 4594140,              // SAME tcID 250.   "tcVersion": 1,               // NEW: Current version number 251.   "tcVersionID": 5536696,       // SAME tcVersionID (source version) 252.   "versionComment": "test",     // NEW: Version comment (optional) 253.   // NOTE: isStepUpdated field is NOT included when withVersion=true 254. } 255. \`\`\` 256. Response: 200 - Success, new tcVersionID created (e.g., 5536697), tcVersion=2 257.  258. IMPLEMENTATION PSEUDO-CODE: 259. \`\`\`typescript 260. try { 261.   // First attempt: Normal update 262.   const response = await updateTestCase({ 263.     tcID, tcVersionID, steps, isStepUpdated: true 264.   }); 265. } catch (error) { 266.   if (error.code === 'TC.VERSION_NOT_SYNCED') { 267.     // Automatic retry with version creation 268.     const testCaseDetails = await fetchTestCaseDetails(tcID); 269.     // CRITICAL: Use the LATEST version number from system 270.     const latestVersion = testCaseDetails.tcVersion;  // e.g., 2 if v2 exists 271.     const response = await updateTestCase({ 272.       tcID, 273.       tcVersionID,  // Same source version 274.       tcVersion: latestVersion,  // Use latest version number (not always 1!) 275.       steps,  // Same steps array 276.       // DO NOT include isStepUpdated when withVersion=true 277.       withVersion: true,  // Enable version creation 278.       notrunall: false,  // Use false (verified working value) 279.       notruncurrent: false,  // Use false (verified working value) 280.       scope: 'project',  // Always required 281.       versionComment: 'Auto-created version due to test suite association' 282.     }); 283.   } else { 284.     throw error;  // Different error, report to user 285.   } 286. } 287. \`\`\` 288.  289. KEY INSIGHTS: 290. - DO NOT ask user for confirmation - auto-retry is expected behavior 291. - Use SAME tcVersionID in both attempts (source version for creation) 292. - Second attempt creates NEW version (tcVersionID changes in response) 293. - Steps array is IDENTICAL in both attempts 294. - tcVersion parameter is ONLY in second attempt (withVersion=true) 295. - This matches QMetry UI behavior where popup auto-triggers version creation 296.  297. CRITICAL: INCREMENTAL tcVersion SELECTION RULE 298.  299. PROBLEM: When multiple versions exist, which tcVersion should you use? 300. SOLUTION: Use the VERSION NUMBER of the version you are creating FROM (the latest existing version) 301.  302. RULE: When creating a new version, tcVersion must equal the CURRENT LATEST VERSION in the system 303.  304. EXAMPLES: 305. - If only version 1 exists: Use tcVersion: 1 (creates version 2 from v1) 306. - If version 1 and 2 exist: Use tcVersion: 2 (creates version 3 from v2) 307. - If version 1, 2, and 3 exist: Use tcVersion: 3 (creates version 4 from v3) 308.  309. WORKFLOW TO DETERMINE CORRECT tcVersion: 310. 1. Call FETCH_TEST_CASE_DETAILS or FETCH_TEST_CASE_EXECUTIONS 311. 2. Check the highest tcVersion number in the system 312. 3. Use that number as your tcVersion parameter in the update payload 313. 4. This ensures you're creating from the latest version, not an old one 314.  315. REAL-WORLD SCENARIO: 316. Scenario: Test case VKMCP-TC-43 has version 2 already created in UI 317. Wrong Approach (will fail): tcVersion: 1, withVersion: true → TC.VERSION_NOT_SYNCED error 318. Correct Approach (will succeed): tcVersion: 2, withVersion: true → Creates version 3 successfully 319.  320. VERIFIED WORKING PAYLOAD (from user's Postman testing): 321. \`\`\`json 322. { 323.   "notrunall": false, 324.   "notruncurrent": false, 325.   "scope": "project", 326.   "tcID": 4594145, 327.   "tcVersion": 2,                        // KEY: Use version 2 because v2 already exists 328.   "tcVersionID": 5536706,                // Source version ID (stays same) 329.   "versionComment": "Added new steps",  // Describes what changed 330.   "withVersion": true,                   // Enable version creation 331.   "steps": [ 332.     // 5 existing steps with tcStepID (preserved from source) 333.     // 2 new steps without tcStepID (to be added) 334.   ] 335. } 336. \`\`\` 337. Result: New version 3 created successfully with 7 total steps 338.  339. DEFAULT VALUES FOR TC.VERSION_NOT_SYNCED RETRIES (THIS PATTERN): 340. - notrunall: false - For this retry pattern, override any usual \`true\` default 341. - notruncurrent: false - For this retry pattern, override any usual \`true\` default 342. - scope: "project" - Always use this 343. - withVersion: true - Required when creating a new version (both initial and retries) 344.  345. WHEN TO APPLY THIS PATTERN: 346. ✓ Adding steps to test case linked to test suite 347. ✓ Editing steps in test case with existing executions 348. ✓ Removing steps from associated test case 349. ✓ Any modification to steps when TC.VERSION_NOT_SYNCED occurs 350. ✓ When creating new versions from existing versions (always check latest version number) 351.  352. WHEN NOT TO APPLY: 353. ✗ Test case is NOT linked to test suite (normal update works) 354. ✗ Only updating metadata (name, priority, etc.) without steps 355. ✗ Different error codes (handle appropriately) 356.  357. BENEFITS OF THIS APPROACH: 358. 1. Seamless UX - LLM handles version creation automatically 359. 2. Matches UI behavior - no manual intervention needed 360. 3. Preserves test history - creates proper version trail 361. 4. Maintains test suite linkage - version creation preserves associations 362. 5. Handles incremental versions correctly - uses latest version as source 363.  364. 🎯 GRACEFUL HANDLING SUMMARY: 365.  366. When adding/editing/removing steps from test cases: 367. 1. Always TRY normal update first (without withVersion flag) 368. 2. If TC.VERSION_NOT_SYNCED error received: 369.    - Fetch latest version number from test case details/executions 370.    - Automatically retry with withVersion=true + correct tcVersion 371.    - Use notrunall=false, notruncurrent=false, scope='project' 372.    - Include version comment describing the changes 373. 3. Report success with new version details to user 374. 4. NEVER ask for confirmation - handle it transparently 375.  376. This ensures test cases with executions or suite associations are handled gracefully 377. without user intervention, matching the QMetry UI experience exactly. 378.  379. executionMinutes time is in minutes (legacy field). 380. estimatedTime is in seconds (preferred for version creation). 381. Description and testingType are optional but recommended for clarity.",
+    "inputSchema": [
+      "baseUrl",
+      "component",
+      "description",
+      "estimatedTime",
+      "executionMinutes",
+      "folderPath",
+      "isStepUpdated",
+      "name",
+      "notrunall",
+      "notruncurrent",
+      "owner",
+      "priority",
+      "projectKey",
+      "removeSteps",
+      "scope",
+      "steps",
+      "tcID",
+      "tcVersion",
+      "tcVersionID",
+      "testCaseState",
+      "testCaseType",
+      "testingType",
+      "updateOnlyMetadata",
+      "versionComment",
+      "withVersion",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Update Test Case",
+  },
+  "qmetry_update_test_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QMetry: Update Test Suite",
+    },
+    "description": "Update an existing QMetry test suite by id(testsuite numeric id), with auto-resolution from entityKey.
+
+**Parameters:**
+- id (number) *required*: Id of Test Suite to be updated (required)
+- TsFolderID (number) *required*: Folder ID where Test Suite resides (required)
+- entityKey (string) *required*: Entity Key of Test Suite to be updated (required)
+- name (string): Name of the Test Suite
+- description (string): Description of the Test Suite
+- testsuiteOwner (number): Owner ID of the Test Suite
+- testSuiteState (number): State of the Test Suite
+
+**Output Description:** JSON object containing the new test suite ID, summary, and creation metadata.
+
+**Use Cases:** 1. Update test suite summary (name) 2. Change owner, or state of a test suite 3. Bulk update using entityKey auto-resolution 4. Modify test suite description
+
+**Examples:**
+1. Update test suite summary (updated name)
+\`\`\`json
+{
+  "id": 1505898,
+  "entityKey": "VT-TS-7",
+  "TsFolderID": 1644087,
+  "name": "MAC Test11"
+}
+\`\`\`
+Expected Output: Test suite summary updated. Only 'name' field changed. Field IDs auto-resolved from project info. id(test suite numeric id) resolved from entityKey. TsFolderID auto-resolved. from the project info. info on rootFolders.TS.id.
+
+2. Update state to Open and owner of the test suite
+\`\`\`json
+{
+  "id": 1505898,
+  "entityKey": "VT-TS-7",
+  "TsFolderID": 1644087,
+  "testSuiteState": 505036,
+  "testsuiteOwner": 6963
+}
+\`\`\`
+Expected Output: State and owner updated. Example uses: testSuiteState=505036 (Open from customListObjs.testSuiteState[index].id), testsuiteOwner=6963 (umang.savaliya from customListObjs.owner[index].id). Field IDs auto-resolved from project info. id(test suite numeric id) resolved from entityKey. TsFolderID auto-resolved from the project info rootFolders.TS.id.
+
+3. Update only description of the test suite
+\`\`\`json
+{
+  "id": 1505898,
+  "entityKey": "VT-TS-7",
+  "TsFolderID": 1644087,
+  "description": "Updated description for the test suite."
+}
+\`\`\`
+Expected Output: description updated only. Field IDs auto-resolved from project info. id(test suite numeric id) resolved from entityKey. TsFolderID auto-resolved. from the project info. info on rootFolders.TS.id.
+
+**Hints:** 1. If user provides entityKey (e.g., MAC-TS-7), first call Fetch Test Suites with a filter on entityKeyId to resolve the id (test suite numeric id) and TsFolderID from rootFolders.TS.id. 2. To get valid values for owner, state, etc., call the 'Admin/Get info Service' API (FETCH_PROJECT_INFO tool) and use the returned customListObjs IDs. 3. CRITICAL: For testsuiteOwner mapping - Call API 'Admin/Get info Service', from the response get value from customListObjs.owner[<index>].id. Match the user by customListObjs.owner[<index>].name. 4. If the user provides an owner name, fetch project info, find the matching user in customListObjs.owner[index].name, and use its ID in the payload as testsuiteOwner. If the name is not found, skip the testsuiteOwner field (it is not required) and show a user-friendly message: 'Test suite updated without owner, as given owner is not available in the current project.' 5. CRITICAL: For testSuiteState mapping - Call API 'Admin/Get info Service', from the response get value from customListObjs.testSuiteState[<index>].id. Match the state by customListObjs.testSuiteState[<index>].name. 6. If the user provides a test suite state name, fetch project info, find the matching state in customListObjs.testSuiteState[index].name, and use its ID in the payload as testSuiteState. If the name is not found, skip the testSuiteState field (it is not required) and show a user-friendly message: 'Test suite updated without test suite state, as given state is not available in the current project.' 7. If either owner or state is not found in project info, the update for that field will be skipped and a user-friendly message will be shown to the user. 8. UDF fields in steps must match your QMetry custom field configuration. 9. All IDs (testSuiteState from customListObjs.testSuiteState[index].id, testsuiteOwner from customListObjs.owner[index].id) must be valid for your QMetry instance. 10. If a custom field is mandatory, include it in the UDF object.",
+    "inputSchema": [
+      "TsFolderID",
+      "description",
+      "entityKey",
+      "id",
+      "name",
+      "testSuiteState",
+      "testsuiteOwner",
+    ],
+    "outputSchema": undefined,
+    "title": "QMetry: Update Test Suite",
+  },
+  "reflect_add_prompt_step": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Add Prompt Step",
+    },
+    "description": "Add a natural language prompt step to an active Reflect recording session
+
+**Parameters:**
+- sessionId (string) *required*: The ID of the Reflect recording session
+- prompt (string) *required*: The natural language prompt describing the test step. The prompt should describe a single action, assertion, or query. The prompt can only contain literal text; it cannot contain template variables, secrets, or other dynamic syntax. If we are in a Web recording, the prompt can perform browser navigation (e.g. "Click on the back button", "Navigate to https://www.example.com") and use the tab and enter keys to navigate (e.g. "Press the tab key", "Press the enter key").",
+    "inputSchema": [
+      "prompt",
+      "sessionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Add Prompt Step",
+  },
+  "reflect_add_segment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Add Segment",
+    },
+    "description": "Insert a reusable test segment into an active Reflect recording session
+
+**Parameters:**
+- sessionId (string) *required*: The ID of the Reflect recording session
+- segmentId (number) *required*: The ID of the segment to add",
+    "inputSchema": [
+      "segmentId",
+      "sessionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Add Segment",
+  },
+  "reflect_cancel_suite_execution": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Cancel Suite Execution",
+    },
+    "description": "Cancel a reflect suite execution
+
+**Parameters:**
+- suiteId (string) *required*: ID of the reflect suite to cancel execution for
+- executionId (string) *required*: ID of the reflect suite execution to cancel",
+    "inputSchema": [
+      "executionId",
+      "suiteId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Cancel Suite Execution",
+  },
+  "reflect_connect_to_session": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Connect To Session",
+    },
+    "description": "Connect to an active Reflect recording session via WebSocket to enable interactive control. When creating or editing a Reflect test using a connected recording session, follow these guidelines:
+
+1. After connecting to a session, get the list of segments for the session's platform type so you know what actions could be added via segments vs needing to create new steps. Do not list tests, only list segments.
+2. Before performing an action, take a screenshot to understand the current state of the application.
+3. Each add_prompt_step request should perform a single action or assertion. Do not combine multiple actions or assertions into a single step.
+4. Only perform one action at a time unless you're sure the action won't move the application to a different screen. For example, you can send multiple add_prompt_step requests to fill out individual form fields if those fields are visible on the current screen.
+5. Check the list of existing Segments to see if a Segment exists that achieves a similar goal to what you're trying to do next. If so, add the segment instead of creating new steps.
+6. If a step fails, use delete_previous_step to remove it and try a different approach.
+7. After completing a task, if the task required multiple prompt steps, add a final prompt step that validates the current state of the page based on what you see on the screen. In your validation, do not reference information that can change from run to run.
+
+**Parameters:**
+- sessionId (string) *required*: The ID of the Reflect recording session to connect to",
+    "inputSchema": [
+      "sessionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Connect To Session",
+  },
+  "reflect_delete_previous_step": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Delete Previous Step",
+    },
+    "description": "Delete the last step added to an active Reflect recording session
+
+**Parameters:**
+- sessionId (string) *required*: The ID of the Reflect recording session",
+    "inputSchema": [
+      "sessionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Delete Previous Step",
+  },
+  "reflect_execute_suite": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Execute Suite",
+    },
+    "description": "Execute a reflect suite
+
+**Parameters:**
+- suiteId (string) *required*: ID of the reflect suite to execute",
+    "inputSchema": [
+      "suiteId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Execute Suite",
+  },
+  "reflect_get_screenshot": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Get Screenshot",
+    },
+    "description": "Capture a screenshot from the current state of an active Reflect recording session
+
+**Parameters:**
+- sessionId (string) *required*: The ID of the Reflect recording session
+- format (enum): The image format for the screenshot (png or jpeg)",
+    "inputSchema": [
+      "format",
+      "sessionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Get Screenshot",
+  },
+  "reflect_get_suite_execution_status": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Get Suite Execution Status",
+    },
+    "description": "Get the status of a reflect suite execution
+
+**Parameters:**
+- suiteId (string) *required*: ID of the reflect suite to get execution status for
+- executionId (string) *required*: ID of the reflect suite execution to get status for",
+    "inputSchema": [
+      "executionId",
+      "suiteId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Get Suite Execution Status",
+  },
+  "reflect_get_test_status": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Get Test Status",
+    },
+    "description": "Get the status of a reflect test execution
+
+**Parameters:**
+- executionId (string) *required*: ID of the reflect test execution to get status for",
+    "inputSchema": [
+      "executionId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Get Test Status",
+  },
+  "reflect_list_segments": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: List Segments",
+    },
+    "description": "Retrieve available reusable test segments for the given platform type. Segments are reusable test steps with an optional set of parameters that can used across multiple tests.
+
+**Parameters:**
+- platform (enum) *required*: The platform type to retrieve segments for
+- offset (number): Offset for pagination
+- limit (number): Maximum number of segments to return",
+    "inputSchema": [
+      "limit",
+      "offset",
+      "platform",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: List Segments",
+  },
+  "reflect_list_suite_executions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: List Suite Executions",
+    },
+    "description": "List all executions for a given suite
+
+**Parameters:**
+- suiteId (string) *required*: ID of the reflect suite to list executions for",
+    "inputSchema": [
+      "suiteId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: List Suite Executions",
+  },
+  "reflect_list_suites": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: List Suites",
+    },
+    "description": "Retrieve a list of all reflect suites available",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Reflect: List Suites",
+  },
+  "reflect_list_tests": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: List Tests",
+    },
+    "description": "List all reflect tests",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Reflect: List Tests",
+  },
+  "reflect_run_test": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Run Test",
+    },
+    "description": "Run a reflect test
+
+**Parameters:**
+- testId (string) *required*: ID of the reflect test to run",
+    "inputSchema": [
+      "testId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Run Test",
+  },
+  "swagger_create_api_from_prompt": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Create API from Prompt",
+    },
+    "description": "Generate and save an API definition based on a prompt using SmartBear AI. This tool automatically applies organization governance and standardization rules during API generation. The specType parameter determines the format of the generated definition. Use: 'openapi20' for OpenAPI 2.0, 'openapi30x' for OpenAPI 3.0.x, 'openapi31x' for OpenAPI 3.1.x, 'asyncapi2xx' for AsyncAPI 2.x, 'asyncapi30x' for AsyncAPI 3.0.x. Use this tool when creating APIs that comply with governance policies or when generating APIs from natural language descriptions. Use this tool when users ask to create, generate, or design APIs with governance or standardization requirements. Returns HTTP 201 for creation, HTTP 200 for update. Response includes 'operation' field indicating whether it was a 'create' or 'update' operation along with API details and SwaggerHub URL.
+
+**Parameters:**
+- owner (string) *required*: API owner (organization or user, case-sensitive)
+- apiName (string) *required*: API name
+- prompt (string) *required*: The prompt describing the desired API functionality (e.g., 'Create a RESTful API for managing a pet store with endpoints for pets, orders, and inventory')
+- specType (enum): Specification type for the generated API definition. Use: 'openapi20' for OpenAPI 2.0, 'openapi30x' for OpenAPI 3.0.x (default), 'openapi31x' for OpenAPI 3.1.x, 'asyncapi2xx' for AsyncAPI 2.x, 'asyncapi30x' for AsyncAPI 3.0.x (default: "openapi30x")",
+    "inputSchema": [
+      "apiName",
+      "owner",
+      "prompt",
+      "specType",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Create API from Prompt",
+  },
+  "swagger_create_or_update_api": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Create or Update API",
+    },
+    "description": "Create a new API or update an existing API in SwaggerHub Registry for Swagger Studio. The API specification type (OpenAPI, AsyncAPI) is automatically detected from the definition content. APIs are always created with fixed values: version 1.0.0, private visibility, and automock disabled (these values cannot be changed). Returns HTTP 201 for creation, HTTP 200 for update. Response includes 'operation' field indicating whether it was a 'create' or 'update' operation along with API details and SwaggerHub URL.
+
+**Parameters:**
+- owner (string) *required*: Organization name (owner of the API)
+- apiName (string) *required*: API name
+- definition (string) *required*: API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. API is created with fixed values: version 1.0.0, private visibility, automock disabled, and no project assignment.",
+    "inputSchema": [
+      "apiName",
+      "definition",
+      "owner",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Create or Update API",
+  },
+  "swagger_create_portal": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Create Portal",
+    },
+    "description": "Create a new portal within Swagger.
+
+**Parameters:**
+- name (string): The display name for the portal - shown to users and in branding (3-40 characters)
+- subdomain (string) *required*: The portal subdomain - used in the portal URL (e.g., 'myportal' for myportal.example.com). Must be unique, lowercase, 3-20 characters, alphanumeric with hyphens
+- offline (boolean): If true, the portal will not be visible to customers - useful for development/staging environments. Defaults to false
+- routing (string): Routing strategy for the portal - either 'browser' (client-side routing) or 'proxy' (server-side routing). Defaults to 'browser'
+- credentialsEnabled (boolean): Whether authentication credentials are enabled for accessing the portal. When true, users can authenticate to access private content. Defaults to true
+- swaggerHubOrganizationId (string) *required*: The corresponding SwaggerHub organization UUID - required for portal creation. This links the portal to your SwaggerHub organization
+- openapiRenderer (string): OpenAPI renderer type: 'SWAGGER_UI' (Swagger UI), 'ELEMENTS' (Stoplight Elements), or 'TOGGLE' (allows switching between both with Elements as default). Defaults to 'TOGGLE'
+- pageContentFormat (string): Format for page content rendering - determines how documentation pages are processed: 'HTML', 'MARKDOWN', or 'BOTH'. Defaults to 'HTML'",
+    "inputSchema": [
+      "credentialsEnabled",
+      "name",
+      "offline",
+      "openapiRenderer",
+      "pageContentFormat",
+      "routing",
+      "subdomain",
+      "swaggerHubOrganizationId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Create Portal",
+  },
+  "swagger_create_portal_product": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Create Portal Product",
+    },
+    "description": "Create a new product for a specific portal.
+
+**Parameters:**
+- portalId (string) *required*: Portal UUID or subdomain - unique identifier for the portal instance
+- type (string) *required*: Product creation type - 'new' to create from scratch or 'copy' to duplicate an existing product
+- productId (string): Source product UUID to copy from - required when type is 'copy', specifies which existing product to duplicate. Omit when type is 'new'
+- name (string) *required*: Product display name - will be shown to users in the portal navigation and product listings (3-40 characters)
+- slug (string) *required*: URL-friendly identifier for the product - must be unique within the portal, used in URLs (e.g., 'my-api' becomes /my-api). 3-22 characters, lowercase, alphanumeric with hyphens, underscores, or dots
+- description (string): Product description - explains what the API/product does, shown in product listings and cards (max 110 characters)
+- public (boolean): Whether the product is publicly visible to all portal visitors - false means only authenticated users with appropriate roles can access it
+- hidden (boolean): Whether the product is hidden from the portal landing page navigation menus - useful for internal or draft products
+- role (boolean): Whether the product has role-based access restrictions - controls if specific user roles are required to access the product",
+    "inputSchema": [
+      "description",
+      "hidden",
+      "name",
+      "portalId",
+      "productId",
+      "public",
+      "role",
+      "slug",
+      "type",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Create Portal Product",
+  },
+  "swagger_create_table_of_contents": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Create Table Of Contents",
+    },
+    "description": "Create a new table of contents item in a portal product section. Supports API references, HTML content, and Markdown content types.
+
+**Parameters:**
+- sectionId (string) *required*: Section ID - unique identifier for the section within the product
+- type (enum) *required*: Type of table of contents creation - 'new' to create from scratch or 'copy' to duplicate an existing one
+- title (string) *required*: Title of the table of contents item - will be displayed in navigation (3-40 characters)
+- slug (string) *required*: URL-friendly identifier for the table of contents item - must be unique within the section (3-22 characters, lowercase, alphanumeric with hyphens/underscores/dots)
+- order (number) *required*: Order position of the table of contents item within its parent section or item
+- parentId (string): Parent table of contents item ID - null for top-level items, or ID of parent item for nested structure
+- content (object): Content configuration for the table of contents item",
+    "inputSchema": [
+      "content",
+      "order",
+      "parentId",
+      "sectionId",
+      "slug",
+      "title",
+      "type",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Create Table Of Contents",
+  },
+  "swagger_delete_portal_product": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Delete Portal Product",
+    },
+    "description": "Delete a product from a specific portal
+
+**Parameters:**
+- productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product",
+    "inputSchema": [
+      "productId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Delete Portal Product",
+  },
+  "swagger_delete_table_of_contents": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Delete Table Of Contents",
+    },
+    "description": "Delete table of contents entry. Performs a soft-delete of an entry from the table of contents. Supports recursive deletion of nested items.
+
+**Parameters:**
+- tableOfContentsId (string) *required*: The table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
+- recursive (boolean): Flag to include all the nested tables of contents (default: false)",
+    "inputSchema": [
+      "recursive",
+      "tableOfContentsId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Delete Table Of Contents",
+  },
+  "swagger_get_api_definition": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Get API Definition",
+    },
+    "description": "Fetch resolved API definition from SwaggerHub Registry based on owner, API name, and version.
+
+**Parameters:**
+- owner (string) *required*: API owner (organization or user, case-sensitive)
+- api (string) *required*: API name (case-sensitive)
+- version (string) *required*: Version identifier
+- resolved (boolean): Set to true to get the resolved version with all external $refs included (default false)
+- flatten (boolean): Set to true to create models from inline schemas in OpenAPI definition (default false)",
+    "inputSchema": [
+      "api",
+      "flatten",
+      "owner",
+      "resolved",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Get API Definition",
+  },
+  "swagger_get_document": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Get Document",
+    },
+    "description": "Get document content and metadata by document ID. Useful for retrieving HTML or Markdown content from table of contents items.
+
+**Parameters:**
+- documentId (string) *required*: Document UUID - unique identifier for the document",
+    "inputSchema": [
+      "documentId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Get Document",
+  },
+  "swagger_get_portal": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Get Portal",
+    },
+    "description": "Retrieve information about a specific portal.
+
+**Parameters:**
+- portalId (string) *required*: Portal UUID or subdomain - unique identifier for the portal instance",
+    "inputSchema": [
+      "portalId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Get Portal",
+  },
+  "swagger_get_portal_product": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Get Portal Product",
+    },
+    "description": "Retrieve information about a specific product resource.
+
+**Parameters:**
+- productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product",
+    "inputSchema": [
+      "productId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Get Portal Product",
+  },
+  "swagger_list_organizations": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: List Organizations",
+    },
+    "description": "Get organizations for a user. Returns a list of organizations that the authenticating user is a member of. On-Premise admin gets a list of all organizations in the system.
+
+**Parameters:**
+- q (string): Search organizations by partial or full name (case-insensitive)
+- sortBy (enum): The property to sort the results by
+- order (enum): Sort order
+- page (number): 0-based index of the page to return
+- pageSize (number): Number of results per page to return",
+    "inputSchema": [
+      "order",
+      "page",
+      "pageSize",
+      "q",
+      "sortBy",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: List Organizations",
+  },
+  "swagger_list_portal_product_sections": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: List Portal Product Sections",
+    },
+    "description": "Get sections for a specific product within a portal.
+
+**Parameters:**
+- productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product
+- embed (array): List of related entities to embed in the response - e.g., ['tableOfContents', 'tableOfContents.swaggerhubApi'] to include table of contents and SwaggerHub API details
+- page (number): Page number for paginated results - specifies which page of results to retrieve (default is 1)
+- size (number): Number of items per page for pagination - controls how many results are returned per page (default is 20)",
+    "inputSchema": [
+      "embed",
+      "page",
+      "productId",
+      "size",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: List Portal Product Sections",
+  },
+  "swagger_list_portal_products": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: List Portal Products",
+    },
+    "description": "Get products for a specific portal that match your criteria.
+
+**Parameters:**
+- portalId (string) *required*: Portal UUID or subdomain - unique identifier for the portal instance",
+    "inputSchema": [
+      "portalId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: List Portal Products",
+  },
+  "swagger_list_portals": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: List Portals",
+    },
+    "description": "Search for available portals within Swagger. Only portals where you have at least a designer role, either at the product level or organization level, are returned.",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "Swagger: List Portals",
+  },
+  "swagger_list_table_of_contents": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: List Table Of Contents",
+    },
+    "description": "Get table of contents for a section of a product within a portal.
+
+**Parameters:**
+- sectionId (string) *required*: Section ID - unique identifier for the section within the product
+- embed (array): List of related entities to embed in the response - e.g., ['swaggerhubApi'] to include SwaggerHub API details
+- page (number): Page number for paginated results - specifies which page of results to retrieve (default is 1)
+- size (number): Number of items per page for pagination - controls how many results are returned per page (default is 20)",
+    "inputSchema": [
+      "embed",
+      "page",
+      "sectionId",
+      "size",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: List Table Of Contents",
+  },
+  "swagger_publish_portal_product": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Publish Portal Product",
+    },
+    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
+
+**Parameters:**
+- productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product
+- preview (boolean): Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) (default: false)",
+    "inputSchema": [
+      "preview",
+      "productId",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Publish Portal Product",
+  },
+  "swagger_scan_api_standardization": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Scan API Standardization",
+    },
+    "description": "Run a standardization scan against an API definition using the organization's governance and standardization rules. Accepts a YAML or JSON OpenAPI/AsyncAPI definition and returns a list of standardization errors and validation issues. Use this tool when users ask to validate, scan, or check API governance or standardization.
+
+**Parameters:**
+- orgName (string) *required*: The organization name to use for standardization rules
+- definition (string) *required*: API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format) to scan for standardization errors",
+    "inputSchema": [
+      "definition",
+      "orgName",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Scan API Standardization",
+  },
+  "swagger_search_apis_and_domains": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Search APIs and Domains",
+    },
+    "description": "Search for APIs and Domains in SwaggerHub Registry using the comprehensive /specs endpoint and retrieve metadata including owner, name, description, summary, version, and specification.
+
+**Parameters:**
+- query (string): Search query to filter APIs by name, description, or content
+- state (enum): Filter APIs by publication state - ALL (default), PUBLISHED, or UNPUBLISHED
+- tag (string): Filter APIs by tag
+- offset (number): Offset for pagination (0-based, default 0)
+- limit (number): Number of results per page (1-100, default 20)
+- sort (enum): Sort field - NAME, UPDATED, or CREATED (default NAME)
+- order (enum): Sort order - ASC or DESC (default ASC)
+- owner (string): Filter APIs by owner (organization or user)
+- specType (enum): Filter by specification type - API or DOMAIN (default all types)",
+    "inputSchema": [
+      "limit",
+      "offset",
+      "order",
+      "owner",
+      "query",
+      "sort",
+      "specType",
+      "state",
+      "tag",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Search APIs and Domains",
+  },
+  "swagger_standardize_api": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Standardize API",
+    },
+    "description": "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found and the fixed definition if successful. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.
+
+**Parameters:**
+- owner (string) *required*: API owner (organization or user, case-sensitive)
+- api (string) *required*: API name (case-sensitive)
+- version (string) *required*: Version identifier
+- newVersion (string): The version to save the fixed definition as (e.g. '1.0.1'). Omitting this will overwrite the current version — prefer providing a patch bump (e.g. '1.0.0' → '1.0.1') unless the user specifies otherwise.",
+    "inputSchema": [
+      "api",
+      "newVersion",
+      "owner",
+      "version",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Standardize API",
+  },
+  "swagger_update_document": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Update Document",
+    },
+    "description": "Update the content or source of an existing document. Supports both HTML and Markdown content types.
+
+**Parameters:**
+- documentId (string) *required*: Document UUID - unique identifier for the document
+- content (string): The document content to update (HTML or Markdown based on document type)
+- type (enum): Content type - 'html' for HTML content or 'markdown' for Markdown content
+- source (enum): Source of the document content - 'internal' allows to edit content in both UI and API, 'external' enables editing only via API.",
+    "inputSchema": [
+      "content",
+      "documentId",
+      "source",
+      "type",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Update Document",
+  },
+  "swagger_update_portal": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Update Portal",
+    },
+    "description": "Update a specific portal's configuration.
+
+**Parameters:**
+- portalId (string) *required*: Portal UUID or subdomain - unique identifier for the portal instance
+- name (string): Update the portal display name - shown to users and in branding (3-40 characters)
+- subdomain (string): Update the portal subdomain - changes the portal URL. Must remain unique across all portals (3-20 characters, lowercase, alphanumeric with hyphens)
+- customDomain (boolean): Enable/disable custom domain for the portal - allows using your own domain instead of the default subdomain
+- gtmKey (string): Google Tag Manager key for analytics tracking - format: GTM-XXXXXX (max 25 characters)
+- offline (boolean): Set portal visibility - true hides portal from customers (useful for maintenance or development)
+- routing (string): Update routing strategy - 'browser' for client-side routing or 'proxy' for server-side routing
+- credentialsEnabled (boolean): Enable/disable authentication credentials for portal access - controls whether users can authenticate to view private content
+- openapiRenderer (string): Change OpenAPI renderer: 'SWAGGER_UI' (Swagger UI), 'ELEMENTS' (Stoplight Elements), or 'TOGGLE' (switch between both)
+- pageContentFormat (string): Update page content format for documentation rendering: 'HTML', 'MARKDOWN', or 'BOTH'",
+    "inputSchema": [
+      "credentialsEnabled",
+      "customDomain",
+      "gtmKey",
+      "name",
+      "offline",
+      "openapiRenderer",
+      "pageContentFormat",
+      "portalId",
+      "routing",
+      "subdomain",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Update Portal",
+  },
+  "swagger_update_portal_product": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Swagger: Update Portal Product",
+    },
+    "description": "Update a product's settings within a specific portal.
+
+**Parameters:**
+- productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product
+- name (string): Update product display name - changes how it appears to users in navigation and listings (3-40 characters)
+- slug (string): Update URL-friendly identifier - must remain unique within the portal, affects product URLs (3-22 characters, lowercase, alphanumeric with hyphens/underscores/dots)
+- description (string): Update product description - explains the API/product functionality, shown in listings (max 110 characters)
+- public (boolean): Change product visibility - true makes it publicly accessible to all visitors, false restricts to authenticated users with roles
+- hidden (boolean): Change navigation visibility - true hides from portal landing page menus while keeping the product accessible via direct links",
+    "inputSchema": [
+      "description",
+      "hidden",
+      "name",
+      "productId",
+      "public",
+      "slug",
+    ],
+    "outputSchema": undefined,
+    "title": "Swagger: Update Portal Product",
+  },
+  "zephyr_create_folder": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Folder",
+    },
+    "description": "Create a folder called 'Axial Pump Tests' in the project SA for organizing test cases
+
+**Parameters:**
+- parentId (number): Folder ID of the parent folder. Must be \`null\` for root folders.
+- name (string) *required*: Folder name. Folder name must not contain \`/\` and \`\\\` characters.
+- projectKey (string) *required*: Jira project key.
+- folderType (string) *required*: Valid values: \`"TEST_CASE"\`, \`"TEST_PLAN"\`, \`"TEST_CYCLE"\`
+
+**Examples:**
+1. Create a root Folder in project SA for organizing test cases
+\`\`\`json
+{
+  "parentId": null,
+  "name": "Axial Pump Tests",
+  "projectKey": "SA",
+  "folderType": "TEST_CASE"
+}
+\`\`\`
+Expected Output: The newly created Folder with its ID and self link
+
+2. Create a sub-folder under folder ID 5 in the project MM2 for test plans related to pumps
+\`\`\`json
+{
+  "parentId": 5,
+  "name": "Pump-related Test Plans",
+  "projectKey": "MM2",
+  "folderType": "TEST_PLAN"
+}
+\`\`\`
+Expected Output: The newly created Folder with its ID and self link
+
+3. Create a Folder called 'Regression Cycles' in project TIS for organizing test cycles
+\`\`\`json
+{
+  "parentId": null,
+  "name": "Regression Cycles",
+  "projectKey": "TIS",
+  "folderType": "TEST_CYCLE"
+}
+\`\`\`
+Expected Output: The newly created Folder with its ID and self link",
+    "inputSchema": [
+      "folderType",
+      "name",
+      "parentId",
+      "projectKey",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Folder",
+  },
+  "zephyr_create_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Case",
+    },
+    "description": "Create a new Test Case in Zephyr specified project
+
+**Parameters:**
+- projectKey (string) *required*: Jira project key.
+- name (string) *required*
+- objective (string): A description of the objective.
+- precondition (string): Any conditions that need to be met.
+- estimatedTime (number): Estimated duration in milliseconds.
+- componentId (number): ID of a component from Jira.
+- priorityName (string): The priority name.
+- statusName (string): The status name.
+- folderId (number): ID of a folder to place the entity within.
+- ownerId (string): Atlassian Account ID of the Jira user.
+- labels (array): Array of labels associated to this entity.
+- customFields (record<string, any>): Multi-line text fields support HTML and should denote new lines with the \\<br\\> tag.
+Dates should be in the format 'yyyy-MM-dd'.
+Users should have values of Jira User Account IDs.
+
+
+**Examples:**
+1. Create a Test Case in project SA to ensure that the axial pump can be enabled
+\`\`\`json
+{
+  "projectKey": "SA",
+  "name": "Check axial pump",
+  "objective": "Ensure the axial pump can be enabled"
+}
+\`\`\`
+Expected Output: The newly created Test Case with its details and key
+
+2. Create a Test Case to ensure that the axial pump can be enabled. The test should be in project MM2, have labels 'automated' and 'mcp', and priority 'High'
+\`\`\`json
+{
+  "projectKey": "MM2",
+  "name": "Check axial pump",
+  "objective": "Ensure the axial pump can be enabled",
+  "labels": [
+    "automated",
+    "mcp"
+  ],
+  "priorityName": "High"
+}
+\`\`\`
+Expected Output: The newly created Test Case with its details and key
+
+3. Create a Test Case for verifying strength of the axial pump with custom field 'Axial pump strength' having value '5' in project SA
+\`\`\`json
+{
+  "projectKey": "SA",
+  "name": "Check axial pump strength",
+  "objective": "Make sure the axial pump operates at the required strength",
+  "customFields": {
+    "Axial pump strength": 5
+  }
+}
+\`\`\`
+Expected Output: The newly created Test Case with its details and key
+
+4. Create a Test Case in project MM2 to verify the performance of the axial pump with Jira component having ID 10001, Jira owner having ID 10057 in folder 'Pumps'
+\`\`\`json
+{
+  "projectKey": "MM2",
+  "name": "Check axial pump performance",
+  "objective": "Ensure the axial pump performs within acceptable limits",
+  "componentId": 10001,
+  "ownerJiraUserId": 10057,
+  "folderId": 18
+}
+\`\`\`
+Expected Output: The newly created Test Case with its details and key",
+    "inputSchema": [
+      "componentId",
+      "customFields",
+      "estimatedTime",
+      "folderId",
+      "labels",
+      "name",
+      "objective",
+      "ownerId",
+      "precondition",
+      "priorityName",
+      "projectKey",
+      "statusName",
+    ],
+    "outputSchema": [
+      "id",
+      "key",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Case",
+  },
+  "zephyr_create_test_case_issue_link": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Case Issue Link",
+    },
+    "description": "Create a new link between an issue in Jira and a Test Case in Zephyr
+
+**Examples:**
+1. Create a link between the test case SA-T1 and the Jira Issue ID 10100
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "issueId": "10100"
+}
+\`\`\`
+Expected Output: The newly created Issue Link with its ID and self link",
+    "inputSchema": [
+      "issueId",
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Case Issue Link",
+  },
+  "zephyr_create_test_case_steps": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Case Steps",
+    },
+    "description": "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: \`APPEND\` adds steps to the end of the existing list, \`OVERWRITE\` deletes all existing steps and replaces them with the provided ones. Always ask the user to choose between OVERWRITE or APPEND before calling this tool.
+
+**Examples:**
+1. To the Test Case SA-T1, add steps that will test a login page.
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "mode": "APPEND",
+  "items": [
+    {
+      "inline": {
+        "description": "Navigate to the login page",
+        "expectedResult": "Login page is displayed"
+      }
+    },
+    {
+      "inline": {
+        "description": "Enter valid credentials and click Submit",
+        "expectedResult": "User is redirected to the dashboard"
+      }
+    }
+  ]
+}
+\`\`\`
+Expected Output: The ID of the Test Steps resource and the API self URL to fetch it
+
+2. To the Test Case MM2-T15, replace all existing steps with new ones that test the settings page for an Admin user.
+\`\`\`json
+{
+  "testCaseKey": "MM2-T15",
+  "mode": "OVERWRITE",
+  "items": [
+    {
+      "inline": {
+        "description": "Open the settings page",
+        "testData": "User role: Admin",
+        "expectedResult": "Settings page is accessible"
+      }
+    },
+    {
+      "inline": {
+        "description": "Change the notification preference",
+        "testData": "Preference: Email only",
+        "expectedResult": "Notification preference is updated successfully"
+      }
+    }
+  ]
+}
+\`\`\`
+Expected Output: The ID of the Test Steps resource and the API self URL to fetch it
+
+3. To the Test Case SA-T1, add a step that reuses the steps from the Test Case PRJ-T42
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "mode": "APPEND",
+  "items": [
+    {
+      "testCase": {
+        "testCaseKey": "PRJ-T42"
+      }
+    }
+  ]
+}
+\`\`\`
+Expected Output: The ID of the Test Steps resource and the API self URL to fetch it",
+    "inputSchema": [
+      "items",
+      "mode",
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Case Steps",
+  },
+  "zephyr_create_test_case_web_link": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Case Web Link",
+    },
+    "description": "Create a new Web Link for a Test Case in Zephyr
+
+**Parameters:**
+- description (string): The web link description
+- url (string) *required*: The web link URL
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+
+**Examples:**
+1. Create a web link for test case SA-T1 pointing to Atlassian's homepage
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "url": "https://www.atlassian.com",
+  "description": "Link to Atlassian's homepage"
+}
+\`\`\`
+Expected Output: The newly created Web Link with its ID and self link
+
+2. Attach a documentation link to test case MM2-T15 for pump specifications
+\`\`\`json
+{
+  "testCaseKey": "MM2-T15",
+  "url": "https://docs.atlassian.com",
+  "description": "Documentation for pump specifications"
+}
+\`\`\`
+Expected Output: The newly created Web Link with its ID and self link",
+    "inputSchema": [
+      "description",
+      "testCaseKey",
+      "url",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Case Web Link",
+  },
+  "zephyr_create_test_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Cycle",
+    },
+    "description": "Create a new Test Cycle in Zephyr specified project
+
+**Parameters:**
+- projectKey (string) *required*: Jira project key.
+- name (string) *required*
+- description (string): Description outlining the scope.
+- plannedStartDate (string): Planned start date of the test cycle. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- plannedEndDate (string): The planned end date of the test cycle. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- jiraProjectVersion (number): Jira Project Version ID. Relates to 'Version' or 'Releases' in Jira projects.
+- statusName (string): The status name.
+- folderId (number): ID of a folder to place the entity within.
+- ownerId (string): Atlassian Account ID of the Jira user.
+- customFields (record<string, any>): Multi-line text fields support HTML and should denote new lines with the \\<br\\> tag.
+Dates should be in the format 'yyyy-MM-dd'.
+Users should have values of Jira User Account IDs.
+
+
+**Examples:**
+1. Create a Test Cycle in project SA to ensure that the axial pump can be enabled
+\`\`\`json
+{
+  "projectKey": "SA",
+  "name": "Check axial pump",
+  "description": "Ensure the axial pump can be enabled"
+}
+\`\`\`
+Expected Output: The newly created Test Cycle with its details and key
+
+2. Create a Test Cycle to ensure that the axial pump can be enabled. The test cycle should be in project MM2, have status 'In Progress', and be planned from 2026-03-01 to 2026-03-10
+\`\`\`json
+{
+  "projectKey": "MM2",
+  "name": "Check axial pump",
+  "description": "Ensure the axial pump can be enabled",
+  "statusName": "In Progress",
+  "plannedStartDate": "2026-03-01T00:00:00Z",
+  "plannedEndDate": "2026-03-10T00:00:00Z"
+}
+\`\`\`
+Expected Output: The newly created Test Cycle with its details and key
+
+3. Create a Test Cycle for verifying strength of the axial pump with custom field 'Axial pump strength' having value '5' in project SA
+\`\`\`json
+{
+  "projectKey": "SA",
+  "name": "Check axial pump strength",
+  "description": "Make sure the axial pump operates at the required strength",
+  "customFields": {
+    "Axial pump strength": 5
+  }
+}
+\`\`\`
+Expected Output: The newly created Test Cycle with its details and key
+
+4. Create a Test Cycle in project MM2 to verify the performance of the axial pump with Jira Project Version ID 10001, owner Atlassian Account ID '12', in folder with ID 18
+\`\`\`json
+{
+  "projectKey": "MM2",
+  "name": "Check axial pump performance",
+  "description": "Ensure the axial pump performs within acceptable limits",
+  "jiraProjectVersion": 10001,
+  "ownerId": "12",
+  "folderId": 18
+}
+\`\`\`
+Expected Output: The newly created Test Cycle with its details and key",
+    "inputSchema": [
+      "customFields",
+      "description",
+      "folderId",
+      "jiraProjectVersion",
+      "name",
+      "ownerId",
+      "plannedEndDate",
+      "plannedStartDate",
+      "projectKey",
+      "statusName",
+    ],
+    "outputSchema": [
+      "id",
+      "key",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Cycle",
+  },
+  "zephyr_create_test_cycle_issue_link": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Cycle Issue Link",
+    },
+    "description": "Create a new link between an issue in Jira and a Test Cycle in Zephyr
+
+**Examples:**
+1. Create a link between the test cycle with key SA-R1 and the Jira Issue ID 10100
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R1",
+  "issueId": 10100
+}
+\`\`\`
+Expected Output: The link between Test Cycle and Jira issue should be created, but no output is expected.
+
+2. Create a link between the test cycle with ID 1001 and the Jira issue ID 20200
+\`\`\`json
+{
+  "testCycleIdOrKey": "1001",
+  "issueId": 20200
+}
+\`\`\`
+Expected Output: The link between Test Cycle and Jira issue should be created, but no output is expected.",
+    "inputSchema": [
+      "issueId",
+      "testCycleIdOrKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Create Test Cycle Issue Link",
+  },
+  "zephyr_create_test_cycle_web_link": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Cycle Web Link",
+    },
+    "description": "Create a new Web Link for a Test Cycle in Zephyr
+
+**Examples:**
+1. Create a link between the specified test cycle by Id '100001' and generic URL 'https://www.atlassian.com' with description 'Atlassian homepage'
+\`\`\`json
+{
+  "testCycleIdOrKey": "100001",
+  "url": "https://www.atlassian.com",
+  "description": "Atlassian homepage"
+}
+\`\`\`
+Expected Output: The newly created Web Link with its ID and self link
+
+2. Create a web link for test cycle 'SA-R15' pointing to url: 'https://atlassian.com' with description 'Atlassian homepage'
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R15",
+  "url": "https://atlassian.com",
+  "description": "Documentation for pump specifications"
+}
+\`\`\`
+Expected Output: The newly created Web Link with its ID and self link
+
+3. Attach a documentation link 'https://docs.atlassian.com'  to test cycle MM2-R15 for pump specifications
+\`\`\`json
+{
+  "testCycleIdOrKey": "10001",
+  "url": "https://docs.atlassian.com",
+  "description": "Documentation for pump specifications"
+}
+\`\`\`
+Expected Output: The newly created Web Link with its ID and self link",
+    "inputSchema": [
+      "description",
+      "testCycleIdOrKey",
+      "url",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Create Test Cycle Web Link",
+  },
+  "zephyr_create_test_execution": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Execution",
+    },
+    "description": "Create a new Test Execution for a Test Case within a specific Test Cycle
+
+**Parameters:**
+- projectKey (string) *required*: Jira project key.
+- testCaseKey (string) *required*: Key of test case the execution applies to. NOTE: Test cases with call to test, parameters and test data are not supported.
+- testCycleKey (string) *required*: Key of test cycle the execution applies to.
+- statusName (string) *required*: The status name.
+- testScriptResults (array)
+- environmentName (string): Environment assigned to the test case.
+- actualEndDate (string): The actual end date of the test cycle. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- executionTime (number): Actual test execution time in milliseconds.
+- executedById (string): Atlassian Account ID of the Jira user.
+- assignedToId (string): Atlassian Account ID of the Jira user.
+- comment (string): Comment added against overall test case execution.
+- customFields (record<string, any>): Multi-line text fields support HTML and should denote new lines with the \\<br\\> tag.
+Dates should be in the format 'yyyy-MM-dd'.
+Users should have values of Jira User Account IDs.
+
+
+**Examples:**
+1. Create a Passed execution for test case SA-T1 in cycle SA-R1
+\`\`\`json
+{
+  "projectKey": "SA",
+  "testCaseKey": "SA-T1",
+  "testCycleKey": "SA-R1",
+  "statusName": "Pass"
+}
+\`\`\`
+Expected Output: The newly created Test Execution with execution details
+
+2. Create a Failed execution with execution time, environment and comment
+\`\`\`json
+{
+  "projectKey": "MM2",
+  "testCaseKey": "MM2-T15",
+  "testCycleKey": "MM2-R3",
+  "statusName": "Fail",
+  "environmentName": "Staging",
+  "executionTime": 125000,
+  "comment": "Step 3 failed due to timeout<br>Logs attached."
+}
+\`\`\`
+Expected Output: The newly created Test Execution including environment and timing information
+
+3. Create execution with custom fields and assignment
+\`\`\`json
+{
+  "projectKey": "SA",
+  "testCaseKey": "SA-T5",
+  "testCycleKey": "SA-R2",
+  "statusName": "Pass",
+  "executedById": "5b10ac8d82e05b22cc7d4ef5",
+  "assignedToId": "5b10ac8d82e05b22cc7d4ef6",
+  "actualEndDate": "2026-02-17T10:15:30Z",
+  "customFields": {
+    "Execution Build": "1.0.3",
+    "Tested Browser": "Chrome",
+    "Execution Date": "2026-02-17"
+  }
+}
+\`\`\`
+Expected Output: The newly created Test Execution including custom field values",
+    "inputSchema": [
+      "actualEndDate",
+      "assignedToId",
+      "comment",
+      "customFields",
+      "environmentName",
+      "executedById",
+      "executionTime",
+      "projectKey",
+      "statusName",
+      "testCaseKey",
+      "testCycleKey",
+      "testScriptResults",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Execution",
+  },
+  "zephyr_create_test_execution_issue_link": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Execution Issue Link",
+    },
+    "description": "Create a new link between a Jira issue and a Test Execution in Zephyr
+
+**Examples:**
+1. Create a link between the test execution with key SA-E40 and the Jira Issue ID 10100
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E40",
+  "issueId": 10100
+}
+\`\`\`
+Expected Output: The link between Test Execution and Jira issue should be created, but no output is expected.
+
+2. Create a link between the test execution with ID 1 and the Jira Issue ID 20050
+\`\`\`json
+{
+  "testExecutionIdOrKey": "1",
+  "issueId": 20050
+}
+\`\`\`
+Expected Output: The link between Test Execution and Jira issue should be created, but no output is expected.",
+    "inputSchema": [
+      "issueId",
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Create Test Execution Issue Link",
+  },
+  "zephyr_create_test_script": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Create Test Script",
+    },
+    "description": "Create a new Test Script of the types Plain Text or BDD in a Zephyr Test Case.
+
+**Examples:**
+1. Create a plain text test script for test case SA-T1 to verify that the axial pump can be enabled
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "type": "plain",
+  "text": "1. Navigate to Pump Settings</br>2. Enable Axial Pump</br>3. Verify pump status is 'Active'"
+}
+\`\`\`
+Expected Output: The created test script metadata including its id and self link
+
+2. Create a BDD test script for test case MM2-T15 to validate axial pump activation
+\`\`\`json
+{
+  "testCaseKey": "MM2-T15",
+  "type": "bdd",
+  "text": "Given the axial pump is installed\\nWhen the user enables the axial pump\\nThen the pump status should be Active"
+}
+\`\`\`
+Expected Output: The created test script metadata including its id and self link
+
+3. Create a BDD test script for test case QA-T100 for axial pump performance validation
+\`\`\`json
+{
+  "testCaseKey": "QA-T100",
+  "type": "bdd",
+  "text": "Given the system is running\\nWhen the axial pump operates under load\\nThen performance metrics should remain within thresholds"
+}
+\`\`\`
+Expected Output: The created test script metadata including its id and self link",
+    "inputSchema": [
+      "testCaseKey",
+      "text",
+      "type",
+    ],
+    "outputSchema": [
+      "id",
+      "self",
+    ],
+    "title": "Zephyr: Create Test Script",
+  },
+  "zephyr_get_environments": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Environments",
+    },
+    "description": "Get environments in Zephyr
+
+**Parameters:**
+- projectKey (string): Jira project key filter
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+
+**Examples:**
+1. Get the first 20 Environments
+\`\`\`json
+{
+  "maxResults": 20,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 20 Environments with their details from different projects
+
+2. Get the first 10 Environments from the project with projectKey TEST
+\`\`\`json
+{
+  "projectKey": "TEST",
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 Environments with their details from project with projectKey TEST
+
+3. Get second 10 Environments from the project with projectKey TEST
+\`\`\`json
+{
+  "projectKey": "TEST",
+  "maxResults": 10,
+  "startAt": 10
+}
+\`\`\`
+Expected Output: The second 10 Environments with their details from project with projectKey TEST
+
+4. Get Environments starting from the 5th Environment from different projects
+\`\`\`json
+{
+  "startAt": 5,
+  "maxResults": 10
+}
+\`\`\`
+Expected Output: Environments starting from the 5th one with their details from different projects
+
+5. Get 5 Environments starting from the 10th Environment from the project with projectKey PROJ
+\`\`\`json
+{
+  "startAt": 10,
+  "maxResults": 5,
+  "projectKey": "PROJ"
+}
+\`\`\`
+Expected Output: The five environments starting from the 10th Environment from the project PROJ with their details",
+    "inputSchema": [
+      "maxResults",
+      "projectKey",
+      "startAt",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Environments",
+  },
+  "zephyr_get_issue_link_test_cases": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Issue Link Test Cases",
+    },
+    "description": "Get test cases linked to a Jira issue in Zephyr
+
+**Parameters:**
+- issueKey (string) *required*: The key of the Jira issue
+
+**Examples:**
+1. Check which test cases are linked to Jira issue PROJ-123
+\`\`\`json
+{
+  "issueKey": "PROJ-123"
+}
+\`\`\`
+Expected Output: The List of test cases linked to Jira issue PROJ-123 with their keys and versions",
+    "inputSchema": [
+      "issueKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Get Issue Link Test Cases",
+  },
+  "zephyr_get_priorities": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get priorities",
+    },
+    "description": "Get Zephyr Test Case priorities with optional filters
+
+**Parameters:**
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+- projectKey (string): Jira project key filter
+
+**Examples:**
+1. Get the first 10 priorities
+\`\`\`json
+{
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 priorities with their details
+
+2. Get priorities for a specific project
+\`\`\`json
+{
+  "projectKey": "PROJ"
+}
+\`\`\`
+Expected Output: The priorities for project PROJ
+
+3. Get all priorities
+\`\`\`json
+{}
+\`\`\`
+Expected Output: All priorities",
+    "inputSchema": [
+      "maxResults",
+      "projectKey",
+      "startAt",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get priorities",
+  },
+  "zephyr_get_project": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Project",
+    },
+    "description": "Get details of project specified by id or key in Zephyr
+
+**Parameters:**
+- projectIdOrKey (string) *required*: The Zephyr project ID or Jira project key
+
+**Examples:**
+1. Get the project with id 1
+\`\`\`json
+{
+  "projectIdOrKey": "1"
+}
+\`\`\`
+Expected Output: The project with its details
+
+2. Get the project with key 'PROJ'
+\`\`\`json
+{
+  "projectIdOrKey": "PROJ"
+}
+\`\`\`
+Expected Output: The project with its details",
+    "inputSchema": [
+      "projectIdOrKey",
+    ],
+    "outputSchema": [
+      "enabled",
+      "id",
+      "jiraProjectId",
+      "key",
+    ],
+    "title": "Zephyr: Get Project",
+  },
+  "zephyr_get_projects": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Projects",
+    },
+    "description": "Get details of projects in Zephyr
+
+**Parameters:**
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+
+**Examples:**
+1. Get the first 10 projects
+\`\`\`json
+{
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 projects with their details
+
+2. Get any project
+\`\`\`json
+{
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One project with its details
+
+3. Get five projects starting from the 7th project of the list
+\`\`\`json
+{
+  "maxResults": 5,
+  "startAt": 6
+}
+\`\`\`
+Expected Output: The 7th to the 11th projects with their details",
+    "inputSchema": [
+      "maxResults",
+      "startAt",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Projects",
+  },
+  "zephyr_get_statuses": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Statuses",
+    },
+    "description": "Get statuses of different types of test artifacts in Zephyr
+
+**Parameters:**
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+- projectKey (string): Jira project key filter
+- statusType (enum): Determines which type of entity the status belongs to.
+
+**Examples:**
+1. Get the first 10 statuses
+\`\`\`json
+{
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 statuses with their details from different projects and test artifact types
+
+2. Get 10 test case statuses
+\`\`\`json
+{
+  "maxResults": 10,
+  "statusType": "TEST_CASE"
+}
+\`\`\`
+Expected Output: A list of statuses related to test cases with their details
+
+3. Get five statuses from the project PROJ
+\`\`\`json
+{
+  "maxResults": 5,
+  "projectKey": "PROJ"
+}
+\`\`\`
+Expected Output: The first five statuses from the project PROJ with their details",
+    "inputSchema": [
+      "maxResults",
+      "projectKey",
+      "startAt",
+      "statusType",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Statuses",
+  },
+  "zephyr_get_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Case",
+    },
+    "description": "Get details of test case specified by key in Zephyr
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+
+**Examples:**
+1. Get the test case with key 'SA-T10'
+\`\`\`json
+{
+  "testCaseKey": "SA-T10"
+}
+\`\`\`
+Expected Output: The test case with its details
+
+2. Get the test case with key 'MM2-T1'
+\`\`\`json
+{
+  "testCaseKey": "MM2-T1"
+}
+\`\`\`
+Expected Output: The test case with its details",
+    "inputSchema": [
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "component",
+      "createdOn",
+      "customFields",
+      "estimatedTime",
+      "folder",
+      "id",
+      "key",
+      "labels",
+      "links",
+      "name",
+      "objective",
+      "owner",
+      "precondition",
+      "priority",
+      "project",
+      "status",
+      "testScript",
+    ],
+    "title": "Zephyr: Get Test Case",
+  },
+  "zephyr_get_test_case_links": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Case Links",
+    },
+    "description": "Get all links (issue links and web links) associated with a test case in Zephyr
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+
+**Examples:**
+1. Get all links associated with the test case with key 'SA-T10'
+\`\`\`json
+{
+  "testCaseKey": "SA-T10"
+}
+\`\`\`
+Expected Output: The links (issue links and web links) associated with the test case",
+    "inputSchema": [
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "issues",
+      "self",
+      "webLinks",
+    ],
+    "title": "Zephyr: Get Test Case Links",
+  },
+  "zephyr_get_test_case_steps": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Case Steps",
+    },
+    "description": "Get details of test case steps in Zephyr
+
+**Examples:**
+1. Get the first 10 test case steps for test case with key 'SA-T1'
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 test case steps with their details
+
+2. Get any test case step for test case with key 'SA-T1'
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One test case step with its details
+
+3. Get five test case steps starting from the 7th test case step of the list for test case with key 'SA-T1'
+\`\`\`json
+{
+  "testCaseKey": "SA-T1",
+  "maxResults": 5,
+  "startAt": 6
+}
+\`\`\`
+Expected Output: The 7th to the 11th test case steps with their details",
+    "inputSchema": [
+      "maxResults",
+      "startAt",
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Case Steps",
+  },
+  "zephyr_get_test_cases": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Cases",
+    },
+    "description": "Get details of test cases in Zephyr
+
+**Parameters:**
+- projectKey (string): Jira project key filter
+- folderId (number): Folder ID filter
+- limit (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the limit value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAtId (number): Zero-indexed starting position for ID-based pagination. (default: 0)
+- updatedAfter (string): Filter only entities updated after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+
+**Examples:**
+1. Get the first 10 Test Cases
+\`\`\`json
+{
+  "limit": 10,
+  "startAtId": 1
+}
+\`\`\`
+Expected Output: The first 10 Test Cases with their details
+
+2. Get any Test Case
+\`\`\`json
+{
+  "limit": 1
+}
+\`\`\`
+Expected Output: One Test Case with its details
+
+3. Get five Test Cases starting from the ID 123
+\`\`\`json
+{
+  "limit": 5,
+  "startAtId": 123
+}
+\`\`\`
+Expected Output: Five Test Cases starting from the ID 123 with their details
+
+4. Get one Test Case from the project PROJ
+\`\`\`json
+{
+  "projectKey": "PROJ",
+  "limit": 1
+}
+\`\`\`
+Expected Output: One Test Case from project PROJ with its details
+
+5. Get one Test Case from the folder with ID 123
+\`\`\`json
+{
+  "folderId": 123,
+  "limit": 1
+}
+\`\`\`
+Expected Output: One Test Case from folder with ID 123 with its details",
+    "inputSchema": [
+      "folderId",
+      "limit",
+      "projectKey",
+      "startAtId",
+      "updatedAfter",
+    ],
+    "outputSchema": [
+      "limit",
+      "next",
+      "nextStartAtId",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Cases",
+  },
+  "zephyr_get_test_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Cycle",
+    },
+    "description": "Get details of test cycle specified by id or key in Zephyr
+
+**Parameters:**
+- testCycleIdOrKey (string) *required*: The ID or key of the test cycle.
+
+**Examples:**
+1. Get the test cycle with id 1
+\`\`\`json
+{
+  "testCycleIdOrKey": "1"
+}
+\`\`\`
+Expected Output: The test cycle with its details
+
+2. Get the test cycle with key 'SA-R40'
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40"
+}
+\`\`\`
+Expected Output: The test cycle with its details",
+    "inputSchema": [
+      "testCycleIdOrKey",
+    ],
+    "outputSchema": [
+      "customFields",
+      "description",
+      "folder",
+      "id",
+      "jiraProjectVersion",
+      "key",
+      "links",
+      "name",
+      "owner",
+      "plannedEndDate",
+      "plannedStartDate",
+      "project",
+      "status",
+    ],
+    "title": "Zephyr: Get Test Cycle",
+  },
+  "zephyr_get_test_cycle_links": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Cycle Links",
+    },
+    "description": "Get all links (issues, web links, and test plans) associated with a test cycle in Zephyr
+
+**Parameters:**
+- testCycleIdOrKey (string) *required*: The ID or key of the test cycle.
+
+**Examples:**
+1. Get all links for test cycle with id 1
+\`\`\`json
+{
+  "testCycleIdOrKey": "1"
+}
+\`\`\`
+Expected Output: All links (issues, web links, test plans) for the test cycle
+
+2. Get all links for test cycle with key 'SA-R40'
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40"
+}
+\`\`\`
+Expected Output: All links (issues, web links, test plans) for the test cycle with key SA-R40",
+    "inputSchema": [
+      "testCycleIdOrKey",
+    ],
+    "outputSchema": [
+      "issues",
+      "self",
+      "testPlans",
+      "webLinks",
+    ],
+    "title": "Zephyr: Get Test Cycle Links",
+  },
+  "zephyr_get_test_cycles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Cycles",
+    },
+    "description": "Get details of Test Cycles in Zephyr
+
+**Parameters:**
+- projectKey (string): Jira project key filter
+- folderId (number): Folder ID filter
+- jiraProjectVersionId (number): Jira Project Version ID. Relates to 'Version' or 'Releases' in Jira projects.
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+
+**Examples:**
+1. Get the first 10 Test Cycles
+\`\`\`json
+{
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 Test Cycles with their details
+
+2. Get any Test Cycle
+\`\`\`json
+{
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One Test Cycle with its details
+
+3. Get five Test Cycles starting from the 7th Test Cycles of the list
+\`\`\`json
+{
+  "maxResults": 5,
+  "startAt": 6
+}
+\`\`\`
+Expected Output: The 7th to the 11th Test Cycles with their details
+
+4. Get one Test Cycle from the project PROJ
+\`\`\`json
+{
+  "projectKey": "PROJ",
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One Test Cycle from project PROJ with its details
+
+5. Get one Test Cycle from the folder with ID 123
+\`\`\`json
+{
+  "folderId": 123,
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One Test Cycle from folder with ID 123 with its details
+
+6. Get one Test Cycle from the version 456
+\`\`\`json
+{
+  "jiraProjectVersionId": 456,
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One Test Cycle from version 456 with its details",
+    "inputSchema": [
+      "folderId",
+      "jiraProjectVersionId",
+      "maxResults",
+      "projectKey",
+      "startAt",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Cycles",
+  },
+  "zephyr_get_test_cycles_linked_to_a_jira_issue": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Cycles linked to a Jira issue",
+    },
+    "description": "Get test cycles linked to a Jira issue in Zephyr
+
+**Parameters:**
+- issueKey (string) *required*: The key of the Jira issue
+
+**Examples:**
+1. Check which test cycles are linked to Jira issue PROJ-123
+\`\`\`json
+{
+  "issueKey": "PROJ-123"
+}
+\`\`\`
+Expected Output: The List of test cycles linked to Jira issue PROJ-123 with their IDs",
+    "inputSchema": [
+      "issueKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Get Test Cycles linked to a Jira issue",
+  },
+  "zephyr_get_test_execution": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Execution",
+    },
+    "description": "Get details of test execution specified by id or key in Zephyr
+
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+
+**Examples:**
+1. Get the test execution with id 1
+\`\`\`json
+{
+  "testExecutionIdOrKey": "1"
+}
+\`\`\`
+Expected Output: The test execution with its details
+
+2. Get the test execution with key 'PROJ-E123'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "PROJ-E123"
+}
+\`\`\`
+Expected Output: The test execution with its details",
+    "inputSchema": [
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": [
+      "actualEndDate",
+      "assignedToId",
+      "automated",
+      "comment",
+      "customFields",
+      "environment",
+      "estimatedTime",
+      "executedById",
+      "executionTime",
+      "id",
+      "jiraProjectVersion",
+      "key",
+      "links",
+      "project",
+      "testCase",
+      "testCycle",
+      "testExecutionStatus",
+    ],
+    "title": "Zephyr: Get Test Execution",
+  },
+  "zephyr_get_test_execution_links": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Execution Links",
+    },
+    "description": "Get links for a specific test execution in Zephyr
+
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+
+**Examples:**
+1. Get the links oftest execution with id 1
+\`\`\`json
+{
+  "testExecutionIdOrKey": "1"
+}
+\`\`\`
+Expected Output: The test execution links with its details
+
+2. Get the links of test execution with key 'PROJ-E123'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "PROJ-E123"
+}
+\`\`\`
+Expected Output: The test execution links with its details",
+    "inputSchema": [
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": [
+      "issues",
+      "self",
+    ],
+    "title": "Zephyr: Get Test Execution Links",
+  },
+  "zephyr_get_test_execution_steps": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Execution Steps",
+    },
+    "description": "Get details of test execution steps in Zephyr
+
+**Examples:**
+1. Get the first 10 test execution steps for test execution with ID 1
+\`\`\`json
+{
+  "testExecutionIdOrKey": "1",
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 test execution steps with their details
+
+2. Get the first 10 test execution steps for test execution with key 'SA-E1'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E1",
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: The first 10 test execution steps with their details
+
+3. Get any test execution step for test execution with key 'SA-E1'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E1",
+  "maxResults": 1
+}
+\`\`\`
+Expected Output: One test execution step with its details
+
+4. Get five test execution steps starting from the 7th test execution step for test execution with key 'SA-E1'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E1",
+  "maxResults": 5,
+  "startAt": 6
+}
+\`\`\`
+Expected Output: The 7th to the 11th test execution steps with their details
+
+5. Get test execution steps from the test data row 1 from test execution with key 'SA-E1'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E1",
+  "testDataRowNumber": 1,
+  "maxResults": 10,
+  "startAt": 0
+}
+\`\`\`
+Expected Output: Test execution steps for the specified test data row",
+    "inputSchema": [
+      "maxResults",
+      "startAt",
+      "testDataRowNumber",
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": [
+      "isLast",
+      "maxResults",
+      "next",
+      "startAt",
+      "total",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Execution Steps",
+  },
+  "zephyr_get_test_executions": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Executions",
+    },
+    "description": "Get test executions with optional filters
+
+**Parameters:**
+- projectKey (string): Jira project key filter
+- testCycle (string): Test cycle key filter.
+- testCase (string): Test case key filter.
+- actualEndDateAfter (string): Filter for 'Actual End Date' after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- actualEndDateBefore (string): Filter for 'Actual End Date' before the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- includeStepLinks (boolean): If true, execution step issue links will be included in the response (default: false)
+- jiraProjectVersionId (number): Jira Project Version ID. Relates to 'Version' or 'Releases' in Jira projects.
+- onlyLastExecutions (boolean): If true, includes only the last execution of each test cycle item (test case), and all ad-hoc test executions. (default: false)
+- limit (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the limit value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAtId (number): Zero-indexed starting position for ID-based pagination. (default: 0)
+
+**Examples:**
+1. Get the first 10 test executions
+\`\`\`json
+{
+  "limit": 10,
+  "startAtId": 0
+}
+\`\`\`
+Expected Output: The first 10 test executions with their details
+
+2. Get 5 test executions for the project PROJ
+\`\`\`json
+{
+  "projectKey": "PROJ",
+  "limit": 5
+}
+\`\`\`
+Expected Output: Up to 5 test executions for project PROJ
+
+3. Get some test executions that finished after 01/Jan/2024
+\`\`\`json
+{
+  "actualEndDateAfter": "2024-01-01T00:00:00Z"
+}
+\`\`\`
+Expected Output: Test executions that ended after 2024-01-01
+
+4. Get test executions with step links included
+\`\`\`json
+{
+  "includeStepLinks": true
+}
+\`\`\`
+Expected Output: Test executions with step links included",
+    "inputSchema": [
+      "actualEndDateAfter",
+      "actualEndDateBefore",
+      "includeStepLinks",
+      "jiraProjectVersionId",
+      "limit",
+      "onlyLastExecutions",
+      "projectKey",
+      "startAtId",
+      "testCase",
+      "testCycle",
+    ],
+    "outputSchema": [
+      "limit",
+      "next",
+      "nextStartAtId",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Executions",
+  },
+  "zephyr_get_test_executions_linked_to_a_jira_issue": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get test executions linked to a Jira issue",
+    },
+    "description": "Get test executions linked to a Jira issue in Zephyr
+
+**Parameters:**
+- issueKey (string) *required*: The key of the Jira issue
+
+**Examples:**
+1. Check which test executions are linked to Jira issue PROJ-123
+\`\`\`json
+{
+  "issueKey": "PROJ-123"
+}
+\`\`\`
+Expected Output: The List of test executions linked to Jira issue PROJ-123 with their keys and versions",
+    "inputSchema": [
+      "issueKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Get test executions linked to a Jira issue",
+  },
+  "zephyr_get_test_script": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Script",
+    },
+    "description": "Get the Test Script (Plain Text or BDD) for a given Test Case in Zephyr
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+
+**Examples:**
+1. Get the test script for test case with key 'SA-T1'
+\`\`\`json
+{
+  "testCaseKey": "SA-T1"
+}
+\`\`\`
+Expected Output: The test script with its type (plain or bdd), text content, and id
+
+2. Retrieve the BDD test script content for test case with key 'MM2-T15'
+\`\`\`json
+{
+  "testCaseKey": "MM2-T15"
+}
+\`\`\`
+Expected Output: The test script with its type (plain or bdd), text content, and id
+
+3. Get the test script for test case with key 'QA-T100' to review the test instructions
+\`\`\`json
+{
+  "testCaseKey": "QA-T100"
+}
+\`\`\`
+Expected Output: The test script with its type (plain or bdd), text content, and id",
+    "inputSchema": [
+      "testCaseKey",
+    ],
+    "outputSchema": [
+      "id",
+      "text",
+      "type",
+    ],
+    "title": "Zephyr: Get Test Script",
+  },
+  "zephyr_update_test_case": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Update Test Case",
+    },
+    "description": "Update an existing Test Case in Zephyr. This operation fetches the current test case and merges your updates with it to prevent accidental property deletion. Properties which are not included in the tool call will be left unchanged. To remove a property, set it to null explicitly. For fields that accept multiple values, such as \`labels\`, if the field is provided, it will override the previous values. For example, if \`labels\` is provided with the values \`["label1", "label2"]\`, the Test Case will now only have those two labels, and any previous labels will be removed. If you want to add a label, you would need to specify in the prompt the intention to add a label.
+
+**Examples:**
+1. Update the name of the test case 'SA-T10' to 'Check axial pump' and objective to 'To ensure the axial pump can be enabled'
+\`\`\`json
+{
+  "testCaseKey": "SA-T10",
+  "name": "Check axial pump",
+  "objective": "To ensure the axial pump can be enabled"
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.
+
+2. Update the test case 'MM2-T1' by setting labels 'Regression','Performance' and 'Automated' and changing the priority to the one with id 2.
+\`\`\`json
+{
+  "testCaseKey": "MM2-T1",
+  "priority": {
+    "id": 2
+  },
+  "labels": [
+    "Regression",
+    "Performance",
+    "Automated"
+  ]
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.
+
+3. Update test case 'SA-T5', by setting the custom field 'Build Number' to 20, 'Release Date' to '2020-01-01' and setting the Test Cases's estimated time to 3600000 milliseconds.
+\`\`\`json
+{
+  "testCaseKey": "SA-T5",
+  "estimatedTime": 3600000,
+  "customFields": {
+    "Build Number": 20,
+    "Release Date": "2020-01-01"
+  }
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.
+
+4. Remove the component from test case 'SA-T20'.
+\`\`\`json
+{
+  "testCaseKey": "SA-T20",
+  "component": null
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.
+
+5. Remove a specific custom field 'Pre-Condition(s)' from test case 'SA-T15' while keeping other custom fields intact
+\`\`\`json
+{
+  "testCaseKey": "SA-T15",
+  "customFields": {
+    "Pre-Condition(s)": null,
+    "Implemented": false
+  }
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.
+
+6. Remove test case  from folder
+\`\`\`json
+{
+  "testCaseKey": "SA-T15",
+  "folder": null
+}
+\`\`\`
+Expected Output: The test case should be updated, but no output is expected.",
+    "inputSchema": [
+      "component",
+      "customFields",
+      "estimatedTime",
+      "folder",
+      "id",
+      "key",
+      "labels",
+      "name",
+      "objective",
+      "owner",
+      "precondition",
+      "priority",
+      "project",
+      "status",
+      "testCaseKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Update Test Case",
+  },
+  "zephyr_update_test_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Update Test Cycle",
+    },
+    "description": "Update an existing Test Cycle in Zephyr. This operation fetches the current test cycle and merges your updates with it to prevent accidental property deletion. To remove a property, set it to null explicitly. The plannedStartDate and plannedEndDate fields cannot be cleared
+
+**Examples:**
+1. Update the name of the test cycle 'SA-R40' to 'Sprint 1 Regression - Updated' and set description.
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40",
+  "name": "Sprint 1 Regression - Updated",
+  "description": "Updated regression scope for Sprint 1"
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.
+
+2. Update planned dates for test cycle id '1' (keep everything else unchanged).
+\`\`\`json
+{
+  "testCycleIdOrKey": "1",
+  "plannedStartDate": "2018-05-19T13:15:13Z",
+  "plannedEndDate": "2018-05-20T13:15:13Z"
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.
+
+3. Change folder and status for test cycle 'SA-R40' by setting folder id and status id.
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40",
+  "folder": {
+    "id": 100006
+  },
+  "status": {
+    "id": 10000
+  }
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.
+
+4. Update custom fields on test cycle 'SA-R40' while keeping other custom fields intact.
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40",
+  "customFields": {
+    "Build Number": 20,
+    "Release Date": "2020-01-01"
+  }
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.
+
+5. Remove the owner from test cycle 'SA-R40'.
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40",
+  "owner": null
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.
+
+6. Remove a specific custom field 'Pre-Condition(s)' from test cycle 'SA-R40' while keeping other custom fields intact.
+\`\`\`json
+{
+  "testCycleIdOrKey": "SA-R40",
+  "customFields": {
+    "Pre-Condition(s)": null,
+    "Implemented": false
+  }
+}
+\`\`\`
+Expected Output: The test cycle should be updated, but no output is expected.",
+    "inputSchema": [
+      "customFields",
+      "description",
+      "folder",
+      "id",
+      "jiraProjectVersion",
+      "key",
+      "name",
+      "owner",
+      "plannedEndDate",
+      "plannedStartDate",
+      "project",
+      "status",
+      "testCycleIdOrKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Update Test Cycle",
+  },
+  "zephyr_update_test_execution": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Update Test Execution",
+    },
+    "description": "Update an existing Test Execution in Zephyr. This operation only updates specified fields in the payload and ignores \`null\` or \`undefined\` values.
+
+**Examples:**
+1. Update the status name to 'PASS' and the environment name to 'ENV-1' in the test execution 'SA-E40'.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E40",
+  "statusName": "PASS",
+  "environmentName": "ENV-1"
+}
+\`\`\`
+Expected Output: The test execution should be updated, but no output is expected.
+
+2. Update execution time and actual end date for test execution id '1' (keep everything else unchanged).
+\`\`\`json
+{
+  "testExecutionIdOrKey": "1",
+  "executionTime": "2018-05-19T13:15:13Z",
+  "actualEndDate": "2018-05-20T13:15:13Z"
+}
+\`\`\`
+Expected Output: The test execution should be updated, but no output is expected.
+
+3. For test execution 'SA-E40', update the test executor and assignee to be the user with ID 10000.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E40",
+  "executedById": "10000",
+  "assignedToId": "10000"
+}
+\`\`\`
+Expected Output: The test execution should be updated, but no output is expected.
+
+4. In test execution 'SA-E40', add a comment saying that this execution was updated via API.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E40",
+  "comment": "execution updated via API"
+}
+\`\`\`
+Expected Output: The test execution should be updated, but no output is expected.
+
+5. Remove the assigned user from test execution 'SA-E40'.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E40",
+  "assignedToId": null
+}
+\`\`\`
+Expected Output: The test execution should be updated, but no output is expected.",
+    "inputSchema": [
+      "actualEndDate",
+      "assignedToId",
+      "comment",
+      "environmentName",
+      "executedById",
+      "executionTime",
+      "statusName",
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Update Test Execution",
+  },
+  "zephyr_update_test_execution_steps": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Zephyr: Update Test Execution Steps",
+    },
+    "description": "Update test steps for a given Test Execution in Zephyr. This operation updates the provided steps with their execution status and actual results. Only the fields included in the request will be modified.
+
+**Examples:**
+1. Mark the status of all steps in the test execution 'SA-E1' as 'Pass'. Set the actual result of step 1 to 'Dashboard widgets loaded correctly' and step 2 to 'Navigation menu responded correctly to user interactions'.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E1",
+  "steps": [
+    {
+      "statusName": "Pass",
+      "actualResult": "Dashboard widgets loaded correctly"
+    },
+    {
+      "statusName": "Pass",
+      "actualResult": "Navigation menu responded correctly to user interactions"
+    }
+  ]
+}
+\`\`\`
+Expected Output: Test steps are updated successfully, but no output is expected.
+
+2. Update only the status of step 2 in test execution 'SA-E5' to 'Fail'. Do not modify any other fields.
+\`\`\`json
+{
+  "testExecutionIdOrKey": "SA-E5",
+  "steps": [
+    {},
+    {
+      "statusName": "Fail"
+    }
+  ]
+}
+\`\`\`
+Expected Output: The test execution steps are updated, but no output is expected.
+
+3. Update only the actual results of the steps in test execution '10'. Set the actual result of step 1 to 'API returned 500 error' and step 2 actual result to 'API returned 200 success'
+\`\`\`json
+{
+  "testExecutionIdOrKey": "10",
+  "steps": [
+    {
+      "actualResult": "API returned 500 error"
+    },
+    {
+      "actualResult": "API returned 200 success"
+    }
+  ]
+}
+\`\`\`
+Expected Output: Test steps are updated successfully, but no output is expected.",
+    "inputSchema": [
+      "steps",
+      "testExecutionIdOrKey",
+    ],
+    "outputSchema": undefined,
+    "title": "Zephyr: Update Test Execution Steps",
+  },
+}
+`;

--- a/src/tests/unit/common/registered-tools.test.ts
+++ b/src/tests/unit/common/registered-tools.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { SmartBearMcpServer } from "../../../common/server";
+
+import "../../../common/register-clients";
+import { clientRegistry } from "../../../common/client-registry";
+
+/**
+ * This test verifies that all registered tools from all clients match the expected snapshot.
+ * If it fails, verify the diff from the vitest output and, if it's expected, update the snapshot with `vitest -u`.
+ */
+describe("tool definitions", () => {
+  it("all registered tool definitions match the snapshot", async () => {
+    const server = new SmartBearMcpServer();
+
+    const registeredTools: Record<string, any> = {};
+
+    vi.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(server)),
+      "registerTool",
+    ).mockImplementation(((toolName: string, config: any) => {
+      registeredTools[toolName] = {
+        ...config,
+        inputSchema: config.inputSchema
+          ? Object.keys(config.inputSchema).sort()
+          : undefined,
+        outputSchema: config.outputSchema
+          ? Object.keys(config.outputSchema).sort()
+          : undefined,
+      };
+    }) as any);
+
+    for (const client of clientRegistry.getAll()) {
+      await server.addClient(client);
+    }
+
+    const sorted = Object.fromEntries(
+      Object.entries(registeredTools).sort(([a], [b]) => a.localeCompare(b)),
+    );
+
+    expect(sorted).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Goal

The tool definition output is pretty key to the success of the server and liable to changes that are hard to spot during development.

## Design

Added a snapshot test to catch changes to the output – so make them pass, the updated version must be checked in (run `vitest -u` to regenerate it) and reviewed.

## Changeset

New `src/tests/unit/common/registered-tools.test.ts` using vitest functionality.

## Testing

Automated testing.
