### PR TITLE
feat(common): graceful shutdown on SIGTERM/SIGINT + split health/readiness endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Common] Add graceful shutdown on SIGTERM/SIGINT in HTTP mode: drains active sessions (closes Streamable HTTP and SSE transports, runs per-client `cleanupSession` hooks including Reflect WebSocket teardown), with a configurable deadline via `MCP_SHUTDOWN_TIMEOUT_MS` (default 25s)
+- [Common] Split health/readiness probes: `GET /health` is now liveness-only and always returns 200 when the process is responsive; `GET /ready` is the readiness probe and returns 503 during drain so load balancers stop routing new sessions to draining pods. Both probes set `Cache-Control: no-store`
 - [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)
 
 ## [0.19.2] - 2026-05-05

--- a/src/common/shutdown.ts
+++ b/src/common/shutdown.ts
@@ -1,0 +1,253 @@
+/**
+ * Graceful shutdown coordination.
+ *
+ * Owns SIGTERM / SIGINT handling and runs registered cleanup callbacks in
+ * LIFO order with a deadline. Designed so each transport / subsystem can
+ * register its own teardown without knowing about the others.
+ *
+ * Lifecycle:
+ *   idle      -> initial state
+ *   draining  -> first signal received; isDraining() returns true so
+ *                readiness probes can flip to 503 and tools can refuse new
+ *                work if they choose to. Handlers are running.
+ *   complete  -> handlers finished or deadline hit; process is about to exit.
+ *
+ * Double-signal escalation: a second SIGTERM/SIGINT during drain forces an
+ * immediate exit(1) without waiting for outstanding handlers.
+ *
+ * Exit codes:
+ *   0  clean drain
+ *   1  deadline exceeded, or forced exit via second signal
+ */
+
+export type ShutdownHandler = () => Promise<void> | void;
+
+interface RegisteredHandler {
+  name: string;
+  fn: ShutdownHandler;
+}
+
+export interface ShutdownManagerOptions {
+  /** Signals to listen for. Defaults to ['SIGTERM', 'SIGINT']. */
+  signals?: NodeJS.Signals[];
+  /** Drain deadline in milliseconds. Defaults to MCP_SHUTDOWN_TIMEOUT_MS or 25000. */
+  timeoutMs?: number;
+  /** Process to attach handlers to. Injectable for tests. */
+  process?: NodeJS.Process;
+  /** Exit function. Injectable for tests. */
+  exit?: (code: number) => void;
+  /** Logger. Injectable for tests. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+}
+
+export interface DrainResult {
+  status: "clean" | "deadline";
+  durationMs: number;
+  /** Names of handlers that did not complete before the deadline. */
+  remainingHandlers: string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 25_000;
+
+function defaultTimeout(): number {
+  const fromEnv = process.env.MCP_SHUTDOWN_TIMEOUT_MS;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+export class ShutdownManager {
+  private handlers: RegisteredHandler[] = [];
+  private state: "idle" | "draining" | "complete" = "idle";
+  private signalsInstalled = false;
+  private installedSignalListeners: Array<{
+    signal: NodeJS.Signals;
+    listener: NodeJS.SignalsListener;
+  }> = [];
+
+  private readonly signals: NodeJS.Signals[];
+  private readonly timeoutMs: number;
+  private readonly proc: NodeJS.Process;
+  private readonly exitFn: (code: number) => void;
+  private readonly logger: Pick<Console, "log" | "warn" | "error">;
+
+  constructor(options: ShutdownManagerOptions = {}) {
+    this.signals = options.signals ?? ["SIGTERM", "SIGINT"];
+    this.timeoutMs = options.timeoutMs ?? defaultTimeout();
+    this.proc = options.process ?? process;
+    this.exitFn = options.exit ?? ((code: number) => process.exit(code));
+    this.logger = options.logger ?? console;
+  }
+
+  /**
+   * Register a cleanup handler. Handlers run in LIFO order on shutdown,
+   * so subsystems registered later (closer to where they are used) tear
+   * down before subsystems registered earlier (closer to startup).
+   */
+  register(name: string, fn: ShutdownHandler): void {
+    if (this.state !== "idle") {
+      this.logger.warn(
+        `[MCP][shutdown] Refusing to register handler "${name}" — already ${this.state}`,
+      );
+      return;
+    }
+    this.handlers.push({ name, fn });
+  }
+
+  /** True from the moment the first shutdown signal is received. */
+  isDraining(): boolean {
+    return this.state !== "idle";
+  }
+
+  /**
+   * Wire SIGTERM / SIGINT listeners. Idempotent — calling more than once
+   * is a no-op.
+   */
+  installSignalHandlers(): void {
+    if (this.signalsInstalled) return;
+    this.signalsInstalled = true;
+
+    for (const signal of this.signals) {
+      const listener: NodeJS.SignalsListener = () => {
+        this.handleSignal(signal);
+      };
+      this.proc.on(signal, listener);
+      this.installedSignalListeners.push({ signal, listener });
+    }
+  }
+
+  /** Tear down installed signal listeners (test-only). */
+  uninstallSignalHandlers(): void {
+    for (const { signal, listener } of this.installedSignalListeners) {
+      this.proc.off(signal, listener);
+    }
+    this.installedSignalListeners = [];
+    this.signalsInstalled = false;
+  }
+
+  /**
+   * Run all registered handlers in LIFO order with the configured deadline.
+   * Returns the drain result without exiting the process — exposed for tests
+   * and for callers that want to log / report before exiting.
+   */
+  async drain(): Promise<DrainResult> {
+    if (this.state === "complete") {
+      return { status: "clean", durationMs: 0, remainingHandlers: [] };
+    }
+    this.state = "draining";
+
+    const start = Date.now();
+    const reversed = [...this.handlers].reverse();
+    const remaining = new Set(reversed.map((h) => h.name));
+
+    this.logger.log(
+      `[MCP][shutdown] Draining ${reversed.length} handler(s), deadline ${this.timeoutMs}ms`,
+    );
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const drainPromise = (async () => {
+      for (const h of reversed) {
+        try {
+          await h.fn();
+        } catch (err) {
+          // Errors in one handler must not prevent others from running.
+          this.logger.error(
+            `[MCP][shutdown] Handler "${h.name}" threw during drain:`,
+            err,
+          );
+        }
+        remaining.delete(h.name);
+      }
+    })();
+
+    const timeoutPromise = new Promise<"deadline">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("deadline"), this.timeoutMs);
+      // Don't keep the event loop alive solely for the deadline timer.
+      timeoutHandle.unref?.();
+    });
+
+    const winner = await Promise.race([
+      drainPromise.then(() => "clean" as const),
+      timeoutPromise,
+    ]);
+
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    this.state = "complete";
+
+    const durationMs = Date.now() - start;
+    const remainingHandlers = [...remaining];
+
+    if (winner === "clean") {
+      this.logger.log(`[MCP][shutdown] Drained cleanly in ${durationMs}ms`);
+      return { status: "clean", durationMs, remainingHandlers: [] };
+    }
+
+    this.logger.error(
+      `[MCP][shutdown] Deadline exceeded after ${durationMs}ms, ${remainingHandlers.length} handler(s) outstanding: ${remainingHandlers.join(", ") || "(none)"}`,
+    );
+    return { status: "deadline", durationMs, remainingHandlers };
+  }
+
+  /** Exposed for tests; not part of the production call path. */
+  getState(): "idle" | "draining" | "complete" {
+    return this.state;
+  }
+
+  private handleSignal(signal: NodeJS.Signals): void {
+    if (this.state === "draining") {
+      // Second signal during drain — operator has lost patience; force exit.
+      this.logger.warn(
+        `[MCP][shutdown] Received ${signal} while draining — forcing immediate exit(1)`,
+      );
+      this.exitFn(1);
+      return;
+    }
+    if (this.state === "complete") {
+      // Already finished draining; just exit.
+      this.exitFn(0);
+      return;
+    }
+
+    this.logger.log(`[MCP][shutdown] Received ${signal}, starting drain`);
+    this.drain()
+      .then((result) => {
+        this.exitFn(result.status === "clean" ? 0 : 1);
+      })
+      .catch((err) => {
+        // drain() catches per-handler errors; this branch should not happen.
+        this.logger.error(
+          "[MCP][shutdown] Unexpected error from drain():",
+          err,
+        );
+        this.exitFn(1);
+      });
+  }
+}
+
+/**
+ * Singleton shutdown manager for the running process.
+ * Tests should construct their own ShutdownManager rather than using this.
+ */
+export const shutdownManager = new ShutdownManager();
+
+/** Convenience: register a handler on the singleton. */
+export function registerShutdownHandler(
+  name: string,
+  fn: ShutdownHandler,
+): void {
+  shutdownManager.register(name, fn);
+}
+
+/** Convenience: install signal handlers on the singleton. */
+export function installSignalHandlers(): void {
+  shutdownManager.installSignalHandlers();
+}
+
+/** Convenience: query draining state on the singleton. */
+export function isDraining(): boolean {
+  return shutdownManager.isDraining();
+}

