### PR TITLE
feat: integrate cache service into QTM4J resolvers and client for improved data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Common] Add graceful shutdown on SIGTERM/SIGINT in HTTP mode: drains active sessions (closes Streamable HTTP and SSE transports, runs per-client `cleanupSession` hooks including Reflect WebSocket teardown), with a configurable deadline via `MCP_SHUTDOWN_TIMEOUT_MS` (default 25s) [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
 - [Common] Split health/readiness probes: `GET /health` is now liveness-only and always returns 200 when the process is responsive; `GET /ready` is the readiness probe and returns 503 during drain so load balancers stop routing new sessions to draining pods. Both probes set `Cache-Control: no-store`. [#455](https://github.com/SmartBear/smartbear-mcp/pull/455)
 - [Common] Add product prefix to registered resources and prompts [#458](https://github.com/SmartBear/smartbear-mcp/pull/458)
+- [QTM4J] Add QTM4J (QMetry Test Management for Jira) capabilities to MCP [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `get-projects` for listing QTM4J projects with optional filtering and pagination [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `set-project-context` for setting the active project for the session [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `create-test-case` for creating a Test Case [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `search-test-cases` for filtering and searching Test Cases with sorting and pagination [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `get-test-steps` for retrieving Test Steps for a given Test Case [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
+- [QTM4J] Added a tool `update-test-case` for updating an existing Test Case [#476](https://github.com/SmartBear/smartbear-mcp/pull/476)
 
 ### Fixed
 

--- a/src/qtm4j/client.ts
+++ b/src/qtm4j/client.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { getRequestHeader } from "../common/request-context";
+import type { SmartBearMcpServer } from "../common/server";
 import type {
   Client,
   GetInputFunction,
@@ -68,14 +69,12 @@ export class Qtm4jClient implements Client {
 
   /**
    * Configure the QTM4J client with API credentials
-   * @param _server - MCP Server instance (not used currently)
+   * @param server - MCP Server instance
    * @param config - Configuration object containing API key and optional base URL
-   * @param _cache - Cache service instance (not used currently)
    */
   async configure(
-    _server: any,
+    server: SmartBearMcpServer,
     config: z.infer<typeof ConfigurationSchema>,
-    _cache?: any,
   ): Promise<void> {
     this._apiKey = config[CONFIG_KEYS.API_KEY];
     if (config[CONFIG_KEYS.BASE_URL]) {
@@ -85,8 +84,11 @@ export class Qtm4jClient implements Client {
     // Initialize API client with token provider for request-scoped credentials
     this.apiClient = new ApiClient(() => this.getAuthToken(), this.baseUrl);
 
-    // Initialize resolver registry with the API client
-    this.resolverRegistry = new ResolverRegistry(this.apiClient);
+    // Initialize resolver registry with the API client and shared cache
+    this.resolverRegistry = new ResolverRegistry(
+      this.apiClient,
+      server.getCache(),
+    );
   }
 
   /**

--- a/src/qtm4j/resolver/cache/cache.ts
+++ b/src/qtm4j/resolver/cache/cache.ts
@@ -1,30 +1,59 @@
+import type { CacheService } from "../../../common/cache";
 import type { FieldValues } from "../../config/field-resolution.types";
 
 /** In-memory cache for field metadata, keyed by projectKey → fieldKey → name→ID map. */
 export class Cache {
-  private readonly store = new Map<string, Map<string, FieldValues>>();
+  private readonly trackedKeys = new Map<string, Set<string>>();
+  private readonly cacheService: CacheService;
+
+  constructor(cacheService: CacheService) {
+    this.cacheService = cacheService;
+  }
+
+  private compositeKey(projectKey: string, fieldKey: string): string {
+    return `qtm4j:${projectKey}:${fieldKey}`;
+  }
 
   get(projectKey: string, fieldKey: string): FieldValues | undefined {
-    return this.store.get(projectKey)?.get(fieldKey);
+    return this.cacheService.get<FieldValues>(
+      this.compositeKey(projectKey, fieldKey),
+    );
   }
 
   set(projectKey: string, fieldKey: string, values: FieldValues): void {
-    if (!this.store.has(projectKey)) {
-      this.store.set(projectKey, new Map());
+    const key = this.compositeKey(projectKey, fieldKey);
+    const existing =
+      this.cacheService.get<FieldValues>(key) ?? ({} as FieldValues);
+    this.cacheService.set(key, { ...existing, ...values });
+    if (!this.trackedKeys.has(projectKey)) {
+      this.trackedKeys.set(projectKey, new Set());
     }
-    const existing = this.store.get(projectKey)?.get(fieldKey) ?? {};
-    this.store.get(projectKey)?.set(fieldKey, { ...existing, ...values });
+    this.trackedKeys.get(projectKey)!.add(key);
   }
 
   has(projectKey: string, fieldKey: string): boolean {
-    return this.store.get(projectKey)?.has(fieldKey) ?? false;
+    return (
+      this.cacheService.get(this.compositeKey(projectKey, fieldKey)) !==
+      undefined
+    );
   }
 
   clear(projectKey?: string): void {
     if (projectKey) {
-      this.store.delete(projectKey);
+      const keys = this.trackedKeys.get(projectKey);
+      if (keys) {
+        for (const key of keys) {
+          this.cacheService.del(key);
+        }
+        this.trackedKeys.delete(projectKey);
+      }
     } else {
-      this.store.clear();
+      for (const keys of this.trackedKeys.values()) {
+        for (const key of keys) {
+          this.cacheService.del(key);
+        }
+      }
+      this.trackedKeys.clear();
     }
   }
 

--- a/src/qtm4j/resolver/resolver-registry.ts
+++ b/src/qtm4j/resolver/resolver-registry.ts
@@ -1,3 +1,4 @@
+import type { CacheService } from "../../common/cache";
 import type { ProjectContext } from "../config/field-resolution.types";
 import type { ApiClient } from "../http/api-client";
 import { CommonAttributeResolver } from "./resolvers/common-attribute-resolver";
@@ -15,11 +16,14 @@ export class ResolverRegistry {
   private readonly testCaseUidResolver: TestCaseUidResolver;
   private projectContext: ProjectContext | undefined;
 
-  constructor(apiClient: ApiClient) {
-    this.commonAttributes = new CommonAttributeResolver(apiClient);
+  constructor(apiClient: ApiClient, cacheService: CacheService) {
+    this.commonAttributes = new CommonAttributeResolver(
+      apiClient,
+      cacheService,
+    );
     this.testCaseUidResolver = new TestCaseUidResolver(apiClient);
-    const labelResolver = new LabelResolver(apiClient);
-    const componentResolver = new ComponentResolver(apiClient);
+    const labelResolver = new LabelResolver(apiClient, cacheService);
+    const componentResolver = new ComponentResolver(apiClient, cacheService);
 
     this.resolverByKey = new Map();
     for (const resolver of [

--- a/src/qtm4j/resolver/resolvers/common-attribute-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/common-attribute-resolver.ts
@@ -1,3 +1,4 @@
+import type { CacheService } from "../../../common/cache";
 import { ENDPOINTS } from "../../config/constants";
 import {
   type FieldValues,
@@ -13,12 +14,13 @@ export class CommonAttributeResolver extends Resolver {
     ResolverKeys.CommonAttribute,
   );
 
-  readonly cache = new Cache();
+  readonly cache: Cache;
   private readonly apiClient: ApiClient;
 
-  constructor(apiClient: ApiClient) {
+  constructor(apiClient: ApiClient, cacheService: CacheService) {
     super();
     this.apiClient = apiClient;
+    this.cache = new Cache(cacheService);
   }
 
   // Priority and status are always single values — no array handling needed.

--- a/src/qtm4j/resolver/resolvers/component-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/component-resolver.ts
@@ -1,3 +1,4 @@
+import type { CacheService } from "../../../common/cache";
 import { ENDPOINTS } from "../../config/constants";
 import {
   type FieldValues,
@@ -13,12 +14,13 @@ export class ComponentResolver extends Resolver {
     ResolverKeys.SearchableField.COMPONENTS,
   ];
 
-  private readonly cache = new Cache();
+  private readonly cache: Cache;
   private readonly apiClient: ApiClient;
 
-  constructor(apiClient: ApiClient) {
+  constructor(apiClient: ApiClient, cacheService: CacheService) {
     super();
     this.apiClient = apiClient;
+    this.cache = new Cache(cacheService);
   }
 
   async resolve(

--- a/src/qtm4j/resolver/resolvers/label-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/label-resolver.ts
@@ -1,3 +1,4 @@
+import type { CacheService } from "../../../common/cache";
 import { ENDPOINTS } from "../../config/constants";
 import {
   type FieldValues,
@@ -13,12 +14,13 @@ export class LabelResolver extends Resolver {
     ResolverKeys.SearchableField.LABEL,
   ];
 
-  private readonly cache = new Cache();
+  private readonly cache: Cache;
   private readonly apiClient: ApiClient;
 
-  constructor(apiClient: ApiClient) {
+  constructor(apiClient: ApiClient, cacheService: CacheService) {
     super();
     this.apiClient = apiClient;
+    this.cache = new Cache(cacheService);
   }
 
   async resolve(

--- a/src/tests/unit/qtm4j/client.test.ts
+++ b/src/tests/unit/qtm4j/client.test.ts
@@ -22,13 +22,16 @@ describe("Qtm4jClient", () => {
 
   it("should initialize ApiClient with default baseUrl", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "token" } as any,
+    );
     expect(client.getApiClient()).toBeInstanceOf(ApiClient);
   });
 
   it("should initialize ApiClient with custom baseUrl", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, {
+    await client.configure({ getCache: () => undefined } as any, {
       api_key: "token",
       base_url: "https://custom.qtm4j.com",
     });
@@ -38,7 +41,10 @@ describe("Qtm4jClient", () => {
   it("should check if client is configured", async () => {
     const client = new Qtm4jClient();
     expect(client.isConfigured()).toBe(false);
-    await client.configure({} as any, { api_key: "token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "token" } as any,
+    );
     expect(client.isConfigured()).toBe(true);
   });
 
@@ -51,7 +57,10 @@ describe("Qtm4jClient", () => {
 
   it("should register tools and call register", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "token" } as any,
+    );
     const register = vi.fn();
     const getInput = vi.fn();
     await client.registerTools(register, getInput);
@@ -68,13 +77,19 @@ describe("Qtm4jClient", () => {
 
   it("should return ResolverRegistry after configure", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "token" } as any,
+    );
     expect(client.getResolverRegistry()).toBeDefined();
   });
 
   it("should throw when requireProjectContext called with no context set", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "token" } as any,
+    );
     expect(() => client.requireProjectContext()).toThrow(
       "No active project set",
     );
@@ -82,7 +97,10 @@ describe("Qtm4jClient", () => {
 
   it("should get auth token from configuration", async () => {
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "test-token-123" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "test-token-123" } as any,
+    );
     const token = client.getAuthToken();
     expect(token).toBe("test-token-123");
   });
@@ -90,21 +108,30 @@ describe("Qtm4jClient", () => {
   it("should prefer request header token over configured api key", async () => {
     vi.mocked(getRequestHeader).mockReturnValue("header-token");
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "config-token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "config-token" } as any,
+    );
     expect(client.getAuthToken()).toBe("header-token");
   });
 
   it("should strip Bearer prefix from Authorization header", async () => {
     vi.mocked(getRequestHeader).mockReturnValue("Bearer my-bearer-token");
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "config-token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "config-token" } as any,
+    );
     expect(client.getAuthToken()).toBe("my-bearer-token");
   });
 
   it("should handle array header value by using first element", async () => {
     vi.mocked(getRequestHeader).mockReturnValue(["array-token", "other"]);
     const client = new Qtm4jClient();
-    await client.configure({} as any, { api_key: "config-token" } as any);
+    await client.configure(
+      { getCache: () => undefined } as any,
+      { api_key: "config-token" } as any,
+    );
     expect(client.getAuthToken()).toBe("array-token");
   });
 });

--- a/src/tests/unit/qtm4j/resolver/cache.test.ts
+++ b/src/tests/unit/qtm4j/resolver/cache.test.ts
@@ -1,11 +1,26 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { Cache } from "../../../../qtm4j/resolver/cache/cache";
 
+function makeMockCacheService() {
+  const store = new Map<string, unknown>();
+  return {
+    get: <T>(key: string): T | undefined => store.get(key) as T | undefined,
+    set: <T>(key: string, value: T): boolean => {
+      store.set(key, value);
+      return true;
+    },
+    del: (key: string): number => {
+      store.delete(key);
+      return 1;
+    },
+  };
+}
+
 describe("Cache", () => {
   let cache: Cache;
 
   beforeEach(() => {
-    cache = new Cache();
+    cache = new Cache(makeMockCacheService() as any);
   });
 
   describe("get", () => {

--- a/src/tests/unit/qtm4j/resolver/common-attribute-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/common-attribute-resolver.test.ts
@@ -10,6 +10,23 @@ import { CommonAttributeResolver } from "../../../../qtm4j/resolver/resolvers/co
 
 vi.mock("../../../../qtm4j/resolver/cache/cache");
 
+function makeMockCacheService() {
+  const store = new Map<string, unknown>();
+  return {
+    get: <T>(key: string): T | undefined => store.get(key) as T | undefined,
+    set: <T>(key: string, value: T): boolean => {
+      store.set(key, value);
+      return true;
+    },
+    del: (key: string): number => {
+      store.delete(key);
+      return 1;
+    },
+    isEnabled: () => true,
+    flushAll: () => {},
+  };
+}
+
 describe("CommonAttributeResolver", () => {
   let mockApiClient: any;
   let resolver: CommonAttributeResolver;
@@ -28,7 +45,10 @@ describe("CommonAttributeResolver", () => {
 
     vi.mocked(Cache).mockImplementation(() => mockCache);
 
-    resolver = new CommonAttributeResolver(mockApiClient);
+    resolver = new CommonAttributeResolver(
+      mockApiClient,
+      makeMockCacheService() as any,
+    );
   });
 
   describe("fieldKeys", () => {

--- a/src/tests/unit/qtm4j/resolver/component-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/component-resolver.test.ts
@@ -10,6 +10,23 @@ import { ComponentResolver } from "../../../../qtm4j/resolver/resolvers/componen
 
 vi.mock("../../../../qtm4j/resolver/cache/cache");
 
+function makeMockCacheService() {
+  const store = new Map<string, unknown>();
+  return {
+    get: <T>(key: string): T | undefined => store.get(key) as T | undefined,
+    set: <T>(key: string, value: T): boolean => {
+      store.set(key, value);
+      return true;
+    },
+    del: (key: string): number => {
+      store.delete(key);
+      return 1;
+    },
+    isEnabled: () => true,
+    flushAll: () => {},
+  };
+}
+
 describe("ComponentResolver", () => {
   let mockApiClient: any;
   let resolver: ComponentResolver;
@@ -28,7 +45,10 @@ describe("ComponentResolver", () => {
 
     vi.mocked(Cache).mockImplementation(() => mockCache);
 
-    resolver = new ComponentResolver(mockApiClient);
+    resolver = new ComponentResolver(
+      mockApiClient,
+      makeMockCacheService() as any,
+    );
   });
 
   describe("fieldKeys", () => {

--- a/src/tests/unit/qtm4j/resolver/label-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/label-resolver.test.ts
@@ -10,6 +10,23 @@ import { LabelResolver } from "../../../../qtm4j/resolver/resolvers/label-resolv
 
 vi.mock("../../../../qtm4j/resolver/cache/cache");
 
+function makeMockCacheService() {
+  const store = new Map<string, unknown>();
+  return {
+    get: <T>(key: string): T | undefined => store.get(key) as T | undefined,
+    set: <T>(key: string, value: T): boolean => {
+      store.set(key, value);
+      return true;
+    },
+    del: (key: string): number => {
+      store.delete(key);
+      return 1;
+    },
+    isEnabled: () => true,
+    flushAll: () => {},
+  };
+}
+
 describe("LabelResolver", () => {
   let mockApiClient: any;
   let resolver: LabelResolver;
@@ -28,7 +45,7 @@ describe("LabelResolver", () => {
 
     vi.mocked(Cache).mockImplementation(() => mockCache);
 
-    resolver = new LabelResolver(mockApiClient);
+    resolver = new LabelResolver(mockApiClient, makeMockCacheService() as any);
   });
 
   describe("fieldKeys", () => {

--- a/src/tests/unit/qtm4j/resolver/resolver-registry.test.ts
+++ b/src/tests/unit/qtm4j/resolver/resolver-registry.test.ts
@@ -11,6 +11,23 @@ vi.mock("../../../../qtm4j/resolver/resolvers/label-resolver");
 vi.mock("../../../../qtm4j/resolver/resolvers/component-resolver");
 vi.mock("../../../../qtm4j/resolver/resolvers/test-case-uid-resolver");
 
+function makeMockCacheService() {
+  const store = new Map<string, unknown>();
+  return {
+    get: <T>(key: string): T | undefined => store.get(key) as T | undefined,
+    set: <T>(key: string, value: T): boolean => {
+      store.set(key, value);
+      return true;
+    },
+    del: (key: string): number => {
+      store.delete(key);
+      return 1;
+    },
+    isEnabled: () => true,
+    flushAll: () => {},
+  };
+}
+
 describe("ResolverRegistry", () => {
   let mockApiClient: any;
   let registry: ResolverRegistry;
@@ -57,14 +74,26 @@ describe("ResolverRegistry", () => {
       () => mockTestCaseUidResolver,
     );
 
-    registry = new ResolverRegistry(mockApiClient);
+    registry = new ResolverRegistry(
+      mockApiClient,
+      makeMockCacheService() as any,
+    );
   });
 
   describe("constructor", () => {
     it("should create all resolver instances", () => {
-      expect(CommonAttributeResolver).toHaveBeenCalledWith(mockApiClient);
-      expect(LabelResolver).toHaveBeenCalledWith(mockApiClient);
-      expect(ComponentResolver).toHaveBeenCalledWith(mockApiClient);
+      expect(CommonAttributeResolver).toHaveBeenCalledWith(
+        mockApiClient,
+        expect.any(Object),
+      );
+      expect(LabelResolver).toHaveBeenCalledWith(
+        mockApiClient,
+        expect.any(Object),
+      );
+      expect(ComponentResolver).toHaveBeenCalledWith(
+        mockApiClient,
+        expect.any(Object),
+      );
       expect(TestCaseUidResolver).toHaveBeenCalledWith(mockApiClient);
     });
   });


### PR DESCRIPTION
## Goal
This pull request introduces QTM4J (QMetry Test Management for Jira) capabilities to the MCP, including a suite of tools for interacting with QTM4J projects and test cases. A major refactor improves caching for field metadata by integrating a shared cache service across all relevant resolvers, ensuring efficient and consistent caching. The changes also update tests to accommodate the new caching mechanism.

**QTM4J Feature Additions:**

* Added QTM4J integration to MCP, including tools for listing projects, setting project context, creating and searching test cases, retrieving test steps, and updating test cases.

**Caching Improvements:**

* Refactored the `Cache` class to use a shared `CacheService` for storing field metadata, replacing the previous in-memory implementation.
* Updated `CommonAttributeResolver`, `LabelResolver`, and `ComponentResolver` to accept and use the shared cache service. [[1]](diffhunk://#diff-1989257e2168188798612a8fd112df98bcfac4e5902f0dced0b5e25adc538d35R1) [[2]](diffhunk://#diff-1989257e2168188798612a8fd112df98bcfac4e5902f0dced0b5e25adc538d35L16-R23) [[3]](diffhunk://#diff-fd3025ff76289e0393449ff5e040dd352870f81d61306d4e4e2ac6334310c247R1) [[4]](diffhunk://#diff-fd3025ff76289e0393449ff5e040dd352870f81d61306d4e4e2ac6334310c247L16-R23) [[5]](diffhunk://#diff-15a26c652858ad38969bae237cfbfba8a35f56b83101ede6b5774c41cb473363R1) [[6]](diffhunk://#diff-15a26c652858ad38969bae237cfbfba8a35f56b83101ede6b5774c41cb473363L16-R23)
* Updated `ResolverRegistry` to inject the shared cache service into all resolvers. [[1]](diffhunk://#diff-097bf9987ab94eb16a04e87f979c766aa51bea128dd86d6fdb8dc87483293676R1) [[2]](diffhunk://#diff-097bf9987ab94eb16a04e87f979c766aa51bea128dd86d6fdb8dc87483293676L18-R26)
* Modified `Qtm4jClient` to pass the MCP server's cache to the resolver registry during configuration. [[1]](diffhunk://#diff-71a9d57d422f476b934cb39f8b3bb39d8bfe210e1a1280b15c59474fb1cd801fR3) [[2]](diffhunk://#diff-71a9d57d422f476b934cb39f8b3bb39d8bfe210e1a1280b15c59474fb1cd801fL71-L78) [[3]](diffhunk://#diff-71a9d57d422f476b934cb39f8b3bb39d8bfe210e1a1280b15c59474fb1cd801fL88-R91)

**Testing Updates:**

* Updated unit tests for the client and resolvers to use a mock cache service, reflecting the new dependency on a shared cache. [[1]](diffhunk://#diff-006e7abf7e2befec60f4bd33e79e71e99176f32b4dbc213eccc3dbd53c7700f0R4-R23) [[2]](diffhunk://#diff-43d33e29b526e69ad0b2a34ac1fd51f1b77b21e091aa879e916b26a382e14069R13-R29) [[3]](diffhunk://#diff-43d33e29b526e69ad0b2a34ac1fd51f1b77b21e091aa879e916b26a382e14069L31-R51) [[4]](diffhunk://#diff-e266e24ca8edea781d6a7d7a8856145d700601f76e343bb4635b344c40f61dadR13-R29) [[5]](diffhunk://#diff-e266e24ca8edea781d6a7d7a8856145d700601f76e343bb4635b344c40f61dadL31-R51) [[6]](diffhunk://#diff-7bac82714f545c1d734a2f8039beb5fea1fb5533fed23c6efdaf7b76b3bdd7f7R13-R29) [[7]](diffhunk://#diff-7bac82714f545c1d734a2f8039beb5fea1fb5533fed23c6efdaf7b76b3bdd7f7L31-R48) [[8]](diffhunk://#diff-69d22f2a6a986c0c7fb3cef1f63573edf617eeb2432870f9b0347c379edf24c9L25-R34) [[9]](diffhunk://#diff-69d22f2a6a986c0c7fb3cef1f63573edf617eeb2432870f9b0347c379edf24c9L41-R47) [[10]](diffhunk://#diff-69d22f2a6a986c0c7fb3cef1f63573edf617eeb2432870f9b0347c379edf24c9L54-R63) [[11]](diffhunk://#diff-69d22f2a6a986c0c7fb3cef1f63573edf617eeb2432870f9b0347c379edf24c9L71-R134)

These changes make QTM4J integration more robust and ensure that field metadata is efficiently cached and shared across the application.
<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? -->
