### PR TITLE
release: v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.0] - 2026-05-15
+
 ### Added
 - [Common] Add graceful shutdown on SIGTERM/SIGINT in HTTP mode: drains active sessions (closes Streamable HTTP and SSE transports, runs per-client `cleanupSession` hooks including Reflect WebSocket teardown), with a configurable deadline via `MCP_SHUTDOWN_TIMEOUT_MS` (default 25s) [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
 - [Common] Split health/readiness probes: `GET /health` is now liveness-only and always returns 200 when the process is responsive; `GET /ready` is the readiness probe and returns 503 during drain so load balancers stop routing new sessions to draining pods. Both probes set `Cache-Control: no-store`. [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Common] Streamable HTTP requests carrying an `MCP-Session-Id` the server doesn't recognize now return `404` (with a JSON-RPC error envelope, code `-32001`) instead of `400`. This aligns with the MCP Streamable HTTP spec's Session Management rules, which require a 404 for requests against a terminated session and oblige clients to respond by sending a fresh `InitializeRequest`. In multi-pod deployments this lets clients transparently re-initialize after a pod restart or routing reshuffle drops the in-memory session, instead of treating it as a permanent protocol error. [#449](https://github.com/SmartBear/smartbear-mcp/pull/449)
 - [Common] Configuration options can now be passed in via query string parameters for HTTP transport [#453](https://github.com/SmartBear/smartbear-mcp/pull/453)
-- [Swagger] Remove unused `role` parameter from the `create_portal_product` tool.
-- [Swagger] Portal API error responses now surface the human-readable reason instead of showing `HTTP 400:` with no message. The client reads the `application/problem+json` error body and extracts the `detail` field (RFC 7807); falls back to `message` if absent.
+- [Swagger] Remove unused `role` parameter from the `create_portal_product` tool. [#469](https://github.com/SmartBear/smartbear-mcp/pull/469)
+- [Swagger] Portal API error responses now surface the human-readable reason instead of showing `HTTP 400:` with no message. The client reads the `application/problem+json` error body and extracts the `detail` field (RFC 7807); falls back to `message` if absent. [#468](https://github.com/SmartBear/smartbear-mcp/pull/468)
 - [Pactflow][Collaborator] Reduced tool names under the apparent 64 character limit for Claude connectors [#470](https://github.com/SmartBear/smartbear-mcp/pull/470)
 - [Pactflow] Fix bug that prevents MCP server from starting with no configuration (for tool exploration) [#445](https://github.com/SmartBear/smartbear-mcp/pull/445)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
## Summary
- Bump version to 0.20.0 and stamp the Unreleased changelog section with today's date
- Backfill missing PR links (#468, #469) on Swagger entries in the changelog

## Test plan
- [x] CI passes on the release branch
- [ ] After merge, create GitHub release `v0.20.0` and verify the publish workflow succeeds
- [ ] Verify docs update at https://developer.smartbear.com/smartbear-mcp/