--- a/src/common/shutdown.ts
+++ b/src/common/shutdown.ts
@@ -183,13 +183,12 @@ export class ShutdownManager {
 
     if (winner === "clean") {
       this.logger.log(`[MCP][shutdown] Drained cleanly in ${durationMs}ms`);
-      return { status: "clean", durationMs, remainingHandlers: [] };
+    } else {
+      this.logger.error(
+        `[MCP][shutdown] Deadline exceeded after ${durationMs}ms, ${remainingHandlers.length} handler(s) outstanding: ${remainingHandlers.join(", ") || "(none)"}`,
+      );
     }
-
-    this.logger.error(
-      `[MCP][shutdown] Deadline exceeded after ${durationMs}ms, ${remainingHandlers.length} handler(s) outstanding: ${remainingHandlers.join(", ") || "(none)"}`,
-    );
-    return { status: "deadline", durationMs, remainingHandlers };
+    return { status: winner, durationMs, remainingHandlers };
   }
 
   /** Exposed for tests; not part of the production call path. */

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -9,9 +9,58 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { clientRegistry } from "./client-registry";
 import { withRequestContext } from "./request-context";
 import { SmartBearMcpServer } from "./server";
+import { isDraining, registerShutdownHandler } from "./shutdown";
 import { getEnvVarName } from "./transport-stdio";
 import type { Client } from "./types";
 import { getTypeDescription, isOptionalType } from "./zod-utils";
