### PR TITLE
fix: npm publishing to avoid mcpb being generated

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -280,7 +280,7 @@ jobs:
         if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}
         id: pack
         run: |
-          npm pack
+          npm run build:mcpb
           MCPB_FILE=$(ls smartbear-mcp-*.mcpb 2>/dev/null)
           if [[ -z "$MCPB_FILE" ]]; then
             echo "::error::No smartbear-mcp-*.mcpb file found after pack"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "tsc && vite build && shx chmod +x dist/*.js",
+    "build:mcpb": "npm run build && node scripts/pack-mcpb.js",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --fix",
     "format": "biome format . --write",
@@ -45,8 +46,7 @@
     "test:coverage:ci": "vitest --coverage --reporter=verbose",
     "test:run": "vitest run",
     "coverage:check": "vitest --coverage --reporter=verbose",
-    "bump": "node scripts/bump.js",
-    "postpack": "node scripts/pack-mcpb.js"
+    "bump": "node scripts/bump.js"
   },
   "dependencies": {
     "@bugsnag/js": "^8.8.1",


### PR DESCRIPTION
## Goal

Previously the MCPB build was triggered by `npm pack` but this interfered with NPM publishing as it is automatically called as part of `npm publish`.

## Changeset

Separated the MCPB generation into a completely separate task.

## Testing

We'll test during the forthcoming release.