### PR TITLE
Enable TypeScript in tests and fix issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mcpServerName": "SmartBear MCP Server"
   },
   "scripts": {
-    "build": "vite build && shx chmod +x dist/*.js",
+    "build": "tsc && vite build && shx chmod +x dist/*.js",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --fix",
     "format": "biome format . --write",

--- a/src/qmetry/client/tools/testsuite-tools.ts
+++ b/src/qmetry/client/tools/testsuite-tools.ts
@@ -1053,8 +1053,8 @@ export const TESTSUITE_TOOLS: QMetryToolParams[] = [
           entityType: "TCR",
           qmTsRunId: "2720260",
           runStatusID: 123266,
-          username: "dhaval.mistry",
-          password: "Ispl123#",
+          username: "test.user",
+          password: "password",
           isBulkOperation: false,
         },
         expectedOutput:

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -276,7 +276,7 @@ describe("BugsnagClient", () => {
     it("should return null when no auth is available", async () => {
       const client = new BugsnagClient();
       const mockServer = { getCache: () => mockCache } as any;
-      await client.configure(mockServer, {});
+      await client.configure(mockServer, {} as any);
       const { requestContextStorage } = await import(
         "../../../common/request-context.js"
       );
@@ -673,7 +673,7 @@ describe("BugsnagClient", () => {
           typeof (call[0] as any).apiKey === "function",
       )?.[0];
       expect(configCall).toBeDefined();
-      const apiKeyFunc = configCall.apiKey as (name: string) => string;
+      const apiKeyFunc = configCall?.apiKey as (name: string) => string;
       expect(apiKeyFunc("any")).toBe(`token ${testToken}`);
     });
 

--- a/src/tests/unit/collaborator/client.test.ts
+++ b/src/tests/unit/collaborator/client.test.ts
@@ -1,5 +1,7 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
+import type { ZodRawShape } from "zod";
 import { CollaboratorClient } from "../../../collaborator/client";
 
 const fetchMock = createFetchMock(vi);
@@ -313,12 +315,13 @@ describe("CollaboratorClient", () => {
   });
 
   describe("tool handler direct invocation", () => {
-    let handlers: Record<string, (args: any, extra: any) => Promise<any>> = {};
+    let handlers: Record<string, ToolCallback<ZodRawShape>> = {};
     const mockGetInput = vi.fn();
     beforeEach(() => {
       handlers = {};
       client.registerTools((def, fn) => {
         handlers[def.title] = fn;
+        return {} as any;
       }, mockGetInput);
     });
 
@@ -335,18 +338,18 @@ describe("CollaboratorClient", () => {
       const fakeResult = [{ reviewId: "42", status: "closed" }];
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler = handlers["Get Collaborator Reviews"];
-      const result = await handler(args, {});
-      expect(result.content[0].text).toContain("42");
-      expect(result.content[0].text).toContain("closed");
+      const result = await handler(args, {} as any);
+      expect((result.content[0] as any).text).toContain("42");
+      expect((result.content[0] as any).text).toContain("closed");
     });
 
     it("getReviews handler handles missing args", async () => {
       const fakeResult = [{ reviewId: "43", status: "open" }];
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler = handlers["Get Collaborator Reviews"];
-      const result = await handler({}, {});
-      expect(result.content[0].text).toContain("43");
-      expect(result.content[0].text).toContain("open");
+      const result = await handler({}, {} as any);
+      expect((result.content[0] as any).text).toContain("43");
+      expect((result.content[0] as any).text).toContain("open");
     });
 
     it("updateWebhook handler processes id as string", async () => {
@@ -354,9 +357,9 @@ describe("CollaboratorClient", () => {
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler =
         handlers["Update Collaborator Remote System Configuration Webhook"];
-      const result = await handler({ id: "99" }, {});
-      expect(result.content[0].text).toContain("99");
-      expect(result.content[0].text).toContain("updated");
+      const result = await handler({ id: "99" }, {} as any);
+      expect((result.content[0] as any).text).toContain("99");
+      expect((result.content[0] as any).text).toContain("updated");
     });
 
     it("testConnection handler processes id as number", async () => {
@@ -364,15 +367,15 @@ describe("CollaboratorClient", () => {
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler =
         handlers["Test Collaborator Remote System Configuration Connection"];
-      const result = await handler({ id: 100 }, {});
-      expect(result.content[0].text).toContain("100");
-      expect(result.content[0].text).toContain("ok");
+      const result = await handler({ id: 100 }, {} as any);
+      expect((result.content[0] as any).text).toContain("100");
+      expect((result.content[0] as any).text).toContain("ok");
     });
 
     it("getReviews handler propagates errors", async () => {
       vi.spyOn(client, "call").mockRejectedValueOnce(new Error("fail"));
       const handler = handlers["Get Collaborator Reviews"];
-      await expect(handler({}, {})).rejects.toThrow("fail");
+      await expect(handler({}, {} as any)).rejects.toThrow("fail");
     });
 
     it("createIntegration handler processes all arguments", async () => {
@@ -386,9 +389,9 @@ describe("CollaboratorClient", () => {
         config: "{}",
         reviewTemplateId: "template1",
       };
-      const result = await handler(args, {});
-      expect(result.content[0].text).toContain("101");
-      expect(result.content[0].text).toContain("created");
+      const result = await handler(args, {} as any);
+      expect((result.content[0] as any).text).toContain("101");
+      expect((result.content[0] as any).text).toContain("created");
     });
 
     it("editIntegration handler processes all optional arguments", async () => {
@@ -401,9 +404,9 @@ describe("CollaboratorClient", () => {
         config: "{}",
         reviewTemplateId: "template2",
       };
-      const result = await handler(args, {});
-      expect(result.content[0].text).toContain("102");
-      expect(result.content[0].text).toContain("edited");
+      const result = await handler(args, {} as any);
+      expect((result.content[0] as any).text).toContain("102");
+      expect((result.content[0] as any).text).toContain("edited");
     });
 
     it("deleteIntegration handler processes id as string", async () => {
@@ -411,9 +414,9 @@ describe("CollaboratorClient", () => {
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler =
         handlers["Delete Collaborator Remote System Configuration"];
-      const result = await handler({ id: "103" }, {});
-      expect(result.content[0].text).toContain("103");
-      expect(result.content[0].text).toContain("deleted");
+      const result = await handler({ id: "103" }, {} as any);
+      expect((result.content[0] as any).text).toContain("103");
+      expect((result.content[0] as any).text).toContain("deleted");
     });
 
     it("rejectReview handler processes all arguments", async () => {
@@ -421,15 +424,17 @@ describe("CollaboratorClient", () => {
       vi.spyOn(client, "call").mockResolvedValueOnce(fakeResult);
       const handler = handlers["Reject Collaborator Review"];
       const args = { reviewId: "104", reason: "Not needed" };
-      const result = await handler(args, {});
-      expect(result.content[0].text).toContain("104");
-      expect(result.content[0].text).toContain("rejected");
+      const result = await handler(args, {} as any);
+      expect((result.content[0] as any).text).toContain("104");
+      expect((result.content[0] as any).text).toContain("rejected");
     });
 
     it("editIntegration handler propagates errors", async () => {
       vi.spyOn(client, "call").mockRejectedValueOnce(new Error("fail-edit"));
       const handler = handlers["Edit Collaborator Remote System Configuration"];
-      await expect(handler({ id: "bad" }, {})).rejects.toThrow("fail-edit");
+      await expect(handler({ id: "bad" }, {} as any)).rejects.toThrow(
+        "fail-edit",
+      );
     });
 
     it("createIntegration handler propagates errors", async () => {
@@ -437,7 +442,7 @@ describe("CollaboratorClient", () => {
       const handler =
         handlers["Create Collaborator Remote System Configuration"];
       await expect(
-        handler({ token: "GITHUB", title: "Test", config: "{}" }, {}),
+        handler({ token: "GITHUB", title: "Test", config: "{}" }, {} as any),
       ).rejects.toThrow("fail-create");
     });
 
@@ -445,7 +450,9 @@ describe("CollaboratorClient", () => {
       vi.spyOn(client, "call").mockRejectedValueOnce(new Error("fail-delete"));
       const handler =
         handlers["Delete Collaborator Remote System Configuration"];
-      await expect(handler({ id: "bad" }, {})).rejects.toThrow("fail-delete");
+      await expect(handler({ id: "bad" }, {} as any)).rejects.toThrow(
+        "fail-delete",
+      );
     });
   });
 });

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -3345,8 +3345,8 @@ Expected Output: Automated test case runs updated to Pass status with automation
   "entityType": "TCR",
   "qmTsRunId": "2720260",
   "runStatusID": 123266,
-  "username": "dhaval.mistry",
-  "password": "Ispl123#",
+  "username": "test.user",
+  "password": "password",
   "isBulkOperation": false
 }
 \`\`\`

--- a/src/tests/unit/pactflow/client.test.ts
+++ b/src/tests/unit/pactflow/client.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 import { PactflowClient } from "../../../pactflow/client";
-import { GenerationInputSchema } from "../../../pactflow/client/ai";
+import {
+  GenerationInputSchema,
+  type GenerationResponse,
+} from "../../../pactflow/client/ai";
 import * as toolsModule from "../../../pactflow/client/tools";
 
 const fetchMock = createFetchMock(vi);
@@ -626,9 +629,9 @@ describe("PactFlowClient", () => {
             headers: client.requestHeaders,
           },
         );
-        expect(result.organizationEntitlements.name).toBe("test-org");
-        expect(result.organizationEntitlements.aiCredits.total).toBe(1000);
-        expect(result.userEntitlements.aiPermissions).toContain("ai:generate");
+        expect(result?.organizationEntitlements.name).toBe("test-org");
+        expect(result?.organizationEntitlements.aiCredits.total).toBe(1000);
+        expect(result?.userEntitlements.aiPermissions).toContain("ai:generate");
       });
 
       it("should handle HTTP errors correctly", async () => {
@@ -653,7 +656,7 @@ describe("PactFlowClient", () => {
         result_url: "https://example.com/api/ai/result/123",
       };
 
-      const mockGenerationResponse = {
+      const mockGenerationResponse: GenerationResponse = {
         language: "javascript",
         code: "const { PactV3 } = require('@pact-foundation/pact');",
       };
@@ -680,8 +683,8 @@ describe("PactFlowClient", () => {
             body: JSON.stringify(mockGenerationInput),
           },
         );
-        expect(result.language).toBe("javascript");
-        expect(result.code).toBeDefined();
+        expect((result as GenerationResponse).language).toBe("javascript");
+        expect((result as GenerationResponse).code).toBeDefined();
       });
 
       it("should handle generation with OpenAPI document and matcher", async () => {
@@ -2934,7 +2937,10 @@ describe("PactFlowClient", () => {
         fetchMock.mockResponseOnce(JSON.stringify({ invited: 2 }));
 
         await client.inviteUsers({
-          users: [{ email: "a@example.com" }, { email: "b@example.com" }],
+          users: [
+            { name: "example_a", email: "a@example.com" },
+            { name: "example_b", email: "b@example.com" },
+          ],
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -2943,7 +2949,10 @@ describe("PactFlowClient", () => {
             method: "POST",
             headers: client.requestHeaders,
             body: JSON.stringify({
-              users: [{ email: "a@example.com" }, { email: "b@example.com" }],
+              users: [
+                { name: "example_a", email: "a@example.com" },
+                { name: "example_b", email: "b@example.com" },
+              ],
             }),
           },
         );
@@ -2956,7 +2965,7 @@ describe("PactFlowClient", () => {
 
         await client.setUserRoles({
           userId: "user-uuid-1",
-          roles: [{ uuid: "role-uuid-1" }, { uuid: "role-uuid-2" }],
+          roles: ["role-uuid-1", "role-uuid-2"],
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -2965,7 +2974,7 @@ describe("PactFlowClient", () => {
             method: "PUT",
             headers: client.requestHeaders,
             body: JSON.stringify({
-              roles: [{ uuid: "role-uuid-1" }, { uuid: "role-uuid-2" }],
+              roles: ["role-uuid-1", "role-uuid-2"],
             }),
           },
         );
@@ -3174,8 +3183,16 @@ describe("PactFlowClient", () => {
         fetchMock.mockResponseOnce(JSON.stringify({}));
 
         const operations = [
-          { op: "add", path: "/0", value: { uuid: "user-uuid-3" } },
-          { op: "remove", path: "/1" },
+          {
+            op: "add" as const,
+            path: "/users" as const,
+            value: { uuid: "user-uuid-1" },
+          },
+          {
+            op: "remove" as const,
+            path: "/users" as const,
+            value: { uuid: "user-uuid-2" },
+          },
         ];
         await client.patchTeamUsers({
           teamId: "team-uuid-1",
@@ -3254,7 +3271,7 @@ describe("PactFlowClient", () => {
 
         const result = await client.createAdminRole({
           name: "ReadOnly",
-          permissions: ["contract:read"],
+          permissions: [{ scope: "contract:read" }],
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -3264,7 +3281,7 @@ describe("PactFlowClient", () => {
             headers: client.requestHeaders,
             body: JSON.stringify({
               name: "ReadOnly",
-              permissions: ["contract:read"],
+              permissions: [{ scope: "contract:read" }],
             }),
           },
         );
@@ -3279,7 +3296,11 @@ describe("PactFlowClient", () => {
         await client.updateAdminRole({
           roleId: "role-uuid-1",
           name: "Super Admin",
-          permissions: ["contract:read", "contract:write", "admin:users"],
+          permissions: [
+            { scope: "contract:read" },
+            { scope: "contract:write" },
+            { scope: "admin:users" },
+          ],
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -3289,7 +3310,11 @@ describe("PactFlowClient", () => {
             headers: client.requestHeaders,
             body: JSON.stringify({
               name: "Super Admin",
-              permissions: ["contract:read", "contract:write", "admin:users"],
+              permissions: [
+                { scope: "contract:read" },
+                { scope: "contract:write" },
+                { scope: "admin:users" },
+              ],
             }),
           },
         );
@@ -3356,7 +3381,6 @@ describe("PactFlowClient", () => {
 
         const result = await client.createSystemAccount({
           name: "CI Bot",
-          description: "Automated CI system account",
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
@@ -3366,7 +3390,6 @@ describe("PactFlowClient", () => {
             headers: client.requestHeaders,
             body: JSON.stringify({
               name: "CI Bot",
-              description: "Automated CI system account",
             }),
           },
         );

--- a/src/tests/unit/qmetry/api/requirement.test.ts
+++ b/src/tests/unit/qmetry/api/requirement.test.ts
@@ -117,7 +117,11 @@ describe("requirement API clients", () => {
     it("should handle API errors gracefully", async () => {
       global.fetch = vi.fn().mockResolvedValue(mockFail(403, "Access denied"));
 
-      const payload = { viewId: 54321, folderPath: "" };
+      const payload = {
+        viewId: 54321,
+        folderPath: "",
+        isFilterSaveRequired: false,
+      };
 
       await expect(
         fetchRequirements(token, baseUrl, projectKey, payload),

--- a/src/tests/unit/reflect/client.test.ts
+++ b/src/tests/unit/reflect/client.test.ts
@@ -28,11 +28,17 @@ describe("ReflectClient", () => {
 
   it("should register and retrieve connection", () => {
     const mockWs = { isConnected: vi.fn().mockReturnValue(true) } as any;
-    client.registerConnection("session-1", mockWs, { platform: "web" });
+    client.registerConnection("session-1", mockWs, {
+      platform: "web",
+      test: { name: "Test 1" },
+    });
 
     expect(client.isSessionConnected("session-1")).toBe(true);
     expect(client.getConnectedSession("session-1")).toBe(mockWs);
-    expect(client.getSessionState("session-1")).toEqual({ platform: "web" });
+    expect(client.getSessionState("session-1")).toEqual({
+      platform: "web",
+      test: { name: "Test 1" },
+    });
   });
 
   it("should have correct tool prefix", () => {

--- a/src/tests/unit/reflect/tool/recording/add-prompt-step.test.ts
+++ b/src/tests/unit/reflect/tool/recording/add-prompt-step.test.ts
@@ -32,7 +32,7 @@ describe("AddPromptStep", () => {
   it("should send add-prompt-step message and return success", async () => {
     const result = await instance.handle(
       { sessionId: "sess-1", prompt: "Click the login button" },
-      {},
+      {} as any,
     );
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
@@ -52,19 +52,22 @@ describe("AddPromptStep", () => {
       throw new Error("not connected");
     });
     await expect(
-      instance.handle({ sessionId: "sess-1", prompt: "do something" }, {}),
+      instance.handle(
+        { sessionId: "sess-1", prompt: "do something" },
+        {} as any,
+      ),
     ).rejects.toThrow("not connected");
   });
 
   it("should throw ToolError if sessionId is missing", async () => {
     await expect(
-      instance.handle({ prompt: "do something" }, {}),
+      instance.handle({ prompt: "do something" }, {} as any),
     ).rejects.toThrow("sessionId argument is required");
   });
 
   it("should throw ToolError if prompt is missing", async () => {
-    await expect(instance.handle({ sessionId: "sess-1" }, {})).rejects.toThrow(
-      "prompt argument is required",
-    );
+    await expect(
+      instance.handle({ sessionId: "sess-1" }, {} as any),
+    ).rejects.toThrow("prompt argument is required");
   });
 });

--- a/src/tests/unit/reflect/tool/recording/add-segment.test.ts
+++ b/src/tests/unit/reflect/tool/recording/add-segment.test.ts
@@ -31,7 +31,7 @@ describe("AddSegment", () => {
   it("should send add-segment message and return success", async () => {
     const result = await instance.handle(
       { sessionId: "sess-1", segmentId: 42 },
-      {},
+      {} as any,
     );
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
@@ -51,12 +51,12 @@ describe("AddSegment", () => {
       throw new Error("not connected");
     });
     await expect(
-      instance.handle({ sessionId: "sess-1", segmentId: 1 }, {}),
+      instance.handle({ sessionId: "sess-1", segmentId: 1 }, {} as any),
     ).rejects.toThrow("not connected");
   });
 
   it("should throw ToolError if sessionId is missing", async () => {
-    await expect(instance.handle({ segmentId: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ segmentId: 1 }, {} as any)).rejects.toThrow(
       "sessionId argument is required",
     );
   });

--- a/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
+++ b/src/tests/unit/reflect/tool/recording/connect-to-session.test.ts
@@ -49,7 +49,7 @@ describe("ConnectToSession", () => {
     mockClient.isSessionConnected.mockReturnValue(true);
     mockClient.getSessionState.mockReturnValue({ platform: "web" });
 
-    const result = await instance.handle({ sessionId: "sess-1" }, {});
+    const result = await instance.handle({ sessionId: "sess-1" }, {} as any);
     expect(result.content[0].type).toBe("text");
     const parsed = JSON.parse((result.content[0] as any).text);
     expect(parsed.success).toBe(true);
@@ -64,7 +64,7 @@ describe("ConnectToSession", () => {
       platform: "native-mobile",
     });
 
-    const result = await instance.handle({ sessionId: "sess-new" }, {});
+    const result = await instance.handle({ sessionId: "sess-new" }, {} as any);
 
     expect(mockWsManager.connect).toHaveBeenCalled();
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
@@ -86,7 +86,7 @@ describe("ConnectToSession", () => {
   });
 
   it("should throw ToolError if sessionId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "sessionId argument is required",
     );
   });
@@ -94,7 +94,7 @@ describe("ConnectToSession", () => {
   it("should throw ToolError if connect fails", async () => {
     mockWsManager.connect.mockRejectedValue(new Error("connection refused"));
     await expect(
-      instance.handle({ sessionId: "sess-fail" }, {}),
+      instance.handle({ sessionId: "sess-fail" }, {} as any),
     ).rejects.toThrow("Failed to connect to session");
   });
 });

--- a/src/tests/unit/reflect/tool/recording/delete-previous-step.test.ts
+++ b/src/tests/unit/reflect/tool/recording/delete-previous-step.test.ts
@@ -30,7 +30,7 @@ describe("DeletePreviousStep", () => {
   });
 
   it("should send delete-step message and return success", async () => {
-    const result = await instance.handle({ sessionId: "sess-1" }, {});
+    const result = await instance.handle({ sessionId: "sess-1" }, {} as any);
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -47,13 +47,13 @@ describe("DeletePreviousStep", () => {
     mockClient.getConnectedSession.mockImplementation(() => {
       throw new Error("not connected");
     });
-    await expect(instance.handle({ sessionId: "sess-1" }, {})).rejects.toThrow(
-      "not connected",
-    );
+    await expect(
+      instance.handle({ sessionId: "sess-1" }, {} as any),
+    ).rejects.toThrow("not connected");
   });
 
   it("should throw ToolError if sessionId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "sessionId argument is required",
     );
   });

--- a/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
+++ b/src/tests/unit/reflect/tool/recording/get-screenshot.test.ts
@@ -31,7 +31,7 @@ describe("GetScreenshot", () => {
   });
 
   it("should send get-screenshot message and return image content", async () => {
-    const result = await instance.handle({ sessionId: "sess-1" }, {});
+    const result = await instance.handle({ sessionId: "sess-1" }, {} as any);
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -63,28 +63,28 @@ describe("GetScreenshot", () => {
       state: {},
     });
 
-    await expect(instance.handle({ sessionId: "sess-1" }, {})).rejects.toThrow(
-      "No imageBase64",
-    );
+    await expect(
+      instance.handle({ sessionId: "sess-1" }, {} as any),
+    ).rejects.toThrow("No imageBase64");
   });
 
   it("should throw ToolError if session is not connected", async () => {
     mockClient.getConnectedSession.mockImplementation(() => {
       throw new Error("not connected");
     });
-    await expect(instance.handle({ sessionId: "sess-1" }, {})).rejects.toThrow(
-      "not connected",
-    );
+    await expect(
+      instance.handle({ sessionId: "sess-1" }, {} as any),
+    ).rejects.toThrow("not connected");
   });
 
   it("should throw ToolError if sessionId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "sessionId argument is required",
     );
   });
 
   it("should default to png format when format is not specified", async () => {
-    await instance.handle({ sessionId: "sess-1" }, {});
+    await instance.handle({ sessionId: "sess-1" }, {} as any);
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "mcp:get-screenshot", format: "png" }),
@@ -94,7 +94,7 @@ describe("GetScreenshot", () => {
   it("should use jpeg format when format is jpeg", async () => {
     const result = await instance.handle(
       { sessionId: "sess-1", format: "jpeg" },
-      {},
+      {} as any,
     );
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(
@@ -108,7 +108,7 @@ describe("GetScreenshot", () => {
   it("should use png format when format is png", async () => {
     const result = await instance.handle(
       { sessionId: "sess-1", format: "png" },
-      {},
+      {} as any,
     );
 
     expect(mockWsManager.sendMcpMessage).toHaveBeenCalledWith(

--- a/src/tests/unit/reflect/tool/suites/cancel-suite-execution.test.ts
+++ b/src/tests/unit/reflect/tool/suites/cancel-suite-execution.test.ts
@@ -33,7 +33,7 @@ describe("CancelSuiteExecution", () => {
 
     const result = await instance.handle(
       { suiteId: "suite-1", executionId: "exec-1" },
-      {},
+      {} as any,
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -50,20 +50,20 @@ describe("CancelSuiteExecution", () => {
 
   it("should throw ToolError if suiteId is missing", async () => {
     await expect(
-      instance.handle({ executionId: "exec-1" }, {}),
+      instance.handle({ executionId: "exec-1" }, {} as any),
     ).rejects.toThrow("Both suiteId and executionId arguments are required");
   });
 
   it("should throw ToolError if executionId is missing", async () => {
-    await expect(instance.handle({ suiteId: "suite-1" }, {})).rejects.toThrow(
-      "Both suiteId and executionId arguments are required",
-    );
+    await expect(
+      instance.handle({ suiteId: "suite-1" }, {} as any),
+    ).rejects.toThrow("Both suiteId and executionId arguments are required");
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Not Found", { status: 404 });
     await expect(
-      instance.handle({ suiteId: "suite-1", executionId: "exec-1" }, {}),
+      instance.handle({ suiteId: "suite-1", executionId: "exec-1" }, {} as any),
     ).rejects.toThrow("Failed to cancel suite execution");
   });
 });

--- a/src/tests/unit/reflect/tool/suites/execute-suite.test.ts
+++ b/src/tests/unit/reflect/tool/suites/execute-suite.test.ts
@@ -31,7 +31,7 @@ describe("ExecuteSuite", () => {
   it("should POST to execute suite and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(executionMock));
 
-    const result = await instance.handle({ suiteId: "suite-1" }, {});
+    const result = await instance.handle({ suiteId: "suite-1" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/suites/suite-1/executions",
@@ -47,15 +47,15 @@ describe("ExecuteSuite", () => {
   });
 
   it("should throw ToolError if suiteId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "suiteId argument is required",
     );
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Forbidden", { status: 403 });
-    await expect(instance.handle({ suiteId: "suite-1" }, {})).rejects.toThrow(
-      "Failed to execute suite",
-    );
+    await expect(
+      instance.handle({ suiteId: "suite-1" }, {} as any),
+    ).rejects.toThrow("Failed to execute suite");
   });
 });

--- a/src/tests/unit/reflect/tool/suites/get-suite-execution-status.test.ts
+++ b/src/tests/unit/reflect/tool/suites/get-suite-execution-status.test.ts
@@ -33,7 +33,7 @@ describe("GetSuiteExecutionStatus", () => {
 
     const result = await instance.handle(
       { suiteId: "suite-1", executionId: "exec-1" },
-      {},
+      {} as any,
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -50,20 +50,20 @@ describe("GetSuiteExecutionStatus", () => {
 
   it("should throw ToolError if suiteId is missing", async () => {
     await expect(
-      instance.handle({ executionId: "exec-1" }, {}),
+      instance.handle({ executionId: "exec-1" }, {} as any),
     ).rejects.toThrow("Both suiteId and executionId arguments are required");
   });
 
   it("should throw ToolError if executionId is missing", async () => {
-    await expect(instance.handle({ suiteId: "suite-1" }, {})).rejects.toThrow(
-      "Both suiteId and executionId arguments are required",
-    );
+    await expect(
+      instance.handle({ suiteId: "suite-1" }, {} as any),
+    ).rejects.toThrow("Both suiteId and executionId arguments are required");
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Server Error", { status: 500 });
     await expect(
-      instance.handle({ suiteId: "suite-1", executionId: "exec-1" }, {}),
+      instance.handle({ suiteId: "suite-1", executionId: "exec-1" }, {} as any),
     ).rejects.toThrow("Failed to get suite execution status");
   });
 });

--- a/src/tests/unit/reflect/tool/suites/list-suite-executions.test.ts
+++ b/src/tests/unit/reflect/tool/suites/list-suite-executions.test.ts
@@ -34,7 +34,7 @@ describe("ListSuiteExecutions", () => {
   it("should call suite executions API and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(executionsMock));
 
-    const result = await instance.handle({ suiteId: "suite-1" }, {});
+    const result = await instance.handle({ suiteId: "suite-1" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/suites/suite-1/executions",
@@ -49,15 +49,15 @@ describe("ListSuiteExecutions", () => {
   });
 
   it("should throw ToolError if suiteId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "suiteId argument is required",
     );
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Not Found", { status: 404 });
-    await expect(instance.handle({ suiteId: "suite-1" }, {})).rejects.toThrow(
-      "Failed to list suite executions",
-    );
+    await expect(
+      instance.handle({ suiteId: "suite-1" }, {} as any),
+    ).rejects.toThrow("Failed to list suite executions");
   });
 });

--- a/src/tests/unit/reflect/tool/suites/list-suites.test.ts
+++ b/src/tests/unit/reflect/tool/suites/list-suites.test.ts
@@ -37,7 +37,7 @@ describe("ListSuites", () => {
   it("should call suites API and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
 
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/suites",
@@ -53,7 +53,7 @@ describe("ListSuites", () => {
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "Failed to list suites",
     );
   });

--- a/src/tests/unit/reflect/tool/tests/get-test-status.test.ts
+++ b/src/tests/unit/reflect/tool/tests/get-test-status.test.ts
@@ -31,7 +31,7 @@ describe("GetTestStatus", () => {
   it("should call execution status API with executionId in URL", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(statusMock));
 
-    const result = await instance.handle({ executionId: "exec-1" }, {});
+    const result = await instance.handle({ executionId: "exec-1" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/executions/exec-1",
@@ -46,15 +46,15 @@ describe("GetTestStatus", () => {
   });
 
   it("should throw ToolError if executionId is missing", async () => {
-    await expect(instance.handle({ testId: "test-1" }, {})).rejects.toThrow(
-      "executionId argument is required",
-    );
+    await expect(
+      instance.handle({ testId: "test-1" }, {} as any),
+    ).rejects.toThrow("executionId argument is required");
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Server Error", { status: 500 });
     await expect(
-      instance.handle({ testId: "test-1", executionId: "exec-1" }, {}),
+      instance.handle({ testId: "test-1", executionId: "exec-1" }, {} as any),
     ).rejects.toThrow("Failed to get test status");
   });
 });

--- a/src/tests/unit/reflect/tool/tests/list-segments.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-segments.test.ts
@@ -52,7 +52,7 @@ describe("ListSegments", () => {
   it("should call segments API and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(segmentsMock));
 
-    const result = await instance.handle({ platform: "web" }, {});
+    const result = await instance.handle({ platform: "web" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/segments?type=web&offset=0&limit=25",
@@ -70,7 +70,7 @@ describe("ListSegments", () => {
   it("should use provided offset and limit", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ segments: [], count: 0 }));
 
-    await instance.handle({ platform: "web", offset: 10, limit: 5 }, {});
+    await instance.handle({ platform: "web", offset: 10, limit: 5 }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/segments?type=web&offset=10&limit=5",
@@ -80,9 +80,9 @@ describe("ListSegments", () => {
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Not Found", { status: 404 });
-    await expect(instance.handle({ platform: "web" }, {})).rejects.toThrow(
-      "Failed to list segments",
-    );
+    await expect(
+      instance.handle({ platform: "web" }, {} as any),
+    ).rejects.toThrow("Failed to list segments");
   });
 
   it("should use WEB_APP_HOSTNAME URL for OAuth request", async () => {
@@ -93,7 +93,7 @@ describe("ListSegments", () => {
     });
     fetchMock.mockResponseOnce(JSON.stringify(segmentsMock));
 
-    const result = await instance.handle({ platform: "web" }, {});
+    const result = await instance.handle({ platform: "web" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://app.reflect.run/api/mcp/segments?type=web&offset=0&limit=25",

--- a/src/tests/unit/reflect/tool/tests/list-tests.test.ts
+++ b/src/tests/unit/reflect/tool/tests/list-tests.test.ts
@@ -35,7 +35,7 @@ describe("ListTests", () => {
   it("should call tests API and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(testsMock));
 
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/tests",
@@ -51,7 +51,7 @@ describe("ListTests", () => {
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "Failed to list tests",
     );
   });

--- a/src/tests/unit/reflect/tool/tests/run-test.test.ts
+++ b/src/tests/unit/reflect/tool/tests/run-test.test.ts
@@ -31,7 +31,7 @@ describe("RunTest", () => {
   it("should POST to run test and return results", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(executionMock));
 
-    const result = await instance.handle({ testId: "test-1" }, {});
+    const result = await instance.handle({ testId: "test-1" }, {} as any);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.reflect.run/v1/tests/test-1/executions",
@@ -47,15 +47,15 @@ describe("RunTest", () => {
   });
 
   it("should throw ToolError if testId is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow(
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
       "testId argument is required",
     );
   });
 
   it("should throw ToolError if fetch fails", async () => {
     fetchMock.mockResponseOnce("Not Found", { status: 404 });
-    await expect(instance.handle({ testId: "test-1" }, {})).rejects.toThrow(
-      "Failed to run test",
-    );
+    await expect(
+      instance.handle({ testId: "test-1" }, {} as any),
+    ).rejects.toThrow("Failed to run test");
   });
 });

--- a/src/tests/unit/reflect/websocket-manager.test.ts
+++ b/src/tests/unit/reflect/websocket-manager.test.ts
@@ -24,15 +24,10 @@ vi.mock("ws", () => {
 
 describe("WebSocketManager", () => {
   let manager: WebSocketManager;
-  let _mockWs: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    const WebSocket = (await import("ws")).default as any;
     manager = new WebSocketManager("test-session-123", apiKeyHeader());
-
-    // Each new manager will use a new mock instance
-    _mockWs = WebSocket.mock.results[0]?.value;
   });
 
   it("should start disconnected", () => {

--- a/src/tests/unit/zephyr/common/auth-service.test.ts
+++ b/src/tests/unit/zephyr/common/auth-service.test.ts
@@ -5,7 +5,8 @@ import { AuthService } from "../../../../zephyr/common/auth-service";
 describe("AuthService", () => {
   it("should trim and store the bearer token", () => {
     const service = new AuthService("  token  ");
-    expect(service.bearerToken).toBe("token");
+    // biome-ignore lint/complexity/useLiteralKeys: Access for test purposes
+    expect(service["bearerToken"]).toBe("token");
   });
 
   it("should return correct auth headers", () => {

--- a/src/tests/unit/zephyr/tool/environment/get-environments.test.ts
+++ b/src/tests/unit/zephyr/tool/environment/get-environments.test.ts
@@ -109,7 +109,7 @@ describe("GetEnvironments", () => {
       .getApiClient()
       .get.mockResolvedValueOnce(responseFromSpecificProjectMock);
     const args = { projectKey: "PROJ", startAt: 0, maxResults: 10 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/environments",
       args,
@@ -122,7 +122,7 @@ describe("GetEnvironments", () => {
       .getApiClient()
       .get.mockResolvedValueOnce(responseFromAllProjectsMock);
     const args = { startAt: 0, maxResults: 10 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/environments",
       args,
@@ -135,7 +135,7 @@ describe("GetEnvironments", () => {
       .getApiClient()
       .get.mockResolvedValueOnce(responseFromSpecificProjectMock);
     const args = { projectKey: "PROJ", maxResults: 10 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/environments",
       { ...args, startAt: 0 },
@@ -149,7 +149,7 @@ describe("GetEnvironments", () => {
       .get.mockResolvedValueOnce(responseFromSpecificProjectMock);
     const result = await instance.handle(
       { projectKey: "PROJ", startAt: 0 },
-      {},
+      {} as any,
     );
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/environments",
@@ -164,14 +164,14 @@ describe("GetEnvironments", () => {
 
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ maxResults: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ maxResults: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ maxResults: 1 }, {});
+    const result = await instance.handle({ maxResults: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/issue-link/get-test-cases.test.ts
+++ b/src/tests/unit/zephyr/tool/issue-link/get-test-cases.test.ts
@@ -50,7 +50,7 @@ describe("GetIssueLinkTestCases", () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
     const args = { issueKey: "PROJ-123" };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/issuelinks/PROJ-123/testcases",
@@ -62,7 +62,7 @@ describe("GetIssueLinkTestCases", () => {
   it("should handle empty list response", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce([]);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/issuelinks/PROJ-123/testcases",
@@ -74,31 +74,33 @@ describe("GetIssueLinkTestCases", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
 
-    await expect(instance.handle({ issueKey: "PROJ-123" }, {})).rejects.toThrow(
-      "API error",
-    );
+    await expect(
+      instance.handle({ issueKey: "PROJ-123" }, {} as any),
+    ).rejects.toThrow("API error");
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
     expect(result.structuredContent).toEqual({ testCases: undefined });
   });
 
   it("should throw validation error if issueKey is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow();
+    await expect(instance.handle({}, {} as any)).rejects.toThrow();
   });
 
   it("should throw validation error if issueKey format is invalid", async () => {
-    await expect(instance.handle({ issueKey: "PROJT!" }, {})).rejects.toThrow();
+    await expect(
+      instance.handle({ issueKey: "PROJT!" }, {} as any),
+    ).rejects.toThrow();
   });
 
   it("should handle apiClient.get returning non-array data", async () => {
     const responseMock = { key: "PROJ-T1", version: 1 };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
     expect(result.structuredContent).toEqual({ testCases: responseMock });
   });
 });

--- a/src/tests/unit/zephyr/tool/issue-link/get-test-executions.test.ts
+++ b/src/tests/unit/zephyr/tool/issue-link/get-test-executions.test.ts
@@ -50,7 +50,7 @@ describe("GetIssueLinkTestExecutions", () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
     const args = { issueKey: "PROJ-123" };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/issuelinks/PROJ-123/executions",
@@ -62,7 +62,7 @@ describe("GetIssueLinkTestExecutions", () => {
   it("should handle empty list response", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce([]);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/issuelinks/PROJ-123/executions",
@@ -74,31 +74,33 @@ describe("GetIssueLinkTestExecutions", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
 
-    await expect(instance.handle({ issueKey: "PROJ-123" }, {})).rejects.toThrow(
-      "API error",
-    );
+    await expect(
+      instance.handle({ issueKey: "PROJ-123" }, {} as any),
+    ).rejects.toThrow("API error");
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
     expect(result.structuredContent).toEqual({ testExecutions: undefined });
   });
 
   it("should throw validation error if issueKey is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow();
+    await expect(instance.handle({}, {} as any)).rejects.toThrow();
   });
 
   it("should throw validation error if issueKey format is invalid", async () => {
-    await expect(instance.handle({ issueKey: "PROJT!" }, {})).rejects.toThrow();
+    await expect(
+      instance.handle({ issueKey: "PROJT!" }, {} as any),
+    ).rejects.toThrow();
   });
 
   it("should handle apiClient.get returning non-array data", async () => {
     const responseMock = { key: "PROJ-1", version: 1 };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
-    const result = await instance.handle({ issueKey: "PROJ-123" }, {});
+    const result = await instance.handle({ issueKey: "PROJ-123" }, {} as any);
     expect(result.structuredContent).toEqual({ testExecutions: responseMock });
   });
 });

--- a/src/tests/unit/zephyr/tool/project/get-projects.test.ts
+++ b/src/tests/unit/zephyr/tool/project/get-projects.test.ts
@@ -47,7 +47,7 @@ describe("GetProjects", () => {
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { maxResults: 10, startAt: 0 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/projects",
       args,
@@ -72,7 +72,7 @@ describe("GetProjects", () => {
       ],
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith("/projects", {
       maxResults: 10, // default value
       startAt: 0, // default value
@@ -82,14 +82,14 @@ describe("GetProjects", () => {
 
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ maxResults: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ maxResults: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ maxResults: 1 }, {});
+    const result = await instance.handle({ maxResults: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/status/get-statuses.test.ts
+++ b/src/tests/unit/zephyr/tool/status/get-statuses.test.ts
@@ -57,7 +57,7 @@ describe("GetStatuses", () => {
       statusType: "TEST_CASE",
       projectKey: "PROJ",
     } as const;
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/statuses",
       args,
@@ -68,7 +68,7 @@ describe("GetStatuses", () => {
   it("should call apiClient.get with only statusType", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { statusType: "TEST_PLAN" } as const;
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith("/statuses", {
       ...args,
       maxResults: 10,
@@ -80,7 +80,7 @@ describe("GetStatuses", () => {
   it("should call apiClient.get with only projectKey", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { projectKey: "PROJ" } as const;
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith("/statuses", {
       ...args,
       maxResults: 10,
@@ -91,7 +91,7 @@ describe("GetStatuses", () => {
 
   it("should handle empty args (all undefined optional params)", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith("/statuses", {
       maxResults: 10,
       startAt: 0,
@@ -101,14 +101,14 @@ describe("GetStatuses", () => {
 
   it("should propagate errors from apiClient.get", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ maxResults: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ maxResults: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected undefined data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ maxResults: 1 }, {});
+    const result = await instance.handle({ maxResults: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-case/get-links.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/get-links.test.ts
@@ -216,10 +216,14 @@ describe("GetTestCaseLinks", () => {
       "/testcases/SA-T10/links",
     );
     expect(result.structuredContent).toBe(responseMock);
-    expect(result.structuredContent.webLinks).toHaveLength(3);
-    expect(result.structuredContent.webLinks[0].url).toBe("not-a-valid-url");
-    expect(result.structuredContent.webLinks[1].url).toBe("//incomplete");
-    expect(result.structuredContent.webLinks[2].url).toBe(
+    expect(result.structuredContent?.webLinks).toHaveLength(3);
+    expect((result.structuredContent?.webLinks as any)[0].url).toBe(
+      "not-a-valid-url",
+    );
+    expect((result.structuredContent?.webLinks as any)[1].url).toBe(
+      "//incomplete",
+    );
+    expect((result.structuredContent?.webLinks as any)[2].url).toBe(
       "http://example.com/path with spaces",
     );
   });

--- a/src/tests/unit/zephyr/tool/test-case/get-test-case.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/get-test-case.test.ts
@@ -100,7 +100,7 @@ describe("GetTestCase", () => {
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { testCaseKey: "SA-T10" };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcases/SA-T10",
     );
@@ -110,17 +110,17 @@ describe("GetTestCase", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
     await expect(
-      instance.handle({ testCaseKey: "SA-T10" }, {}),
+      instance.handle({ testCaseKey: "SA-T10" }, {} as any),
     ).rejects.toThrow("API error");
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ testCaseKey: "SA-T10" }, {});
+    const result = await instance.handle({ testCaseKey: "SA-T10" }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 
   it("should throw validation error if testCaseKey is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow();
+    await expect(instance.handle({}, {} as any)).rejects.toThrow();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-case/get-test-cases.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/get-test-cases.test.ts
@@ -109,7 +109,7 @@ describe("GetTestCases", () => {
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { limit: 10, startAtId: 0 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcases/nextgen",
       args,
@@ -192,7 +192,7 @@ describe("GetTestCases", () => {
       ],
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcases/nextgen",
       {
@@ -205,14 +205,14 @@ describe("GetTestCases", () => {
 
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ limit: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ limit: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ limit: 1 }, {});
+    const result = await instance.handle({ limit: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-case/get-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/get-test-steps.test.ts
@@ -49,7 +49,7 @@ describe("GetTestCaseSteps", () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { testCaseKey: "SA-T1", maxResults: 10, startAt: 0 };
 
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcases/SA-T1/teststeps",
@@ -83,7 +83,7 @@ describe("GetTestCaseSteps", () => {
       ],
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({ testCaseKey: "SA-T1" }, {});
+    const result = await instance.handle({ testCaseKey: "SA-T1" }, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcases/SA-T1/teststeps",
       {
@@ -97,7 +97,7 @@ describe("GetTestCaseSteps", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
     await expect(
-      instance.handle({ testCaseKey: "SA-T1", maxResults: 1 }, {}),
+      instance.handle({ testCaseKey: "SA-T1", maxResults: 1 }, {} as any),
     ).rejects.toThrow("API error");
   });
 
@@ -105,7 +105,7 @@ describe("GetTestCaseSteps", () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
     const result = await instance.handle(
       { testCaseKey: "SA-T1", maxResults: 1 },
-      {},
+      {} as any,
     );
     expect(result.structuredContent).toBeUndefined();
   });

--- a/src/tests/unit/zephyr/tool/test-cycle/get-test-cycle.test.ts
+++ b/src/tests/unit/zephyr/tool/test-cycle/get-test-cycle.test.ts
@@ -94,7 +94,7 @@ describe("GetTestCycle", () => {
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { testCycleIdOrKey: "TEST-R1" };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcycles/TEST-R1",
     );
@@ -104,17 +104,17 @@ describe("GetTestCycle", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
     await expect(
-      instance.handle({ testCycleIdOrKey: "1" }, {}),
+      instance.handle({ testCycleIdOrKey: "1" }, {} as any),
     ).rejects.toThrow("API error");
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ testCycleIdOrKey: "1" }, {});
+    const result = await instance.handle({ testCycleIdOrKey: "1" }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 
   it("should throw validation error if testCycleKey is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow();
+    await expect(instance.handle({}, {} as any)).rejects.toThrow();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-cycle/get-test-cycles.test.ts
+++ b/src/tests/unit/zephyr/tool/test-cycle/get-test-cycles.test.ts
@@ -108,7 +108,7 @@ describe("GetTestCycles", () => {
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { maxResults: 10, startAt: 0 };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testcycles",
       args,
@@ -194,7 +194,7 @@ describe("GetTestCycles", () => {
       ],
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith("/testcycles", {
       maxResults: 10,
       startAt: 0,
@@ -204,14 +204,14 @@ describe("GetTestCycles", () => {
 
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ maxResults: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ maxResults: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ maxResults: 1 }, {});
+    const result = await instance.handle({ maxResults: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-execution/get-test-execution-links.test.ts
+++ b/src/tests/unit/zephyr/tool/test-execution/get-test-execution-links.test.ts
@@ -54,7 +54,7 @@ describe("GetTestExecutionLinks", () => {
 
     const args = { testExecutionIdOrKey: "1" };
 
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/1/links",
@@ -89,7 +89,7 @@ describe("GetTestExecutionLinks", () => {
 
     const result = await instance.handle(
       { testExecutionIdOrKey: "PROJ-E123" },
-      {},
+      {} as any,
     );
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
@@ -103,14 +103,17 @@ describe("GetTestExecutionLinks", () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
 
     await expect(
-      instance.handle({ testExecutionIdOrKey: "PROJ-E123" }, {}),
+      instance.handle({ testExecutionIdOrKey: "PROJ-E123" }, {} as any),
     ).rejects.toThrow("API error");
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
 
-    const result = await instance.handle({ testExecutionIdOrKey: "1" }, {});
+    const result = await instance.handle(
+      { testExecutionIdOrKey: "1" },
+      {} as any,
+    );
 
     expect(result.structuredContent).toBeUndefined();
   });

--- a/src/tests/unit/zephyr/tool/test-execution/get-test-execution.test.ts
+++ b/src/tests/unit/zephyr/tool/test-execution/get-test-execution.test.ts
@@ -89,7 +89,7 @@ describe("GetTestExecution", () => {
   it("should call apiClient.get with string testExecutionIdOrKey and return formatted content", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { testExecutionIdOrKey: "SA-E10" };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/SA-E10",
     );
@@ -99,7 +99,7 @@ describe("GetTestExecution", () => {
   it("should call apiClient.get with numeric string testExecutionIdOrKey and return formatted content", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
     const args = { testExecutionIdOrKey: "1" }; // Pass as string
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/1",
     );
@@ -109,11 +109,11 @@ describe("GetTestExecution", () => {
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
     await expect(
-      instance.handle({ testExecutionIdOrKey: "1" }, {}),
+      instance.handle({ testExecutionIdOrKey: "1" }, {} as any),
     ).rejects.toThrow("API error");
   });
 
   it("should throw validation error if testExecutionIdOrKey is missing", async () => {
-    await expect(instance.handle({}, {})).rejects.toThrow();
+    await expect(instance.handle({}, {} as any)).rejects.toThrow();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-execution/get-test-executions.test.ts
+++ b/src/tests/unit/zephyr/tool/test-execution/get-test-executions.test.ts
@@ -98,7 +98,7 @@ describe("GetTestExecutions", () => {
       startAtId: 0,
       onlyLastExecutions: false,
     };
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/nextgen",
       args,
@@ -116,7 +116,7 @@ describe("GetTestExecutions", () => {
       values: [],
     };
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
-    const result = await instance.handle({}, {});
+    const result = await instance.handle({}, {} as any);
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/nextgen",
       {
@@ -131,14 +131,14 @@ describe("GetTestExecutions", () => {
 
   it("should handle apiClient.get throwing error", async () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
-    await expect(instance.handle({ limit: 1 }, {})).rejects.toThrow(
+    await expect(instance.handle({ limit: 1 }, {} as any)).rejects.toThrow(
       "API error",
     );
   });
 
   it("should handle apiClient.get returning unexpected data", async () => {
     mockClient.getApiClient().get.mockResolvedValueOnce(undefined);
-    const result = await instance.handle({ limit: 1 }, {});
+    const result = await instance.handle({ limit: 1 }, {} as any);
     expect(result.structuredContent).toBeUndefined();
   });
 });

--- a/src/tests/unit/zephyr/tool/test-execution/get-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-execution/get-test-steps.test.ts
@@ -59,7 +59,7 @@ describe("GetTestExecutionSteps", () => {
       testExecutionIdOrKey: "SA-E1",
     };
 
-    const result = await instance.handle(args, {});
+    const result = await instance.handle(args, {} as any);
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/SA-E1/teststeps",
@@ -89,7 +89,10 @@ describe("GetTestExecutionSteps", () => {
 
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
-    const result = await instance.handle({ testExecutionIdOrKey: "SA-E1" }, {});
+    const result = await instance.handle(
+      { testExecutionIdOrKey: "SA-E1" },
+      {} as any,
+    );
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/SA-E1/teststeps",
@@ -124,7 +127,10 @@ describe("GetTestExecutionSteps", () => {
 
     mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
 
-    const result = await instance.handle({ testExecutionIdOrKey: "SA-E1" }, {});
+    const result = await instance.handle(
+      { testExecutionIdOrKey: "SA-E1" },
+      {} as any,
+    );
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
       "/testexecutions/SA-E1/teststeps",
@@ -165,7 +171,7 @@ describe("GetTestExecutionSteps", () => {
         startAt: 0,
         testDataRowNumber: 3,
       },
-      {},
+      {} as any,
     );
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
@@ -205,7 +211,7 @@ describe("GetTestExecutionSteps", () => {
         testExecutionIdOrKey: "12345",
         maxResults: 1,
       },
-      {},
+      {} as any,
     );
 
     expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
@@ -223,7 +229,10 @@ describe("GetTestExecutionSteps", () => {
     mockClient.getApiClient().get.mockRejectedValueOnce(new Error("API error"));
 
     await expect(
-      instance.handle({ testExecutionIdOrKey: "SA-E1", maxResults: 1 }, {}),
+      instance.handle(
+        { testExecutionIdOrKey: "SA-E1", maxResults: 1 },
+        {} as any,
+      ),
     ).rejects.toThrow("API error");
   });
 
@@ -232,7 +241,7 @@ describe("GetTestExecutionSteps", () => {
 
     const result = await instance.handle(
       { testExecutionIdOrKey: "SA-E1", maxResults: 1 },
-      {},
+      {} as any,
     );
 
     expect(result.structuredContent).toBeUndefined();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "include": ["src/**/*.ts", "**/*.test.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Goal

Improve maintainability and reduce chances of unexpected unit test behavior by enabling TypeScript checking of the tests.

## Changeset

* Moved the test pattern from exclude to include in `tsconfig.json`
* Added `tsc` check to the `npm build` script
* Fixed reported issues
  * These were mainly where a generic object (`{}`) had been used in the tests for convenience – so I cast to `any`
  * Some were more specific and I fixed in as reasonable-way as I could: specific teams may want to amend this later.

## Testing

Re-run of unit tests.