### PR TITLE
fix: unwrapping of Zod types for tool definitions

### DIFF
--- a/src/common/client-registry.ts
+++ b/src/common/client-registry.ts
@@ -1,7 +1,7 @@
 import { type ZodType, ZodURL } from "zod";
 import type { SmartBearMcpServer } from "./server";
 import type { Client } from "./types";
-import { isOptionalType, unwrapZodType } from "./zod-utils";
+import { fullyUnwrapZodType, isOptionalType } from "./zod-utils";
 
 /**
  * Central registry for all MCP clients
@@ -52,7 +52,7 @@ class ClientRegistry {
    * @param value The actual config value to validate
    */
   private validateAllowedEndpoint(zodType: ZodType, value: string): void {
-    if (unwrapZodType(zodType) instanceof ZodURL) {
+    if (fullyUnwrapZodType(zodType) instanceof ZodURL) {
       const allowedEndpoints = process.env.MCP_ALLOWED_ENDPOINTS?.split(",");
       if (allowedEndpoints) {
         for (const endpoint of allowedEndpoints) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -7,21 +7,10 @@ import type {
   ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
-  ZodAny,
-  ZodArray,
-  ZodBoolean,
-  ZodDefault,
-  ZodEnum,
   ZodIntersection,
-  ZodLiteral,
-  ZodNumber,
   ZodObject,
-  ZodOptional,
   type ZodRawShape,
-  ZodRecord,
-  ZodString,
   type ZodType,
-  ZodUnion,
 } from "zod";
 import Bugsnag from "../common/bugsnag";
 import { CacheService } from "./cache";
@@ -32,7 +21,12 @@ import {
 } from "./pollyfills";
 import { ToolError } from "./tools";
 import type { Client, ToolParams } from "./types";
-import { unwrapZodType } from "./zod-utils";
+import {
+  getDefaultValue,
+  getReadableTypeName,
+  getTypeDescription,
+  isOptionalType,
+} from "./zod-utils";
 
 export class SmartBearMcpServer extends McpServer {
   private cache: CacheService;
@@ -287,9 +281,17 @@ export class SmartBearMcpServer extends McpServer {
 
     if (inputSchema && inputSchema instanceof ZodObject) {
       let parameters = Object.keys(inputSchema.shape)
-        .map((key) =>
-          this.formatParameterDescription(key, inputSchema.shape[key]),
-        )
+        .map((key) => {
+          const field = inputSchema.shape[key];
+          const description = getTypeDescription(field);
+          const defaultValue = getDefaultValue(field);
+          return (
+            `- ${key} (${getReadableTypeName(field)})` +
+            `${isOptionalType(field) ? "" : " *required*"}` +
+            `${description ? `: ${description}` : ""}` +
+            `${defaultValue !== null ? ` (default: ${JSON.stringify(defaultValue)})` : ""}`
+          );
+        })
         .join("\n");
       if (parameters.length === 0) {
         parameters = "None";
@@ -324,62 +326,5 @@ export class SmartBearMcpServer extends McpServer {
     }
 
     return description.trim();
-  }
-
-  private formatParameterDescription(
-    key: string,
-    field: ZodType,
-    description: string | null = null,
-    isOptional = false,
-    defaultValue: string | null = null,
-  ): string {
-    description = description ?? (field.description || null);
-    if (field instanceof ZodOptional) {
-      field = (field as ZodOptional<ZodType>).unwrap();
-      return this.formatParameterDescription(
-        key,
-        field,
-        description,
-        true,
-        defaultValue,
-      );
-    }
-    if (field instanceof ZodDefault) {
-      defaultValue = JSON.stringify(
-        (field as ZodDefault<ZodType>).def.defaultValue,
-      );
-      field = (field as ZodDefault<ZodType>).unwrap();
-      return this.formatParameterDescription(
-        key,
-        field,
-        description,
-        true,
-        defaultValue,
-      );
-    }
-    return (
-      `- ${key} (${this.getReadableTypeName(field)})` +
-      `${isOptional ? "" : " *required*"}` +
-      `${description ? `: ${description}` : ""}` +
-      `${defaultValue ? ` (default: ${defaultValue})` : ""}`
-    );
-  }
-
-  private getReadableTypeName(zodType: ZodType): string {
-    zodType = unwrapZodType(zodType);
-    if (zodType instanceof ZodRecord) {
-      const record = zodType as ZodRecord;
-      return `record<${this.getReadableTypeName(record.def.keyType as ZodType)}, ${this.getReadableTypeName(record.def.valueType as ZodType)}>`;
-    }
-    if (zodType instanceof ZodString) return "string";
-    if (zodType instanceof ZodNumber) return "number";
-    if (zodType instanceof ZodBoolean) return "boolean";
-    if (zodType instanceof ZodArray) return "array";
-    if (zodType instanceof ZodObject) return "object";
-    if (zodType instanceof ZodEnum) return "enum";
-    if (zodType instanceof ZodLiteral) return "literal";
-    if (zodType instanceof ZodUnion) return "union";
-    if (zodType instanceof ZodAny) return "any";
-    return "any";
   }
 }

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -11,7 +11,7 @@ import { withRequestContext } from "./request-context";
 import { SmartBearMcpServer } from "./server";
 import { getEnvVarName } from "./transport-stdio";
 import type { Client } from "./types";
-import { isOptionalType } from "./zod-utils";
+import { getTypeDescription, isOptionalType } from "./zod-utils";
 
 /**
  * Helper to construct the base URL from the request, respecting proxy headers.
@@ -630,7 +630,7 @@ function getHttpHeadersHelp(): string[] {
         ? " (optional)"
         : " (required)";
       messages.push(
-        `    - ${headerName}${requiredTag}: ${requirement.description}`,
+        `    - ${headerName}${requiredTag}: ${getTypeDescription(requirement)}`,
       );
     }
   }

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -4,7 +4,7 @@ import { clientRegistry } from "./client-registry";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
 import { SmartBearMcpServer } from "./server";
 import type { Client } from "./types";
-import { isOptionalType } from "./zod-utils";
+import { getTypeDescription, isOptionalType } from "./zod-utils";
 
 /**
  * Generate a dynamic error message listing all available clients and their required env vars
@@ -19,7 +19,7 @@ function getNoConfigMessage(): string[] {
         ? " (optional)"
         : " (required)";
       messages.push(
-        `    - ${envVarName}${requiredTag}: ${requirement.description}`,
+        `    - ${envVarName}${requiredTag}: ${getTypeDescription(requirement)}`,
       );
     }
   }
@@ -32,6 +32,12 @@ function getNoConfigMessage(): string[] {
 export async function runStdioMode() {
   if (process.argv.includes("--version")) {
     console.log(`${MCP_SERVER_NAME}: v${MCP_SERVER_VERSION}`);
+    process.exit(0);
+  } else if (process.argv.includes("--help")) {
+    console.log(
+      "The following environment variables can be set to configure each of the SmartBear clients:",
+    );
+    console.log(getNoConfigMessage().join("\n"));
     process.exit(0);
   }
 

--- a/src/common/zod-utils.ts
+++ b/src/common/zod-utils.ts
@@ -1,22 +1,91 @@
-import { ZodDefault, ZodNullable, ZodOptional, type ZodType } from "zod";
-
-export function isOptionalType(zodType: ZodType): boolean {
-  return (
-    zodType instanceof ZodOptional ||
-    zodType instanceof ZodDefault ||
-    zodType instanceof ZodNullable
-  );
-}
+import {
+  ZodAny,
+  ZodArray,
+  ZodBoolean,
+  ZodDefault,
+  ZodEnum,
+  ZodLiteral,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodRecord,
+  ZodString,
+  type ZodType,
+  ZodUnion,
+} from "zod";
 
 export function unwrapZodType(zodType: ZodType): ZodType {
   if (zodType instanceof ZodOptional) {
-    return unwrapZodType((zodType as ZodOptional<any>).unwrap());
+    return (zodType as ZodOptional<any>).unwrap();
   }
   if (zodType instanceof ZodDefault) {
-    return unwrapZodType((zodType as ZodDefault<any>).unwrap());
+    return (zodType as ZodDefault<any>).unwrap();
   }
   if (zodType instanceof ZodNullable) {
-    return unwrapZodType((zodType as ZodNullable<any>).unwrap());
+    return (zodType as ZodNullable<any>).unwrap();
   }
   return zodType;
+}
+
+export function isOptionalType(zodType: ZodType): boolean {
+  const isOptional =
+    zodType instanceof ZodOptional ||
+    zodType instanceof ZodDefault ||
+    zodType instanceof ZodNullable;
+  if (!isOptional) {
+    const unwrapped = unwrapZodType(zodType);
+    if (unwrapped !== zodType) {
+      return isOptionalType(unwrapped);
+    }
+  }
+  return isOptional;
+}
+
+export function getDefaultValue(zodType: ZodType): any {
+  if (zodType instanceof ZodDefault) {
+    return (zodType as ZodDefault<any>).def.defaultValue;
+  }
+  const unwrapped = unwrapZodType(zodType);
+  if (unwrapped !== zodType) {
+    return getDefaultValue(unwrapped);
+  }
+  return null;
+}
+
+export function fullyUnwrapZodType(zodType: ZodType): ZodType {
+  const unwrappedType = unwrapZodType(zodType);
+  if (unwrappedType === zodType) {
+    return unwrappedType;
+  }
+  return fullyUnwrapZodType(unwrappedType);
+}
+
+export function getTypeDescription(zodType: ZodType): string | null {
+  if (zodType.description) {
+    return zodType.description;
+  }
+  const unwrapped = unwrapZodType(zodType);
+  if (unwrapped !== zodType) {
+    return getTypeDescription(unwrapped);
+  }
+  return null;
+}
+
+export function getReadableTypeName(zodType: ZodType): string {
+  zodType = fullyUnwrapZodType(zodType);
+  if (zodType instanceof ZodRecord) {
+    const record = zodType as ZodRecord;
+    return `record<${getReadableTypeName(record.def.keyType as ZodType)}, ${getReadableTypeName(record.def.valueType as ZodType)}>`;
+  }
+  if (zodType instanceof ZodString) return "string";
+  if (zodType instanceof ZodNumber) return "number";
+  if (zodType instanceof ZodBoolean) return "boolean";
+  if (zodType instanceof ZodArray) return "array";
+  if (zodType instanceof ZodObject) return "object";
+  if (zodType instanceof ZodEnum) return "enum";
+  if (zodType instanceof ZodLiteral) return "literal";
+  if (zodType instanceof ZodUnion) return "union";
+  if (zodType instanceof ZodAny) return "any";
+  return "any";
 }

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -643,26 +643,4 @@ describe("SmartBearMcpServer", () => {
       expect(rawShape).toBeUndefined();
     });
   });
-
-  describe("getReadableTypeName", () => {
-    it.each([
-      ["string", z.string()],
-      ["number", z.number()],
-      ["boolean", z.boolean()],
-      ["array", z.array(z.string())],
-      ["object", z.object({ key: z.string() })],
-      ["enum", z.enum(["value1", "value2"])],
-      ["literal", z.literal("value")],
-      ["union", z.union([z.string(), z.number()])],
-      ["record<string, number>", z.record(z.string(), z.number())],
-      ["record<string, array>", z.record(z.string(), z.array(z.string()))],
-      ["any", z.any()],
-      ["string", z.optional(z.string())],
-      ["string", z.string().default("default")],
-    ])("should return '%s' for the given Zod type", (expected, zodType) => {
-      // biome-ignore lint/complexity/useLiteralKeys: accessing internal method for test
-      const result = server["getReadableTypeName"](zodType);
-      expect(result).toBe(expected);
-    });
-  });
 });

--- a/src/tests/unit/common/zod-utils.test.ts
+++ b/src/tests/unit/common/zod-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  fullyUnwrapZodType,
+  getReadableTypeName,
+  getTypeDescription,
+  isOptionalType,
+} from "../../../common/zod-utils";
+
+describe("zod-utils", () => {
+  describe("isOptionalType", () => {
+    it.each([
+      ["ZodOptional", z.string().optional(), true],
+      ["ZodNullable", z.string().nullable(), true],
+      ["ZodDefault", z.string().default("foo"), true],
+      [
+        "nested optionals",
+        z.string().optional().nullable().default("bar"),
+        true,
+      ],
+      [
+        "nested optionals in any order",
+        z.string().optional().describe("foo"),
+        true,
+      ],
+      ["required type", z.string(), false],
+    ])("returns $2 for $0", (_desc, zodType, expected) => {
+      expect(isOptionalType(zodType)).toBe(expected);
+    });
+  });
+
+  describe("fullyUnwrapZodType", () => {
+    it.each([
+      ["base type", z.string(), z.ZodString],
+      ["unwraps ZodOptional", z.string().optional(), z.ZodString],
+      ["unwraps ZodNullable number", z.number().nullable(), z.ZodNumber],
+      ["unwraps ZodDefault", z.string().default("foo"), z.ZodString],
+      [
+        "unwraps nested wrappers",
+        z.string().optional().nullable().default("bar"),
+        z.ZodString,
+      ],
+      [
+        "unwraps nested wrappers in any order",
+        z.string().optional().describe("foo"),
+        z.ZodString,
+      ],
+      [
+        "unwraps nested wrappers in any order",
+        z.number().default(1).describe("foo"),
+        z.ZodNumber,
+      ],
+    ])("it unwraps %s", (_desc, zodType, expectedCtor) => {
+      expect(fullyUnwrapZodType(zodType)).toBeInstanceOf(expectedCtor);
+    });
+  });
+
+  describe("getTypeDescription", () => {
+    it.each([
+      ["description", z.string().describe("desc"), "desc"],
+      [
+        "description from url",
+        z.url().describe("http://example.com"),
+        "http://example.com",
+      ],
+      [
+        "description from wrapped type",
+        z.string().describe("desc").optional(),
+        "desc",
+      ],
+      [
+        "description from wrapped type in any order",
+        z.string().optional().describe("desc"),
+        "desc",
+      ],
+      ["no description", z.string(), null],
+    ])("returns %s", (_desc, zodType, expected) => {
+      expect(getTypeDescription(zodType)).toBe(expected);
+    });
+  });
+
+  describe("getReadableTypeName", () => {
+    it.each([
+      ["string", z.string()],
+      ["number", z.number()],
+      ["boolean", z.boolean()],
+      ["array", z.array(z.string())],
+      ["object", z.object({ key: z.string() })],
+      ["enum", z.enum(["value1", "value2"])],
+      ["literal", z.literal("value")],
+      ["union", z.union([z.string(), z.number()])],
+      ["record<string, number>", z.record(z.string(), z.number())],
+      ["record<string, array>", z.record(z.string(), z.array(z.string()))],
+      ["any", z.any()],
+      ["string", z.optional(z.string())],
+      ["string", z.string().default("default")],
+      ["string", z.string().regex(/test/).nullish().describe("regex test")],
+    ])("should return '%s' for the given Zod type", (expected, zodType) => {
+      const result = getReadableTypeName(zodType);
+      expect(result).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Goal

I noticed that the no-config output was affected by the ordering of the `optional()`, `default()` and `describe()` in the chain of the definition:

e.g.
```
z.string().describe("Collaborator username for authentication").optional(),
```
> - COLLABORATOR_USERNAME (optional): undefined

vs
```
z.string().optional().describe("Collaborator username for authentication"),
```
> - COLLABORATOR_USERNAME (required): Collaborator username for authentication

## Changeset

I've pushed more of the Zod->text logic into zod-utils and made these fully recursive for optional, default and nullable types so that we can retrieve the description and default value at any level.

## Testing

Added extra unit tests to cover ordering of declaration.