### PR TITLE
fix: pipe through portal error messages correctly (PROVCON-5296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Swagger] Portal API error responses now surface the human-readable reason instead of showing `HTTP 400:` with no message. The client reads the `application/problem+json` error body and extracts the `detail` field (RFC 7807); falls back to `message` if absent.
 - [Transport] Streamable HTTP requests carrying an `MCP-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#449](https://github.com/SmartBear/smartbear-mcp/pull/449)
 - [Common] Configuration options can now be passed in via query string parameters for HTTP transport [#453](https://github.com/SmartBear/smartbear-mcp/pull/453)
 - [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -118,9 +118,12 @@ export class SwaggerAPI {
       return defaultReturn;
     }
 
-    // Check if response is JSON
+    // Check if response is JSON (including application/problem+json)
     const contentType = response.headers.get("content-type");
-    if (contentType?.includes("application/json")) {
+    if (
+      contentType?.includes("application/json") ||
+      contentType?.includes("application/problem+json")
+    ) {
       try {
         return (await response.json()) as T;
       } catch (error) {
@@ -158,7 +161,22 @@ export class SwaggerAPI {
     defaultReturn: T | Record<string, never> = {} as T,
   ): Promise<T | FallbackResponse> {
     if (!response.ok) {
-      throw new ToolError(`HTTP ${response.status}: ${response.statusText}`);
+      const errorBody = await this.parseResponse<Record<string, unknown>>(
+        response,
+        {},
+      );
+      const detail =
+        (typeof errorBody === "object" &&
+          errorBody !== null &&
+          String(
+            (errorBody as Record<string, unknown>).detail ??
+              (errorBody as Record<string, unknown>).message ??
+              "",
+          )) ||
+        response.statusText;
+      throw new ToolError(
+        `HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+      );
     }
 
     return this.parseResponse<T, T | Record<string, never>>(

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -257,5 +257,50 @@ describe("SwaggerAPI", () => {
 
       await expect(api.getPortals()).rejects.toThrow("HTTP 401");
     });
+
+    it("should include detail from application/problem+json error body", async () => {
+      const errorBody = {
+        code: "SB400-01",
+        type: "https://problems-registry.smartbear.com/missing-request-parameter",
+        title: "Missing request parameter",
+        detail: "The request is missing an expected query parameter",
+        status: 400,
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(errorBody), {
+        status: 400,
+        statusText: "",
+        headers: { "content-type": "application/problem+json" },
+      });
+
+      await expect(
+        api.updatePortal("portal-123", { name: "Duplicate Name" }),
+      ).rejects.toThrow(
+        "HTTP 400: The request is missing an expected query parameter",
+      );
+    });
+
+    it("should include message from JSON error body when details is absent", async () => {
+      const errorBody = { message: "Invalid field value" };
+      fetchMock.mockResponseOnce(JSON.stringify(errorBody), {
+        status: 400,
+        statusText: "",
+        headers: { "content-type": "application/json" },
+      });
+
+      await expect(
+        api.updatePortal("portal-123", { name: "Bad Value" }),
+      ).rejects.toThrow("HTTP 400: Invalid field value");
+    });
+
+    it("should not append a trailing colon when status text is empty", async () => {
+      fetchMock.mockResponseOnce("", {
+        status: 400,
+        statusText: "",
+      });
+
+      await expect(
+        api.updatePortal("portal-123", { name: "Bad Value" }),
+      ).rejects.toThrow(/^HTTP 400$/);
+    });
   });
 });


### PR DESCRIPTION
## Goal

The MCP was setup to simply funnel through standard status and statusText messages, instead of handling the actual error message body structure we pass down.

## Design

This just changes the error handler to support problem+json and extract the .message if encountered.

## Changeset

Added the extra support for application/problem+json format and portal response structure.

## Testing

Using MCP Connector it was wired up to portal infrastructure. Piped through bad values to endpoints and observed the returned error messages now displaying correctly ie. 

```"Error: HTTP 400: Invalid parameters: subdomain: size must be between 3 and 20 (trace ID: 6715742381851819355)"```

Full unit test coverage added that supports the appropriate error schema.
