### PR TITLE
feat: create GitHub release with MCPB attached from tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: Publish
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   packages: write
 
@@ -23,8 +23,14 @@ on:
         required: false
         type: boolean
         default: true
-  release:
-    types: [published]
+      publish_mcpb:
+        description: "Build and attach .mcpb to the latest GitHub release"
+        required: false
+        type: boolean
+        default: true
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   # Build platform-specific images on native runners
@@ -187,6 +193,7 @@ jobs:
     env:
       RUN_PUBLISH_NPM: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_npm }}
       RUN_PUBLISH_MCP: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_mcp }}
+      RUN_PUBLISH_MCPB: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_mcpb }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -211,7 +218,6 @@ jobs:
             server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install dependencies
-        if: ${{ env.RUN_PUBLISH_NPM == 'true' }}
         run: npm ci
 
       - name: Publish to npm
@@ -234,3 +240,55 @@ jobs:
       - name: Publish to MCP Registry
         if: ${{ env.RUN_PUBLISH_MCP == 'true' }}
         run: ./mcp-publisher publish
+
+      - name: Build and pack .mcpb
+        if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
+        id: pack
+        run: |
+          npm pack
+          MCPB_FILE=$(ls smartbear-mcp-*.mcpb 2>/dev/null)
+          if [[ -z "$MCPB_FILE" ]]; then
+            echo "::error::No smartbear-mcp-*.mcpb file found after pack"
+            exit 1
+          fi
+          echo "mcpb_file=$MCPB_FILE" >> "$GITHUB_OUTPUT"
+      - name: Get release tag
+        if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
+        id: get_tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=$(git describe --tags --abbrev=0)
+          fi
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No release tag found"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create/Update GitHub Release
+        if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES=$(awk '/^## \[[0-9]+\.[0-9]+\.[0-9]+/{if(found) exit; found=1; next} found' CHANGELOG.md)
+          if [[ -z "$NOTES" ]]; then
+            echo "::error::No release notes found in CHANGELOG.md"
+            exit 1
+          fi
+          if gh release view "${{ steps.get_tag.outputs.tag }}" &>/dev/null; then
+            echo "::notice::Updating release ${{ steps.get_tag.outputs.tag }}"
+            gh release edit "${{ steps.get_tag.outputs.tag }}" \
+            --notes "$NOTES"
+            else
+            echo "::notice::Creating release ${{ steps.get_tag.outputs.tag }}"
+            gh release create "${{ steps.get_tag.outputs.tag }}" \
+              --title "${{ steps.get_tag.outputs.tag }}" \
+              --notes "$NOTES"
+          fi
+          gh release upload "${{ steps.get_tag.outputs.tag }}" \
+            "${{ steps.pack.outputs.mcpb_file }}" \
+            --clobber

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,9 +32,8 @@ on:
         required: false
         type: boolean
         default: true
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   # Build platform-specific images on native runners
@@ -220,7 +219,7 @@ jobs:
       - name: Resolve release tag
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "release" ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           else
             TAG="${{ inputs.tag }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,10 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Git tag to publish (e.g. v1.0.0)"
+        required: true
+        type: string
       push_ecr:
         description: "Push Docker image to Amazon ECR"
         required: false
@@ -55,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -125,6 +131,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
@@ -197,6 +205,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -205,11 +217,35 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           scope: '@smartbear'
 
+      - name: Resolve release tag
+        id: get_tag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No release tag found"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Extract version from package.json
         id: extract_version
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate tag matches package.json version
+        run: |
+          TAG="${{ steps.get_tag.outputs.tag }}"
+          VERSION="${{ steps.extract_version.outputs.VERSION }}"
+          EXPECTED_TAG="v${VERSION}"
+          if [[ "$TAG" != "$EXPECTED_TAG" ]]; then
+            echo "::error::Tag $TAG does not match package.json version $VERSION (expected $EXPECTED_TAG)"
+            exit 1
+          fi
 
       - name: Update server.json version
         run: |
@@ -252,29 +288,13 @@ jobs:
             exit 1
           fi
           echo "mcpb_file=$MCPB_FILE" >> "$GITHUB_OUTPUT"