+
+type SessionEntry = {
+  server: SmartBearMcpServer;
+  transport: StreamableHTTPServerTransport | SSEServerTransport;
+};
+
+/**
+ * Common cache-control headers for probe endpoints.
+ */
+const PROBE_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+} as const;
+
+/**
+ * Liveness probe handler. Returns 200 unconditionally as long as the HTTP
+ * server is responsive.
+ */
+export function handleHealthRequest(res: ServerResponse): void {
+  res.writeHead(200, PROBE_HEADERS);
+  res.end(
+    JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }),
+  );
+}
+
+/**
+ * Readiness probe handler. Returns 200 normally, 503 once the process has
+ * received SIGTERM and started draining.
+ */
+export function handleReadyRequest(
+  res: ServerResponse,
+  draining: () => boolean = isDraining,
+): void {
+  if (draining()) {
+    res.writeHead(503, PROBE_HEADERS);
+    res.end(
+      JSON.stringify({
+        status: "draining",
+        timestamp: new Date().toISOString(),
+      }),
+    );
+    return;
+  }
+  res.writeHead(200, PROBE_HEADERS);
+  res.end(
+    JSON.stringify({ status: "ready", timestamp: new Date().toISOString() }),
+  );
+}
 
 /**
  * Helper to construct the base URL from the request, respecting proxy headers.
@@ -39,13 +88,7 @@ export async function runHttpMode() {
   ];
 
   // Store transports by session ID
-  const transports = new Map<
-    string,
-    {
-      server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
-    }
-  >();
+  const transports = new Map<string, SessionEntry>();
 
   // Get dynamic list of allowed headers from registered clients
   const allowedAuthHeaders = getHttpHeaders();
@@ -82,12 +125,15 @@ export async function runHttpMode() {
       const baseUrl = getBaseUrl(req);
       const url = new URL(req.url || "/", baseUrl);
 
-      // HEALTH CHECK ENDPOINT
+      // LIVENESS PROBE — always 200 if the process is responsive.
       if (req.method === "GET" && url.pathname === "/health") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }),
-        );
+        handleHealthRequest(res);
+        return;
+      }
+
+      // READINESS PROBE — 200 normally, 503 once draining has started.
+      if (req.method === "GET" && url.pathname === "/ready") {
+        handleReadyRequest(res);
         return;
       }
 
@@ -136,9 +182,8 @@ export async function runHttpMode() {
 
   httpServer.listen(PORT, () => {
     console.log(`[MCP HTTP Server] Listening on http://localhost:${PORT}`);
-    console.log(
-      `[MCP HTTP Server] Health check: http://localhost:${PORT}/health`,
-    );
+    console.log(`[MCP HTTP Server] Liveness:  http://localhost:${PORT}/health`);
+    console.log(`[MCP HTTP Server] Readiness: http://localhost:${PORT}/ready`);
     console.log(
       `[MCP HTTP Server] Modern endpoint: http://localhost:${PORT}/mcp (Streamable HTTP)`,
     );
@@ -157,6 +202,62 @@ export async function runHttpMode() {
       );
     }
   });
+
+  // Register graceful shutdown. Tears down active
+  // transports before any subsystem registered earlier (e.g. logging).
+  registerShutdownHandler("http-transport", async () => {
+    await drainHttpTransport(httpServer, transports);
+  });
+}
+
+/**
+ * Drain the HTTP transport. Called by the shutdown manager on SIGTERM.
+ *
+ * Sequence:
+ *   1. Stop accepting new TCP connections (httpServer.close).
+ *      This does NOT close existing keep-alive / SSE connections.
+ *   2. Close idle keep-alive connections immediately.
+ *   3. Close every active transport, which fires transport.onclose →
+ *      cleanupSession(sessionId) → per-client cleanupSession (e.g. Reflect
+ *      WebSockets).
+ *   4. Wait for httpServer.close() to fully resolve, then force-close any
+ *      remaining keep-alive connections as a backstop.
+ */
+export async function drainHttpTransport(
+  httpServer: import("node:http").Server,
+  transports: Map<string, SessionEntry>,
+): Promise<void> {
+  console.log(
+    `[MCP][shutdown] Draining HTTP transport (${transports.size} active session(s))`,
+  );
+
+  // Stop accepting new connections.
+  const serverClosed = new Promise<void>((resolve) => {
+    httpServer.close(() => resolve());
+  });
+
+  // Close idle keep-alive sockets right away — no in-flight work to lose.
+  httpServer.closeIdleConnections?.();
+
+  // Close every active transport. transport.close() ends SSE streams and
+  // triggers the existing onclose -> cleanupSession chain.
+  const transportCloses = [...transports.values()].map(async (entry) => {
+    try {
+      await entry.transport.close();
+    } catch (err) {
+      console.error("[MCP][shutdown] Error closing transport:", err);
+    }
+  });
+
+  await Promise.all(transportCloses);
+
+  // Backstop: force-close any TCP connections still hanging around so
+  // httpServer.close() can resolve. Safe to call after transport.close()
+  // because all session-aware teardown has already run.
+  httpServer.closeAllConnections?.();
+
+  await serverClosed;
+  console.log("[MCP][shutdown] HTTP transport drained");
 }
 
 /**

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -224,7 +224,7 @@ export async function runHttpMode() {
  *      remaining keep-alive connections as a backstop.
  */
 export async function drainHttpTransport(
-  httpServer: import("node:http").Server,
+  httpServer: Server,
   transports: Map<string, SessionEntry>,
 ): Promise<void> {
   console.log(

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { clientRegistry } from "./client-registry";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
 import { SmartBearMcpServer } from "./server";
+import { registerShutdownHandler } from "./shutdown";
 import type { Client } from "./types";
 import { getTypeDescription, isOptionalType } from "./zod-utils";
 
@@ -65,6 +66,30 @@ export async function runStdioMode() {
   }
 
   const transport = new StdioServerTransport();
+
+  // Graceful shutdown: close the transport on SIGTERM/SIGINT.
+  //
+  // Stdio normally exits cleanly when the parent closes stdin. This handler
+  // is only meaningful when the process receives a signal directly (e.g.
+  // the parent kills us hard). It calls transport.close() so the SDK stops
+  // reading stdin promptly.
+  //
+  // Note: there is no per-session `cleanupSession` call here because the
+  // stdio transport has no sessionId — there is exactly one connection per
+  // process lifetime — and tools running over stdio never receive an
+  // mcpSessionId in their `extra` argument, so per-client session maps are
+  // never populated under stdio. Resources held by clients (e.g. Reflect
+  // WebSockets) are released when the process exits. Adding a process-wide
+  // teardown hook for stdio would require extending the Client interface
+  // with a `cleanupAll()`; tracked as a separate enhancement.
+  registerShutdownHandler("stdio-transport", async () => {
+    try {
+      await transport.close();
+    } catch (err) {
+      console.error("[MCP][shutdown] Error closing stdio transport:", err);
+    }
+  });
+
   transport.onmessage = (message) => {
     if ("method" in message && message.method === "initialize") {
       if (message.params?.protocolVersion === "2025-11-25") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import Bugsnag from "./common/bugsnag";
 import "./common/register-clients"; // Register all available clients
+import { installSignalHandlers } from "./common/shutdown";
 import { runHttpMode } from "./common/transport-http";
 import { runStdioMode } from "./common/transport-stdio";
 
@@ -10,6 +11,10 @@ const McpServerBugsnagAPIKey = process.env.MCP_SERVER_BUGSNAG_API_KEY;
 if (McpServerBugsnagAPIKey) {
   Bugsnag.start(McpServerBugsnagAPIKey);
 }
+
+// Install SIGTERM / SIGINT handlers before any transport starts so that
+// signals received during startup are captured and trigger an orderly drain.
+installSignalHandlers();
 
 async function main() {
   // Determine transport mode from environment variable

--- a/src/tests/unit/common/shutdown.test.ts
+++ b/src/tests/unit/common/shutdown.test.ts
@@ -1,0 +1,311 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ShutdownManager } from "../../../common/shutdown";
+
+/**
+ * Build a fake process.on/off surface so tests can fire signals at the
+ * manager without involving the real Node process.
+ */
+function fakeProcess(): NodeJS.Process {
+  const emitter = new EventEmitter();
+  const proc: any = {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    listenerCount: emitter.listenerCount.bind(emitter),
+  };
+  return proc as NodeJS.Process;
+}
+
+function silentLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("ShutdownManager.drain", () => {
+  it("runs handlers in LIFO order", async () => {
+    const order: string[] = [];
+    const m = new ShutdownManager({
+      logger: silentLogger(),
+      exit: () => {},
+    });
+    m.register("first", () => {
+      order.push("first");
+    });
+    m.register("second", () => {
+      order.push("second");
+    });
+    m.register("third", () => {
+      order.push("third");
+    });
+
+    const result = await m.drain();
+
+    expect(result.status).toBe("clean");
+    expect(order).toEqual(["third", "second", "first"]);
+  });
+
+  it("awaits async handlers sequentially", async () => {
+    const order: string[] = [];
+    const m = new ShutdownManager({
+      logger: silentLogger(),
+      exit: () => {},
+    });
+    m.register("a", async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("a-done");
+    });
+    m.register("b", async () => {
+      order.push("b-start");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("b-done");
+    });
+
+    await m.drain();
+
+    // LIFO: b runs first, fully, then a.
+    expect(order).toEqual(["b-start", "b-done", "a-done"]);
+  });
+
+  it("continues running subsequent handlers when one throws", async () => {
+    const ran: string[] = [];
+    const logger = silentLogger();
+    const m = new ShutdownManager({ logger, exit: () => {} });
+    m.register("good-1", () => {
+      ran.push("good-1");
+    });
+    m.register("bad", () => {
+      throw new Error("boom");
+    });
+    m.register("good-2", () => {
+      ran.push("good-2");
+    });
+
+    const result = await m.drain();
+
+    expect(result.status).toBe("clean");
+    expect(ran).toEqual(["good-2", "good-1"]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Handler "bad" threw'),
+      expect.any(Error),
+    );
+  });
+
+  it("continues when an async handler rejects", async () => {
+    const ran: string[] = [];
+    const logger = silentLogger();
+    const m = new ShutdownManager({ logger, exit: () => {} });
+    m.register("ok", () => {
+      ran.push("ok");
+    });
+    m.register("rejects", async () => {
+      throw new Error("async boom");
+    });
+
+    const result = await m.drain();
+
+    expect(result.status).toBe("clean");
+    expect(ran).toEqual(["ok"]);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("returns deadline status with names of unfinished handlers", async () => {
+    const m = new ShutdownManager({
+      timeoutMs: 50,
+      logger: silentLogger(),
+      exit: () => {},
+    });
+    m.register("fast", () => {});
+    m.register("hangs", () => new Promise<void>(() => {}));
+
+    const result = await m.drain();
+
+    expect(result.status).toBe("deadline");
+    // LIFO: "hangs" runs first and never finishes, so "hangs" and "fast"
+    // are both in the remaining set.
+    expect(result.remainingHandlers).toContain("hangs");
+    expect(result.remainingHandlers).toContain("fast");
+  });
+
+  it("flips isDraining() during drain and getState() through the lifecycle", async () => {
+    const m = new ShutdownManager({
+      logger: silentLogger(),
+      exit: () => {},
+    });
+    expect(m.isDraining()).toBe(false);
+    expect(m.getState()).toBe("idle");
+
+    let observedDuringHandler: boolean | undefined;
+    m.register("observe", () => {
+      observedDuringHandler = m.isDraining();
+    });
+
+    await m.drain();
+
+    expect(observedDuringHandler).toBe(true);
+    expect(m.isDraining()).toBe(true); // still true once complete (state is "complete", not "idle")
+    expect(m.getState()).toBe("complete");
+  });
+
+  it("is idempotent: second drain is a no-op", async () => {
+    const handler = vi.fn();
+    const m = new ShutdownManager({
+      logger: silentLogger(),
+      exit: () => {},
+    });
+    m.register("once", handler);
+
+    await m.drain();
+    await m.drain();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to register handlers after drain has started", async () => {
+    const logger = silentLogger();
+    const m = new ShutdownManager({ logger, exit: () => {} });
+    m.register("first", () => {});
+    const drainPromise = m.drain();
+    // Once drain has begun, late registrations are rejected.
+    m.register("late", () => {
+      throw new Error("should not run");
+    });
+    await drainPromise;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Refusing to register handler "late"'),
+    );
+  });
+});
+
+describe("ShutdownManager signal handling", () => {
+  let proc: NodeJS.Process;
+  let exit: ReturnType<typeof vi.fn>;
+  let logger: ReturnType<typeof silentLogger>;
+
+  beforeEach(() => {
+    proc = fakeProcess();
+    exit = vi.fn();
+    logger = silentLogger();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("triggers drain on SIGTERM and exits 0 on clean drain", async () => {
+    const handler = vi.fn();
+    const m = new ShutdownManager({ process: proc, exit, logger });
+    m.register("h", handler);
+    m.installSignalHandlers();
+
+    (proc as unknown as EventEmitter).emit("SIGTERM");
+
+    // Drain runs on the microtask queue; flush.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("exits 1 when drain hits the deadline", async () => {
+    const m = new ShutdownManager({
+      process: proc,
+      exit,
+      logger,
+      timeoutMs: 20,
+    });
+    m.register("hangs", () => new Promise<void>(() => {}));
+    m.installSignalHandlers();
+
+    (proc as unknown as EventEmitter).emit("SIGTERM");
+
+    // Wait past the deadline.
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("forces exit(1) on a second signal during drain", async () => {
+    const m = new ShutdownManager({
+      process: proc,
+      exit,
+      logger,
+      timeoutMs: 5_000,
+    });
+    m.register("slow", () => new Promise((r) => setTimeout(r, 200)));
+    m.installSignalHandlers();
+
+    (proc as unknown as EventEmitter).emit("SIGTERM");
+    // Yield so drain enters the "draining" state.
+    await new Promise((r) => setImmediate(r));
+    expect(m.isDraining()).toBe(true);
+
+    (proc as unknown as EventEmitter).emit("SIGTERM");
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Received SIGTERM while draining"),
+    );
+  });
+
+  it("listens on SIGTERM and SIGINT by default", () => {
+    const m = new ShutdownManager({ process: proc, exit, logger });
+    m.installSignalHandlers();
+
+    expect((proc as unknown as EventEmitter).listenerCount("SIGTERM")).toBe(1);
+    expect((proc as unknown as EventEmitter).listenerCount("SIGINT")).toBe(1);
+  });
+
+  it("installSignalHandlers is idempotent", () => {
+    const m = new ShutdownManager({ process: proc, exit, logger });
+    m.installSignalHandlers();
+    m.installSignalHandlers();
+    expect((proc as unknown as EventEmitter).listenerCount("SIGTERM")).toBe(1);
+  });
+
+  it("uninstallSignalHandlers removes listeners", () => {
+    const m = new ShutdownManager({ process: proc, exit, logger });
+    m.installSignalHandlers();
+    m.uninstallSignalHandlers();
+    expect((proc as unknown as EventEmitter).listenerCount("SIGTERM")).toBe(0);
+    expect((proc as unknown as EventEmitter).listenerCount("SIGINT")).toBe(0);
+  });
+});
+
+describe("ShutdownManager configuration", () => {
+  it("reads MCP_SHUTDOWN_TIMEOUT_MS for default timeout", async () => {
+    const original = process.env.MCP_SHUTDOWN_TIMEOUT_MS;
+    process.env.MCP_SHUTDOWN_TIMEOUT_MS = "30";
+
+    const m = new ShutdownManager({ logger: silentLogger(), exit: () => {} });
+    m.register("hangs", () => new Promise<void>(() => {}));
+    const result = await m.drain();
+
+    expect(result.status).toBe("deadline");
+    // Should have hit deadline at ~30ms, well under any default.
+    expect(result.durationMs).toBeLessThan(500);
+
+    if (original === undefined) {
+      delete process.env.MCP_SHUTDOWN_TIMEOUT_MS;
+    } else {
+      process.env.MCP_SHUTDOWN_TIMEOUT_MS = original;
+    }
+  });
+
+  it("ignores invalid MCP_SHUTDOWN_TIMEOUT_MS", () => {
+    const original = process.env.MCP_SHUTDOWN_TIMEOUT_MS;
+    process.env.MCP_SHUTDOWN_TIMEOUT_MS = "not-a-number";
+
+    // Should not throw at construction time.
+    expect(
+      () => new ShutdownManager({ logger: silentLogger(), exit: () => {} }),
+    ).not.toThrow();
+
+    if (original === undefined) {
+      delete process.env.MCP_SHUTDOWN_TIMEOUT_MS;
+    } else {
+      process.env.MCP_SHUTDOWN_TIMEOUT_MS = original;
+    }
+  });
+});

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -2,8 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clientRegistry } from "../../../common/client-registry";
 import {
+  drainHttpTransport,
   getBaseUrl,
   getHeaderName,
+  handleHealthRequest,
+  handleReadyRequest,
   newServer,
 } from "../../../common/transport-http";
 import type { Client } from "../../../common/types";
@@ -422,5 +425,125 @@ describe("newServer (OAuth flow)", () => {
     expect(res._body).toContain("Configuration error");
     expect(res._body).toContain("HelpTest");
     expect(res._body).toContain("HelpTest-Auth-Token");
+  });
+});
+
+describe("probe endpoints", () => {
+  describe("handleHealthRequest (liveness)", () => {
+    it("returns 200 with no-store cache header", () => {
+      const res = fakeResponse();
+      handleHealthRequest(res);
+      expect(res._status).toBe(200);
+      expect(res._headers["Cache-Control"]).toBe("no-store");
+      expect(res._headers["Content-Type"]).toBe("application/json");
+      const body = JSON.parse(res._body);
+      expect(body.status).toBe("ok");
+      expect(body.timestamp).toEqual(expect.any(String));
+    });
+
+    // Critical regression guard: liveness must NEVER flip during drain. If
+    // it did, the kubelet would kill the pod mid-drain instead of letting
+    // it finish gracefully. /ready is the one that flips.
+    it("does not depend on draining state", () => {
+      const res = fakeResponse();
+      handleHealthRequest(res);
+      // Even though we don't pass a draining function, /health is
+      // unconditional — so this is asserting the contract by absence.
+      expect(res._status).toBe(200);
+    });
+  });
+
+  describe("handleReadyRequest (readiness)", () => {
+    it("returns 200 when not draining", () => {
+      const res = fakeResponse();
+      handleReadyRequest(res, () => false);
+      expect(res._status).toBe(200);
+      expect(res._headers["Cache-Control"]).toBe("no-store");
+      const body = JSON.parse(res._body);
+      expect(body.status).toBe("ready");
+    });
+
+    it("returns 503 with no-store when draining", () => {
+      const res = fakeResponse();
+      handleReadyRequest(res, () => true);
+      expect(res._status).toBe(503);
+      expect(res._headers["Cache-Control"]).toBe("no-store");
+      const body = JSON.parse(res._body);
+      expect(body.status).toBe("draining");
+    });
+  });
+});
+
+describe("drainHttpTransport", () => {
+  function fakeHttpServer(
+    closeBehaviour: "immediate" | "manual" = "immediate",
+  ) {
+    let closeCb: (() => void) | undefined;
+    return {
+      _closeCb: () => closeCb?.(),
+      close: vi.fn().mockImplementation((cb: () => void) => {
+        if (closeBehaviour === "immediate") {
+          cb();
+        } else {
+          closeCb = cb;
+        }
+      }),
+      closeIdleConnections: vi.fn(),
+      closeAllConnections: vi.fn(),
+    };
+  }
+
+  function fakeTransportEntry() {
+    return {
+      server: {} as any,
+      transport: {
+        close: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    };
+  }
+
+  it("closes idle connections, every transport, then awaits server close", async () => {
+    const httpServer = fakeHttpServer("immediate");
+    const a = fakeTransportEntry();
+    const b = fakeTransportEntry();
+    const transports = new Map<string, any>([
+      ["sid-a", a],
+      ["sid-b", b],
+    ]);
+
+    await drainHttpTransport(httpServer as any, transports);
+
+    expect(httpServer.close).toHaveBeenCalled();
+    expect(httpServer.closeIdleConnections).toHaveBeenCalled();
+    expect(a.transport.close).toHaveBeenCalled();
+    expect(b.transport.close).toHaveBeenCalled();
+    expect(httpServer.closeAllConnections).toHaveBeenCalled();
+  });
+
+  it("swallows errors from transport.close so other transports still drain", async () => {
+    const httpServer = fakeHttpServer("immediate");
+    const good = fakeTransportEntry();
+    const bad = fakeTransportEntry();
+    bad.transport.close = vi.fn().mockRejectedValue(new Error("boom"));
+    const transports = new Map<string, any>([
+      ["sid-good", good],
+      ["sid-bad", bad],
+    ]);
+
+    await expect(
+      drainHttpTransport(httpServer as any, transports),
+    ).resolves.toBeUndefined();
+
+    expect(good.transport.close).toHaveBeenCalled();
+    expect(bad.transport.close).toHaveBeenCalled();
+  });
+
+  it("works with an empty transports map", async () => {
+    const httpServer = fakeHttpServer("immediate");
+    const transports = new Map<string, any>();
+    await expect(
+      drainHttpTransport(httpServer as any, transports),
+    ).resolves.toBeUndefined();
+    expect(httpServer.close).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Goal

Adds graceful shutdown so that on SIGTERM the process:

1. Stops advertising itself as ready (so the LB stops sending new sessions).
2. Drains active sessions, running each client's `cleanupSession` hook.
3. Exits 0 on a clean drain or 1 if a configurable deadline is exceeded.

It also splits the existing `/health` endpoint into two probes: liveness and readiness.

## Design

**ShutdownManager** (`src/common/shutdown.ts`) is a small lifecycle module with SIGTERM/SIGINT handling. Subsystems register named cleanup callbacks; on signal they run in **LIFO order** with a deadline (default 25s, overridable via `MCP_SHUTDOWN_TIMEOUT_MS`).

**Probe split.** 
- `/health` is now liveness-only 
- `/ready` is readiness and returns 503 once `isDraining()` is true. 

**HTTP transport drain** (`drainHttpTransport`) sequences:

1. `httpServer.close()` to stop accepting new TCP connections.
2. `httpServer.closeIdleConnections()` to release keep-alive sockets with no in-flight work.
3. `transport.close()` on every entry in the `transports` map. This ends SSE streams and triggers the existing `transport.onclose` → `server.cleanupSession(sessionId)` chain, which is where Reflect's
per-session WebSocket teardown actually runs.
4. `httpServer.closeAllConnections()` as a backstop so `httpServer.close()` resolves even if a client refuses to drop its socket.

**Stdio transport** registers a much smaller handler that just calls `transport.close()`. Process-wide teardown for stdio (e.g. closing all Reflect WebSockets) would need a new `Client.cleanupAll()` interface method, out of scope here.

## Changeset

- `src/common/shutdown.ts` - added shutdown manager class 
- `src/common/transport-http.ts`- added `handleHealthRequest`, `handleReadyRequest`, `drainHttpTransport` methods
- `src/common/transport-stdio.ts` - added shutdown handler
- added tests for new http endpoints and shutdown handling
- new env var: `MCP_SHUTDOWN_TIMEOUT_MS` (default `25000`).

## Testing
No change to mcp tools functionality

**Manual test**: started in HTTP mode, hit both probes, sent SIGTERM:

```
=== /health (should be 200 ok) ===
HTTP/1.1 200 OK
Cache-Control: no-store
{"status":"ok","timestamp":"..."}

=== /ready (should be 200 ready) ===
HTTP/1.1 200 OK
Cache-Control: no-store
{"status":"ready","timestamp":"..."}

=== Sending SIGTERM ===
[MCP][shutdown] Received SIGTERM, starting drain
[MCP][shutdown] Draining 1 handler(s), deadline 5000ms
[MCP][shutdown] Draining HTTP transport (0 active session(s))
[MCP][shutdown] HTTP transport drained
[MCP][shutdown] Drained cleanly in 1ms

=== Process exited with code 0 ===
```