### PR TITLE
docs: fix non-published Local MCP page

### DIFF
--- a/docs/scripts/publish-portal-content.sh
+++ b/docs/scripts/publish-portal-content.sh
@@ -277,6 +277,7 @@ function process_content_item() {
 
     if [ "$children_length" -gt 0 ]; then
         log_message $INFO "Recursing into $children_length children of $slug ..."
+        local j
         for ((j=0; j<children_length; j++)); do
             local child=$(jq -c ".[$j]" <<< "$children")
             process_content_item "$child" "$current_toc_id" "$file" "$product_name"


### PR DESCRIPTION
## Goal

The improved docs publishing script in #464 didn't quite work with the recursive call as the loop counter was global and so got overridden. This meant the publishing never actioned the second+ siblings of pages.

## Changeset

Added the `local` declaration.

## Testing

Published to staging: https://github.com/SmartBear/smartbear-mcp/actions/runs/25856444440/job/75975433141
