### PR TITLE
feat: allow configuration by querystring from the server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Common] Configuration options can now be passed in via query string parameters for HTTP transport [#453](https://github.com/SmartBear/smartbear-mcp/pull/453)
 - [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)
 
 ## [0.19.2] - 2026-05-05

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
+import querystring from "node:querystring";
 
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -505,16 +506,27 @@ export async function newServer(
       clientRegistry.configure(
         server,
         (client, key) => {
+          // 1. Try query string
+          const queryStringName = getQueryStringName(client, key);
+          const queryParams = querystring.parse(req.url?.split("?")[1] || "");
+          let value =
+            queryParams[queryStringName] ||
+            queryParams[queryStringName.toLowerCase()];
+          if (typeof value === "string") {
+            return value;
+          }
+
+          // 2. Try headers
           const headerName = getHeaderName(client, key);
           // Check both original case and lower-case headers for compatibility
           // (HTTP headers are case-insensitive, but Node.js lowercases them)
-          const value =
+          value =
             req.headers[headerName] || req.headers[headerName.toLowerCase()];
           if (typeof value === "string") {
             return value;
           }
 
-          // Fall back to environment variable if header is not present
+          // 3. Fall back to environment variable
           const envVarName = getEnvVarName(client, key);
           return process.env[envVarName] || null;
         },
@@ -597,6 +609,16 @@ export function getHeaderName(client: Client, key: string): string {
         part.charAt(0).toUpperCase() + part.slice(1).toLowerCase(),
     )
     .join("-")}`;
+}
+
+export function getQueryStringName(client: Client, key: string): string {
+  return `${client.configPrefix.toLowerCase()}${key
+    .split("_")
+    .map(
+      (part: string) =>
+        part.charAt(0).toUpperCase() + part.slice(1).toLowerCase(),
+    )
+    .join("")}`;
 }
 
 /**

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -4,6 +4,7 @@ import { clientRegistry } from "../../../common/client-registry";
 import {
   getBaseUrl,
   getHeaderName,
+  getQueryStringName,
   newServer,
 } from "../../../common/transport-http";
 import type { Client } from "../../../common/types";
@@ -184,6 +185,30 @@ describe("transport-http helpers", () => {
     it("should handle different client prefixes", () => {
       const client = fakeClient("Zephyr");
       expect(getHeaderName(client, "api_token")).toBe("Zephyr-Api-Token");
+    });
+  });
+
+  describe("getQueryStringName", () => {
+    it("should convert snake_case key to pascalCase with client prefix", () => {
+      const client = fakeClient("Bugsnag");
+      expect(getQueryStringName(client, "auth_token")).toBe("bugsnagAuthToken");
+    });
+
+    it("should handle single-word keys", () => {
+      const client = fakeClient("Reflect");
+      expect(getQueryStringName(client, "token")).toBe("reflectToken");
+    });
+
+    it("should handle multi-word keys", () => {
+      const client = fakeClient("Bugsnag");
+      expect(getQueryStringName(client, "project_api_key")).toBe(
+        "bugsnagProjectApiKey",
+      );
+    });
+
+    it("should handle different client prefixes", () => {
+      const client = fakeClient("Zephyr");
+      expect(getQueryStringName(client, "api_token")).toBe("zephyrApiToken");
     });
   });
 });


### PR DESCRIPTION
## Goal

For MCP clients who don't support setting custom headers when connecting to a remote MCP server, this change offers an alternative for configuring the server using the querystring of the server URL.

## Design

This PR builds on the convention we have for configuring clients using the client name prefix and configuration name, but in pascal case for a query string parameter (although it's also case insensitive).

As with header configuration, if the configuration option is a URL, it must be allow-listed in an environment variable to be used.

## Changeset

Added new query string parsing at common server level.

## Testing

Additional unit tests for the parsing and manual testing of configuration.