-      - name: Get release tag
-        if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
-        id: get_tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
-            TAG=$(git describe --tags --abbrev=0)
-          fi
-          if [[ -z "$TAG" ]]; then
-            echo "::error::No release tag found"
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Create/Update GitHub Release
         if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NOTES=$(awk '/^## \[[0-9]+\.[0-9]+\.[0-9]+/{if(found) exit; found=1; next} found' CHANGELOG.md)
+          VERSION="${{ steps.extract_version.outputs.VERSION }}"
+          NOTES=$(awk -v ver="$VERSION" '/^## \[/{if(found) exit; if($0 ~ "## \\[" ver "\\]") found=1; next} found' CHANGELOG.md)
           if [[ -z "$NOTES" ]]; then
             echo "::error::No release notes found in CHANGELOG.md"
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,9 @@ Please follow these steps to create a new release:
     - Get approval and merge the PR into `main`
 
 2. **Release**
-    - Create and push a tag for the new release (e.g., `git tag v1.2.3` and `git push origin v1.2.3`)
-    - This will trigger the publish workflow, which will publish the new version to external sites (e.g. npm) and create the GitHub release
+    - Create a new release on GitHub (or push a new tag) with the version, including the `v` prefix (e.g. `v1.2.3`)
+      - This will trigger the publish workflow, which will publish the new version to external sites (e.g. npm) and update the GitHub release with the changelog details and artifacts
+    - Await/request approval of the publish workflow
 
 3. **Post-Release**
     - Check the publish action to make sure all deployments succeeded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,23 +148,20 @@ A release will be carried out by a member of the SmartBear team when a set of re
 
 Please follow these steps to create a new release:
 
-1. **Run bump script**
-  The bump script will help automate some of the steps below:
+1. **Run `npm run bump`** to:
    - Suggest a version number based on [semantic versioning](https://semver.org/)
    - Create a release branch from `main`
    - Update the version in `package.json` , `package-lock.json` and `CHANGELOG.md` files
    - Commit the changes
    - Push the release branch to GitHub
 
-   ```bash
-   npm run bump
-   ```
 1. **Create PR to main**
-    - Push the changes to GitHub and create a Pull Request from your release branch into `main`
+    - Create a Pull Request from your release branch into `main`
+    - Get approval and merge the PR into `main`
 
 2. **Release**
-    - Create a new Github release with the version you decided on earlier
-    - Changes will be automatically deployed once the Github release is created
+    - Create and push a tag for the new release (e.g., `git tag v1.2.3` and `git push origin v1.2.3`)
+    - This will trigger the publish workflow, which will publish the new version to external sites (e.g. npm) and create the GitHub release
 
 3. **Post-Release**
     - Check the publish action to make sure all deployments succeeded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,8 @@ Please follow these steps to create a new release:
     - Get approval and merge the PR into `main`
 
 2. **Release**
-    - Create a new release on GitHub (or push a new tag) with the version, including the `v` prefix (e.g. `v1.2.3`)
-      - This will trigger the publish workflow, which will publish the new version to external sites (e.g. npm) and update the GitHub release with the changelog details and artifacts
+    - Create a new release on GitHub with just a tag name (e.g. `v0.20.0`)
+      - The `publish` automation will publish the new version to external sites (e.g. npm) and update the GitHub release with the changelog details and artifacts
     - Await/request approval of the publish workflow
 
 3. **Post-Release**


### PR DESCRIPTION
## Goal

It would be useful to attach `.mcpb` files to the GitHub release for reference. To facilitate this I've amended the publish job to automatically create (or update) the release with the artifact.

I've also taken the opportunity to script the adding of the changelog to the release notes.

## Design

Added `publish_mcpb` parameter for manual dispatch to run later if required.

Also added `tag` input on which to run the script - this ensures that all the build and publish steps act on the same commit.

## Testing

Cloned the repo and ran the scripts with a new tag and updating existing releases.

This hasn't been tested with the rest of the publishing, but this will need to happen on next release.
