### PR TITLE
Standardise prompt and resource registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Common] Add graceful shutdown on SIGTERM/SIGINT in HTTP mode: drains active sessions (closes Streamable HTTP and SSE transports, runs per-client `cleanupSession` hooks including Reflect WebSocket teardown), with a configurable deadline via `MCP_SHUTDOWN_TIMEOUT_MS` (default 25s) [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
 - [Common] Split health/readiness probes: `GET /health` is now liveness-only and always returns 200 when the process is responsive; `GET /ready` is the readiness probe and returns 503 during drain so load balancers stop routing new sessions to draining pods. Both probes set `Cache-Control: no-store`. [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
-- [Common] Add product prefix to registered prompts [#458](https://github.com/SmartBear/smartbear-mcp/pull/458)
+- [Common] Add product prefix to registered resources and prompts [#458](https://github.com/SmartBear/smartbear-mcp/pull/458)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Common] Add graceful shutdown on SIGTERM/SIGINT in HTTP mode: drains active sessions (closes Streamable HTTP and SSE transports, runs per-client `cleanupSession` hooks including Reflect WebSocket teardown), with a configurable deadline via `MCP_SHUTDOWN_TIMEOUT_MS` (default 25s) [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
 - [Common] Split health/readiness probes: `GET /health` is now liveness-only and always returns 200 when the process is responsive; `GET /ready` is the readiness probe and returns 503 during drain so load balancers stop routing new sessions to draining pods. Both probes set `Cache-Control: no-store`. [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
+- [Common] Add product prefix to registered prompts [#458](https://github.com/SmartBear/smartbear-mcp/pull/458)
 
 ### Fixed
 

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -458,15 +458,22 @@ export class BugsnagClient implements Client {
   }
 
   registerResources(register: RegisterResourceFunction): void {
-    register("event", "{id}", async (uri, variables, _extra) => {
-      return {
-        contents: [
-          {
-            uri: uri.href,
-            text: JSON.stringify(await this.getEvent(variables.id as string)),
-          },
-        ],
-      };
-    });
+    register(
+      {
+        name: "event",
+        path: "{id}",
+        description: "Retrieve a specific event by its ID.",
+      },
+      async (uri, variables, _extra) => {
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              text: JSON.stringify(await this.getEvent(variables.id as string)),
+            },
+          ],
+        };
+      },
+    );
   }
 }

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -107,7 +107,7 @@ export class BugsnagClient implements Client {
   }
 
   name = "BugSnag";
-  toolPrefix = "bugsnag";
+  capabilityPrefix = "bugsnag";
   configPrefix = "Bugsnag";
   config = ConfigurationSchema;
 

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -457,7 +457,7 @@ export class BugsnagClient implements Client {
     }
   }
 
-  registerResources(register: RegisterResourceFunction): void {
+  async registerResources(register: RegisterResourceFunction): Promise<void> {
     register(
       {
         name: "event",

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -460,7 +460,7 @@ export class BugsnagClient implements Client {
   async registerResources(register: RegisterResourceFunction): Promise<void> {
     register(
       {
-        name: "event",
+        title: "Event",
         path: "{id}",
         description: "Retrieve a specific event by its ID.",
       },

--- a/src/collaborator/client.ts
+++ b/src/collaborator/client.ts
@@ -21,7 +21,7 @@ const ConfigurationSchema = z.object({
 
 export class CollaboratorClient implements Client {
   name = "Collaborator";
-  toolPrefix = "collaborator";
+  capabilityPrefix = "collaborator";
   configPrefix = "Collaborator";
   config = ConfigurationSchema;
 

--- a/src/common/bugsnag.ts
+++ b/src/common/bugsnag.ts
@@ -1,3 +1,5 @@
 // workaround for a known issue with Bugsnag types in node16 modules: https://github.com/bugsnag/bugsnag-js/issues/2052
 import * as Bugsnag from "@bugsnag/js";
-export default Bugsnag.default as unknown as typeof Bugsnag.default.default;
+export default Bugsnag.default as unknown as typeof Bugsnag.default;
+
+export type { Event as BugsnagEvent } from "@bugsnag/js/types";

--- a/src/common/prompts.ts
+++ b/src/common/prompts.ts
@@ -1,6 +1,6 @@
 import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ZodRawShape } from "zod";
-import type { Client } from "./types";
+import type { Client, PromptParams } from "./types";
 
 /**
  * Base class encapsulating a prompt's configuration and callback, with reference to its client.
@@ -10,11 +10,6 @@ export abstract class Prompt<T extends Client> {
   constructor(client: T) {
     this.client = client;
   }
-  abstract name: string;
-  abstract params: {
-    title?: string;
-    description?: string;
-    argsSchema?: ZodRawShape;
-  };
+  abstract specification: PromptParams;
   abstract callback: PromptCallback<ZodRawShape>;
 }

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -41,20 +41,11 @@ export class SmartBearMcpServer extends McpServer {
         version: MCP_SERVER_VERSION,
       },
       {
-        instructions: `When creating or editing a Reflect test using a connected recording session, follow these guidelines:
-
-1. After connecting to a session, get the list of segments for the session's platform type so you know what actions could be added via segments vs needing to create new steps. Do not list tests, only list segments.
-2. Before performing an action, take a screenshot to understand the current state of the application.
-3. Each add_prompt_step request should perform a single action or assertion. Do not combine multiple actions or assertions into a single step.
-4. Only perform one action at a time unless you're sure the action won't move the application to a different screen. For example, you can send multiple add_prompt_step requests to fill out individual form fields if those fields are visible on the current screen.
-5. Check the list of existing Segments to see if a Segment exists that achieves a similar goal to what you're trying to do next. If so, add the segment instead of creating new steps.
-6. If a step fails, use delete_previous_step to remove it and try a different approach.
-7. After completing a task, if the task required multiple prompt steps, add a final prompt step that validates the current state of the page based on what you see on the screen. In your validation, do not reference information that can change from run to run.`,
         capabilities: {
-          resources: { listChanged: true }, // Server supports dynamic resource lists
           tools: { listChanged: true }, // Server supports dynamic tool lists
+          resources: { listChanged: true }, // Server supports dynamic resource lists
+          prompts: { listChanged: true }, // Server supports sending prompts to Host
           logging: {}, // Server supports logging messages
-          prompts: {}, // Server supports sending prompts to Host
         },
       },
     );

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -95,8 +95,8 @@ export class SmartBearMcpServer extends McpServer {
     this.clients.push(client);
     await client.registerTools(
       (params, cb) => {
-        const toolName = `${client.toolPrefix}_${params.title.replace(/\s+/g, "_").toLowerCase()}`;
-        const toolTitle = `${client.name}: ${params.title}`;
+        const toolName = this.getToolName(client, params.title);
+        const toolTitle = this.getToolTitle(client, params.title);
         return super.registerTool(
           toolName,
           {
@@ -205,10 +205,26 @@ export class SmartBearMcpServer extends McpServer {
     }
 
     if (client.registerPrompts) {
-      client.registerPrompts((name, config, cb) => {
-        return super.registerPrompt(name, config, cb);
+      client.registerPrompts((params, cb) => {
+        return super.registerPrompt(
+          this.getToolName(client, params.title),
+          {
+            title: this.getToolTitle(client, params.title),
+            description: params.description,
+            argsSchema: this.schemaToRawShape(params.argsSchema) || {},
+          },
+          (args: any, extra: any) => cb(args, extra),
+        );
       });
     }
+  }
+
+  private getToolTitle(client: Client, title: string): string {
+    return `${client.name}: ${title}`;
+  }
+
+  private getToolName(client: Client, title: string): string {
+    return `${client.toolPrefix}_${title.replace(/\s+/g, "_").toLowerCase()}`;
   }
 
   private validateCallbackResult(result: CallToolResult, params: ToolParams) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -172,14 +172,17 @@ export class SmartBearMcpServer extends McpServer {
     );
 
     if (client.registerResources) {
-      client.registerResources((name, path, cb) => {
-        const url = `${client.toolPrefix}://${name}/${path}`;
+      client.registerResources((params, cb) => {
+        const url = `${client.toolPrefix}://${params.name}/${params.path}`;
         return super.registerResource(
-          name,
+          this.getToolName(client, params.name),
           new ResourceTemplate(url, {
             list: undefined,
           }),
-          {},
+          {
+            title: this.getToolTitle(client, params.name),
+            description: params.description,
+          },
           async (url: any, variables: any, extra: any) => {
             try {
               return await cb(url, variables, extra);
@@ -193,7 +196,10 @@ export class SmartBearMcpServer extends McpServer {
                   ) => void;
                   unhandled: boolean;
                 }) => {
-                  event.addMetadata("app", { resource: name, url: url });
+                  event.addMetadata("app", {
+                    resource: this.getToolName(client, params.name),
+                    url: url,
+                  });
                   event.unhandled = true;
                 },
               );

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -163,7 +163,7 @@ export class SmartBearMcpServer extends McpServer {
     );
 
     if (client.registerResources) {
-      client.registerResources((params, cb) => {
+      await client.registerResources((params, cb) => {
         const url = `${client.toolPrefix}://${params.name}/${params.path}`;
         return super.registerResource(
           this.getToolName(client, params.name),
@@ -202,7 +202,7 @@ export class SmartBearMcpServer extends McpServer {
     }
 
     if (client.registerPrompts) {
-      client.registerPrompts((params, cb) => {
+      await client.registerPrompts((params, cb) => {
         return super.registerPrompt(
           this.getToolName(client, params.title),
           {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -158,15 +158,16 @@ export class SmartBearMcpServer extends McpServer {
 
     if (client.registerResources) {
       await client.registerResources((params, cb) => {
-        const slug = params.name.replace(/\s+/g, "_").toLowerCase();
+        const resourceName = this.getCapabilityName(client, params.title);
+        const slug = params.title.replace(/\s+/g, "_").toLowerCase();
         const url = `${client.capabilityPrefix}://${slug}/${params.path}`;
         return super.registerResource(
-          this.getCapabilityName(client, params.name),
+          resourceName,
           new ResourceTemplate(url, {
             list: undefined,
           }),
           {
-            title: this.getCapabilityTitle(client, params.name),
+            title: this.getCapabilityTitle(client, params.title),
             description: params.description,
           },
           async (url: any, variables: any, extra: any) => {
@@ -175,7 +176,7 @@ export class SmartBearMcpServer extends McpServer {
             } catch (e) {
               Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
                 event.addMetadata("app", {
-                  resource: this.getCapabilityName(client, params.name),
+                  resource: resourceName,
                   url: url,
                 });
                 event.unhandled = true;

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -12,7 +12,7 @@ import {
   type ZodRawShape,
   type ZodType,
 } from "zod";
-import Bugsnag from "../common/bugsnag";
+import Bugsnag, { type BugsnagEvent } from "../common/bugsnag";
 import { CacheService } from "./cache";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
 import {
@@ -86,8 +86,8 @@ export class SmartBearMcpServer extends McpServer {
     this.clients.push(client);
     await client.registerTools(
       (params, cb) => {
-        const toolName = this.getToolName(client, params.title);
-        const toolTitle = this.getToolTitle(client, params.title);
+        const toolName = this.getCapabilityName(client, params.title);
+        const toolTitle = this.getCapabilityTitle(client, params.title);
         return super.registerTool(
           toolName,
           {
@@ -125,16 +125,10 @@ export class SmartBearMcpServer extends McpServer {
                   ],
                 };
               } else {
-                Bugsnag.notify(
-                  e as unknown as Error,
-                  (event: {
-                    addMetadata: (arg0: string, arg1: { tool: string }) => void;
-                    unhandled: boolean;
-                  }) => {
-                    event.addMetadata("app", { tool: toolName });
-                    event.unhandled = true;
-                  },
-                );
+                Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
+                  event.addMetadata("app", { tool: toolName });
+                  event.unhandled = true;
+                });
               }
               throw e;
             }
@@ -164,36 +158,28 @@ export class SmartBearMcpServer extends McpServer {
 
     if (client.registerResources) {
       await client.registerResources((params, cb) => {
-        const url = `${client.toolPrefix}://${params.name}/${params.path}`;
+        const slug = params.name.replace(/\s+/g, "_").toLowerCase();
+        const url = `${client.capabilityPrefix}://${slug}/${params.path}`;
         return super.registerResource(
-          this.getToolName(client, params.name),
+          this.getCapabilityName(client, params.name),
           new ResourceTemplate(url, {
             list: undefined,
           }),
           {
-            title: this.getToolTitle(client, params.name),
+            title: this.getCapabilityTitle(client, params.name),
             description: params.description,
           },
           async (url: any, variables: any, extra: any) => {
             try {
               return await cb(url, variables, extra);
             } catch (e) {
-              Bugsnag.notify(
-                e as unknown as Error,
-                (event: {
-                  addMetadata: (
-                    arg0: string,
-                    arg1: { resource: string; url: any },
-                  ) => void;
-                  unhandled: boolean;
-                }) => {
-                  event.addMetadata("app", {
-                    resource: this.getToolName(client, params.name),
-                    url: url,
-                  });
-                  event.unhandled = true;
-                },
-              );
+              Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
+                event.addMetadata("app", {
+                  resource: this.getCapabilityName(client, params.name),
+                  url: url,
+                });
+                event.unhandled = true;
+              });
               throw e;
             }
           },
@@ -204,24 +190,28 @@ export class SmartBearMcpServer extends McpServer {
     if (client.registerPrompts) {
       await client.registerPrompts((params, cb) => {
         return super.registerPrompt(
-          this.getToolName(client, params.title),
+          this.getCapabilityName(client, params.title),
           {
-            title: this.getToolTitle(client, params.title),
+            title: this.getCapabilityTitle(client, params.title),
             description: params.description,
             argsSchema: this.schemaToRawShape(params.argsSchema) || {},
           },
-          (args: any, extra: any) => cb(args, extra),
+          async (args: any, extra: any) => {
+            try {
+              return await cb(args, extra);
+            } catch (e) {
+              Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
+                event.addMetadata("app", {
+                  prompt: this.getCapabilityName(client, params.title),
+                });
+                event.unhandled = true;
+              });
+              throw e;
+            }
+          },
         );
       });
     }
-  }
-
-  private getToolTitle(client: Client, title: string): string {
-    return `${client.name}: ${title}`;
-  }
-
-  private getToolName(client: Client, title: string): string {
-    return `${client.toolPrefix}_${title.replace(/\s+/g, "_").toLowerCase()}`;
   }
 
   private validateCallbackResult(result: CallToolResult, params: ToolParams) {
@@ -278,6 +268,14 @@ export class SmartBearMcpServer extends McpServer {
       }
     }
     return undefined;
+  }
+
+  private getCapabilityTitle(client: Client, title: string): string {
+    return `${client.name}: ${title}`;
+  }
+
+  private getCapabilityName(client: Client, title: string): string {
+    return `${client.capabilityPrefix}_${title.replace(/\s+/g, "_").toLowerCase()}`;
   }
 
   private getDescription(params: ToolParams): string {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -48,7 +48,7 @@ export interface PromptParams {
 }
 
 export interface ResourceParams {
-  name: string;
+  title: string;
   description?: string;
   path: string;
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -42,13 +42,9 @@ export interface ToolParams {
 }
 
 export interface PromptParams {
-  name: string;
-  callback: any;
-  params: {
-    description?: string;
-    argsSchema?: ZodRawShape;
-    title?: string;
-  };
+  title: string;
+  description?: string;
+  argsSchema?: ZodType;
 }
 
 export type RegisterToolsFunction = <InputArgs extends ZodRawShape>(
@@ -63,12 +59,7 @@ export type RegisterResourceFunction = (
 ) => RegisteredResourceTemplate;
 
 export type RegisterPromptFunction = <Args extends ZodRawShape>(
-  name: string,
-  config: {
-    title?: string;
-    description?: string;
-    argsSchema?: Args;
-  },
+  params: PromptParams,
   cb: PromptCallback<Args>,
 ) => RegisteredPrompt;
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -97,8 +97,8 @@ export interface Client {
     register: RegisterToolsFunction,
     getInput: GetInputFunction,
   ): Promise<void>;
-  registerResources?(register: RegisterResourceFunction): void;
-  registerPrompts?(register: RegisterPromptFunction): void;
+  registerResources?(register: RegisterResourceFunction): Promise<void>;
+  registerPrompts?(register: RegisterPromptFunction): Promise<void>;
   /**
    * Optional method to retrieve the authentication token for the current request context.
    * This is used for request-level authentication where the token might change per request.

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -47,14 +47,19 @@ export interface PromptParams {
   argsSchema?: ZodType;
 }
 
+export interface ResourceParams {
+  name: string;
+  description?: string;
+  path: string;
+}
+
 export type RegisterToolsFunction = <InputArgs extends ZodRawShape>(
   params: ToolParams,
   cb: ToolCallback<InputArgs>,
 ) => RegisteredTool;
 
 export type RegisterResourceFunction = (
-  name: string,
-  path: string,
+  params: ResourceParams,
   cb: ReadResourceTemplateCallback,
 ) => RegisteredResourceTemplate;
 
@@ -67,15 +72,6 @@ export type GetInputFunction = (
   params: ElicitRequest["params"],
   options?: RequestOptions,
 ) => Promise<ElicitResult>;
-
-export type Parameters = Array<{
-  name: string;
-  type: ZodType;
-  required: boolean;
-  description?: string;
-  examples?: string[];
-  constraints?: string[];
-}>;
 
 export interface Client {
   /** Human-readable name for the client - usually the product name - used to prefix tool names */

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -74,10 +74,10 @@ export type GetInputFunction = (
 ) => Promise<ElicitResult>;
 
 export interface Client {
-  /** Human-readable name for the client - usually the product name - used to prefix tool names */
+  /** Human-readable name for the client - usually the product name */
   name: string;
-  /** Prefix for tool IDs */
-  toolPrefix: string;
+  /** Prefix for tool, resource and prompt naming */
+  capabilityPrefix: string;
   /** Prefix for configuration (environment variables and http headers) */
   configPrefix: string;
   /**

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -2421,7 +2421,7 @@ export class PactflowClient implements Client {
    *
    * @param register - The function used to register prompts.
    */
-  registerPrompts(register: RegisterPromptFunction): void {
+  async registerPrompts(register: RegisterPromptFunction): Promise<void> {
     PROMPTS.forEach((prompt) => {
       register(
         {

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -75,7 +75,7 @@ const ConfigurationSchema = z.object({
 // Tool definitions for PactFlow AI API client
 export class PactflowClient implements Client {
   name = "Contract Testing";
-  toolPrefix = "contract-testing";
+  capabilityPrefix = "contract-testing";
   configPrefix = "Pact-Broker";
   config = ConfigurationSchema;
 

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -2423,7 +2423,14 @@ export class PactflowClient implements Client {
    */
   registerPrompts(register: RegisterPromptFunction): void {
     PROMPTS.forEach((prompt) => {
-      register(prompt.name, prompt.params, prompt.callback);
+      register(
+        {
+          title: prompt.title,
+          description: prompt.description,
+          argsSchema: prompt.argsSchema,
+        },
+        prompt.callback,
+      );
     });
   }
 }

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -2389,8 +2389,8 @@ export class PactflowClient implements Client {
         continue;
       }
 
-      const { handler, clients: _, formatResponse, ...toolparams } = tool;
-      register(toolparams, async (args, _extra) => {
+      const { handler, clients: _, formatResponse, ...toolParams } = tool;
+      register(toolParams, async (args, _extra) => {
         const handler_fn = (this as any)[handler];
         if (typeof handler_fn !== "function") {
           throw new Error(`Handler '${handler}' not found on PactClient`);
@@ -2422,7 +2422,7 @@ export class PactflowClient implements Client {
    * @param register - The function used to register prompts.
    */
   async registerPrompts(register: RegisterPromptFunction): Promise<void> {
-    PROMPTS.forEach((prompt) => {
+    for (const prompt of PROMPTS) {
       register(
         {
           title: prompt.title,
@@ -2431,6 +2431,6 @@ export class PactflowClient implements Client {
         },
         prompt.callback,
       );
-    });
+    }
   }
 }

--- a/src/pactflow/client/prompts.ts
+++ b/src/pactflow/client/prompts.ts
@@ -1,6 +1,12 @@
-import { z } from "zod";
+import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+import { type ZodRawShape, z } from "zod";
 import type { PromptParams } from "../../common/types";
 import { EndpointMatcherSchema } from "./ai";
+
+export interface PactflowPromptParams extends PromptParams {
+  callback: PromptCallback<ZodRawShape>;
+}
 
 const OADMatcherPromptOpenAPIDocExample = {
   openapi: "3.1.0",
@@ -110,26 +116,30 @@ Now provided the below OpenAPI document:-
 Give JSON recommendations only provide the JSON block in markdown don't include any additional text.
 `;
 
-export const PROMPTS: PromptParams[] = [
+const argsSchema = z.object({
+  openAPI: z
+    .string()
+    .describe("The OpenAPI document to generate matcher recommendations for"),
+});
+
+export const PROMPTS: PactflowPromptParams[] = [
   {
-    name: "OpenAPI Matcher recommendations",
-    params: {
-      description: "Get OpenAPI matcher recommendations using sampling",
-      title: "OpenAPI Matcher recommendations",
-      argsSchema: {
-        openAPI: z.string(),
-      },
-    },
-    callback: ({ openAPI }: { openAPI: string }): object => ({
-      messages: [
-        {
-          role: "user",
-          content: {
-            type: "text",
-            text: OADMatcherPrompt.replace("{0}", openAPI),
+    title: "OpenAPI Matcher recommendations",
+    description: "Get OpenAPI matcher recommendations using sampling",
+    argsSchema,
+    callback: (args): GetPromptResult => {
+      const params = argsSchema.parse(args);
+      return {
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: OADMatcherPrompt.replace("{0}", params.openAPI),
+            },
           },
-        },
-      ],
-    }),
+        ],
+      };
+    },
   },
 ];

--- a/src/qmetry/client.ts
+++ b/src/qmetry/client.ts
@@ -27,7 +27,7 @@ const ConfigurationSchema = z.object({
 
 export class QmetryClient implements Client {
   name = "QMetry";
-  toolPrefix = "qmetry";
+  capabilityPrefix = "qmetry";
   configPrefix = "Qmetry";
   config = ConfigurationSchema;
 

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -212,7 +212,7 @@ export class ReflectClient implements Client {
     const prompts = [new SapTest(this)];
 
     for (const prompt of prompts) {
-      register(prompt.name, prompt.params, prompt.callback);
+      register(prompt.specification, prompt.callback);
     }
   }
 }

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -208,7 +208,7 @@ export class ReflectClient implements Client {
     }
   }
 
-  registerPrompts(register: RegisterPromptFunction): void {
+  async registerPrompts(register: RegisterPromptFunction): Promise<void> {
     const prompts = [new SapTest(this)];
 
     for (const prompt of prompts) {

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -48,7 +48,7 @@ export class ReflectClient implements Client {
   private mcpSessionConnections = new Map<string, Set<string>>();
 
   name = "Reflect";
-  toolPrefix = "reflect";
+  capabilityPrefix = "reflect";
   configPrefix = "Reflect";
 
   config = ConfigurationSchema;

--- a/src/reflect/prompt/sap-test.ts
+++ b/src/reflect/prompt/sap-test.ts
@@ -1,19 +1,17 @@
 import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
+import { type ZodRawShape, z } from "zod";
 import { Prompt } from "../../common/prompts";
 import type { ReflectClient } from "../client";
 
 export class SapTest extends Prompt<ReflectClient> {
-  name = "reflect-sap-test";
-
-  params = {
-    title: "Reflect SAP Test",
+  specification = {
+    title: "SAP Test",
     description:
       "Guidelines for creating a Reflect test against an SAP S4/HANA or SAP BTP application.",
-    argsSchema: {},
+    argsSchema: z.object({}),
   };
 
-  callback: PromptCallback<ZodRawShape> = () => ({
+  callback: PromptCallback<ZodRawShape> = (_args) => ({
     messages: [
       {
         role: "user",

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -74,7 +74,7 @@ export class SwaggerClient implements Client {
   private _apiKey: string | undefined;
 
   name = "Swagger";
-  toolPrefix = "swagger";
+  capabilityPrefix = "swagger";
   configPrefix = "Swagger";
   config = ConfigurationSchema;
 

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -920,7 +920,7 @@ describe("BugsnagClient", () => {
 
       expect(registerResourcesSpy).toHaveBeenCalledWith(
         {
-          name: "event",
+          title: "Event",
           path: "{id}",
           description: "Retrieve a specific event by its ID.",
         },

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -916,7 +916,7 @@ describe("BugsnagClient", () => {
     });
 
     it("should register event resource", async () => {
-      client.registerResources(registerResourcesSpy);
+      await client.registerResources(registerResourcesSpy);
 
       expect(registerResourcesSpy).toHaveBeenCalledWith(
         {
@@ -3134,7 +3134,7 @@ describe("BugsnagClient", () => {
         mockCache.get.mockReturnValueOnce(mockProjects);
         mockErrorAPI.viewEventById.mockResolvedValue({ body: mockEvent });
 
-        client.registerResources(registerResourcesSpy);
+        await client.registerResources(registerResourcesSpy);
         const resourceHandler = registerResourcesSpy.mock.calls[0][1];
 
         const result = await resourceHandler(

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -919,8 +919,11 @@ describe("BugsnagClient", () => {
       client.registerResources(registerResourcesSpy);
 
       expect(registerResourcesSpy).toHaveBeenCalledWith(
-        "event",
-        "{id}",
+        {
+          name: "event",
+          path: "{id}",
+          description: "Retrieve a specific event by its ID.",
+        },
         expect.any(Function),
       );
     });
@@ -3132,7 +3135,7 @@ describe("BugsnagClient", () => {
         mockErrorAPI.viewEventById.mockResolvedValue({ body: mockEvent });
 
         client.registerResources(registerResourcesSpy);
-        const resourceHandler = registerResourcesSpy.mock.calls[0][2];
+        const resourceHandler = registerResourcesSpy.mock.calls[0][1];
 
         const result = await resourceHandler(
           { href: "bugsnag://event/event-1" },

--- a/src/tests/unit/collaborator/client.test.ts
+++ b/src/tests/unit/collaborator/client.test.ts
@@ -48,7 +48,7 @@ describe("CollaboratorClient", () => {
 
     it("has correct client properties", () => {
       expect(client.name).toBe("Collaborator");
-      expect(client.toolPrefix).toBe("collaborator");
+      expect(client.capabilityPrefix).toBe("collaborator");
       expect(client.configPrefix).toBe("Collaborator");
     });
   });

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -21,7 +21,7 @@ exports[`server definitions are not changed unexpectedly > registered resources 
 {
   "bugsnag_event": {
     "description": "Retrieve a specific event by its ID.",
-    "title": "BugSnag: event",
+    "title": "BugSnag: Event",
     "url": "bugsnag://event/{id}",
     "variables": [
       "id",

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -17,6 +17,19 @@ exports[`server definitions are not changed unexpectedly > registered prompts 1`
 }
 `;
 
+exports[`server definitions are not changed unexpectedly > registered resources 1`] = `
+{
+  "bugsnag_event": {
+    "description": "Retrieve a specific event by its ID.",
+    "title": "BugSnag: event",
+    "url": "bugsnag://event/{id}",
+    "variables": [
+      "id",
+    ],
+  },
+}
+`;
+
 exports[`server definitions are not changed unexpectedly > registered tools 1`] = `
 {
   "bugsnag_get_build": {

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -1,6 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`tool definitions > all registered tool definitions match the snapshot 1`] = `
+exports[`server definitions are not changed unexpectedly > registered prompts 1`] = `
+{
+  "contract-testing_openapi_matcher_recommendations": {
+    "argsSchema": [
+      "openAPI",
+    ],
+    "description": "Get OpenAPI matcher recommendations using sampling",
+    "title": "Contract Testing: OpenAPI Matcher recommendations",
+  },
+  "reflect_sap_test": {
+    "argsSchema": [],
+    "description": "Guidelines for creating a Reflect test against an SAP S4/HANA or SAP BTP application.",
+    "title": "Reflect: SAP Test",
+  },
+}
+`;
+
+exports[`server definitions are not changed unexpectedly > registered tools 1`] = `
 {
   "bugsnag_get_build": {
     "annotations": {

--- a/src/tests/unit/common/client-registry.test.ts
+++ b/src/tests/unit/common/client-registry.test.ts
@@ -38,7 +38,7 @@ describe("ClientRegistry", () => {
   ): Client {
     return {
       name,
-      toolPrefix: name,
+      capabilityPrefix: name,
       configPrefix: name,
       config: configSchema,
       configure: vi.fn().mockResolvedValue(true),

--- a/src/tests/unit/common/server-definitions.test.ts
+++ b/src/tests/unit/common/server-definitions.test.ts
@@ -8,8 +8,8 @@ import { clientRegistry } from "../../../common/client-registry";
  * This test verifies that all registered tools from all clients match the expected snapshot.
  * If it fails, verify the diff from the vitest output and, if it's expected, update the snapshot with `vitest -u`.
  */
-describe("tool definitions", () => {
-  it("all registered tool definitions match the snapshot", async () => {
+describe("server definitions are not changed unexpectedly", () => {
+  it("registered tools", async () => {
     const server = new SmartBearMcpServer();
 
     const registeredTools: Record<string, any> = {};
@@ -35,6 +35,33 @@ describe("tool definitions", () => {
 
     const sorted = Object.fromEntries(
       Object.entries(registeredTools).sort(([a], [b]) => a.localeCompare(b)),
+    );
+
+    expect(sorted).toMatchSnapshot();
+  });
+  it("registered prompts", async () => {
+    const server = new SmartBearMcpServer();
+
+    const registeredPrompts: Record<string, any> = {};
+
+    vi.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(server)),
+      "registerPrompt",
+    ).mockImplementation(((promptName: string, config: any) => {
+      registeredPrompts[promptName] = {
+        ...config,
+        argsSchema: config.argsSchema
+          ? Object.keys(config.argsSchema).sort()
+          : undefined,
+      };
+    }) as any);
+
+    for (const client of clientRegistry.getAll()) {
+      await server.addClient(client);
+    }
+
+    const sorted = Object.fromEntries(
+      Object.entries(registeredPrompts).sort(([a], [b]) => a.localeCompare(b)),
     );
 
     expect(sorted).toMatchSnapshot();

--- a/src/tests/unit/common/server-definitions.test.ts
+++ b/src/tests/unit/common/server-definitions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SmartBearMcpServer } from "../../../common/server";
 
 import "../../../common/register-clients";
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { clientRegistry } from "../../../common/client-registry";
 
 /**
@@ -62,6 +63,39 @@ describe("server definitions are not changed unexpectedly", () => {
 
     const sorted = Object.fromEntries(
       Object.entries(registeredPrompts).sort(([a], [b]) => a.localeCompare(b)),
+    );
+
+    expect(sorted).toMatchSnapshot();
+  });
+  it("registered resources", async () => {
+    const server = new SmartBearMcpServer();
+
+    const registeredResources: Record<string, any> = {};
+
+    vi.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(server)),
+      "registerResource",
+    ).mockImplementation(((
+      resourceName: string,
+      template: ResourceTemplate,
+      config: any,
+    ) => {
+      registeredResources[resourceName] = {
+        // @ts-expect-error
+        url: template.uriTemplate.template,
+        variables: template.uriTemplate.variableNames,
+        ...config,
+      };
+    }) as any);
+
+    for (const client of clientRegistry.getAll()) {
+      await server.addClient(client);
+    }
+
+    const sorted = Object.fromEntries(
+      Object.entries(registeredResources).sort(([a], [b]) =>
+        a.localeCompare(b),
+      ),
     );
 
     expect(sorted).toMatchSnapshot();

--- a/src/tests/unit/common/server-definitions.test.ts
+++ b/src/tests/unit/common/server-definitions.test.ts
@@ -6,7 +6,7 @@ import type { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { clientRegistry } from "../../../common/client-registry";
 
 /**
- * This test verifies that all registered tools from all clients match the expected snapshot.
+ * This test verifies that all registered tools, prompts, and resources from all clients match the expected snapshot.
  * If it fails, verify the diff from the vitest output and, if it's expected, update the snapshot with `vitest -u`.
  */
 describe("server definitions are not changed unexpectedly", () => {

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -355,7 +355,14 @@ describe("SmartBearMcpServer", () => {
       // Get the register function passed from the server and execute it with test resource details
       const registerFn = mockClient.registerResources.mock.calls[0][0];
       const registerCbMock = vi.fn();
-      registerFn("test_resource", "{identifier}", registerCbMock);
+      registerFn(
+        {
+          name: "test_resource",
+          path: "{identifier}",
+          description: "A test resource",
+        },
+        registerCbMock,
+      );
 
       expect(superRegisterResourceMock).toHaveBeenCalledExactlyOnceWith(
         expect.any(String),
@@ -366,10 +373,14 @@ describe("SmartBearMcpServer", () => {
 
       // Assert some of the details
       const registerResourceParams = superRegisterResourceMock.mock.calls[0];
-      expect(registerResourceParams[0]).toBe("test_resource");
+      expect(registerResourceParams[0]).toBe("test_product_test_resource");
       expect(registerResourceParams[1].uriTemplate.template).toBe(
         "test_product://test_resource/{identifier}",
       );
+      expect(registerResourceParams[2]).toEqual({
+        description: "A test resource",
+        title: "Test Product: test_resource",
+      });
 
       // Get the wrapper function that will execute the tool and call it
       registerResourceParams[3]();
@@ -402,7 +413,14 @@ describe("SmartBearMcpServer", () => {
       // Get the register function passed from the server and execute it with test resource details
       const registerFn = mockClient.registerResources.mock.calls[0][0];
       const registerCbMock = vi.fn();
-      registerFn("test_resource", "{identifier}", registerCbMock);
+      registerFn(
+        {
+          name: "test_resource",
+          path: "{identifier}",
+          description: "A test resource",
+        },
+        registerCbMock,
+      );
 
       // Make the callback throw an error to test error handling
       registerCbMock.mockImplementation(() => {

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -357,7 +357,7 @@ describe("SmartBearMcpServer", () => {
       const registerCbMock = vi.fn();
       registerFn(
         {
-          name: "test_resource",
+          title: "Test Resource",
           path: "{identifier}",
           description: "A test resource",
         },
@@ -379,7 +379,7 @@ describe("SmartBearMcpServer", () => {
       );
       expect(registerResourceParams[2]).toEqual({
         description: "A test resource",
-        title: "Test Product: test_resource",
+        title: "Test Product: Test Resource",
       });
 
       // Get the wrapper function that will execute the tool and call it
@@ -415,7 +415,7 @@ describe("SmartBearMcpServer", () => {
       const registerCbMock = vi.fn();
       registerFn(
         {
-          name: "test_resource",
+          title: "test_resource",
           path: "{identifier}",
           description: "A test resource",
         },

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -46,7 +46,7 @@ describe("SmartBearMcpServer", () => {
     beforeEach(() => {
       mockClient = {
         name: "Test Product",
-        toolPrefix: "test_product",
+        capabilityPrefix: "test_product",
         configPrefix: "test-product",
         config: z.object({}),
         registerTools: vi.fn(),
@@ -336,7 +336,7 @@ describe("SmartBearMcpServer", () => {
     it("should register resources when client provides them", async () => {
       const mockClient = {
         name: "Test Product",
-        toolPrefix: "test_product",
+        capabilityPrefix: "test_product",
         configPrefix: "test-product",
         registerTools: vi.fn(),
         registerResources: vi.fn(),
@@ -392,7 +392,7 @@ describe("SmartBearMcpServer", () => {
     it("should not register resources when client does not provide them", async () => {
       const mockClient = {
         name: "Test Product",
-        toolPrefix: "test_product",
+        capabilityPrefix: "test_product",
         configPrefix: "test-product",
         registerTools: vi.fn(),
         registerResources: undefined,
@@ -607,7 +607,7 @@ describe("SmartBearMcpServer", () => {
     it("should skip clients without cleanupSession and call those that have it", async () => {
       const clientWithCleanup = {
         name: "Test Product A",
-        toolPrefix: "test_product_a",
+        capabilityPrefix: "test_product_a",
         configPrefix: "test-product-a",
         config: z.object({}),
         registerTools: vi.fn(),
@@ -618,7 +618,7 @@ describe("SmartBearMcpServer", () => {
       };
       const clientWithoutCleanup = {
         name: "Test Product B",
-        toolPrefix: "test_product_b",
+        capabilityPrefix: "test_product_b",
         configPrefix: "test-product-b",
         config: z.object({}),
         registerTools: vi.fn(),

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -82,7 +82,7 @@ function createTestClient(
 
   const client: any = {
     name,
-    toolPrefix: name.toLowerCase(),
+    capabilityPrefix: name.toLowerCase(),
     configPrefix,
     config: z.object(shape),
     _configured: false,

--- a/src/tests/unit/reflect/client.test.ts
+++ b/src/tests/unit/reflect/client.test.ts
@@ -36,7 +36,7 @@ describe("ReflectClient", () => {
   });
 
   it("should have correct tool prefix", () => {
-    expect(client.toolPrefix).toBe("reflect");
+    expect(client.capabilityPrefix).toBe("reflect");
   });
 
   it("should have correct config prefix", () => {

--- a/src/tests/unit/swagger/client.test.ts
+++ b/src/tests/unit/swagger/client.test.ts
@@ -25,7 +25,7 @@ describe("SwaggerClient", () => {
     it("should initialize with correct parameters", () => {
       expect(client).toBeInstanceOf(SwaggerClient);
       expect(client.name).toBe("Swagger");
-      expect(client.toolPrefix).toBe("swagger");
+      expect(client.capabilityPrefix).toBe("swagger");
       expect(client.configPrefix).toBe("Swagger");
     });
 

--- a/src/tests/unit/zephyr/client.test.ts
+++ b/src/tests/unit/zephyr/client.test.ts
@@ -6,7 +6,7 @@ describe("ZephyrClient", () => {
   it("should set name and prefix", () => {
     const client = new ZephyrClient();
     expect(client.name).toBe("Zephyr");
-    expect(client.toolPrefix).toBe("zephyr");
+    expect(client.capabilityPrefix).toBe("zephyr");
     expect(client.configPrefix).toBe("Zephyr");
   });
 

--- a/src/zephyr/client.ts
+++ b/src/zephyr/client.ts
@@ -60,7 +60,7 @@ export class ZephyrClient implements Client {
   private _apiToken: string | undefined;
 
   name = "Zephyr";
-  toolPrefix = "zephyr";
+  capabilityPrefix = "zephyr";
   configPrefix = "Zephyr";
   config = ConfigurationSchema;
 


### PR DESCRIPTION
## Goal

We have defined types for Tool parameters but not Resources or Prompts, so some naming inconsistencies have crept in, and may continue, between products. I'm working on a script to automatically generate the documentation by extracting tools, resources and prompts, so fixing this will mean that it can parse them in a consistent way: allowing them to be split between the products.

## Design

This PR applies the same pattern to registering of prompts and resources as for tools – using the common server class to prefix them with the product name to disambiguate.

## Testing

Amended unit test and confirmed resources and prompts work in VSCode.

I've also added the resources and prompts to the snapshot testing to guard against unintended changes in future.