### PR TITLE
fix(pactflow): remove .email() Zod validator from admin user tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [PactFlow] Remove `.email()` Zod validator from PactFlow admin user tool schemas — the generated JSON Schema pattern used regex lookahead which is rejected by strict JSON Schema validators (e.g. OpenAI gpt-5.5) [#491](https://github.com/SmartBear/smartbear-mcp/issues/491)
+
 ## [0.23.0] - 2026-05-22
 
 ### Added

--- a/src/pactflow/client/base.ts
+++ b/src/pactflow/client/base.ts
@@ -662,7 +662,7 @@ export const AdminUserIdSchema = z.object({
 export type AdminUserIdInput = z.infer<typeof AdminUserIdSchema>;
 
 export const CreateAdminUserSchema = z.object({
-  email: z.string().email().describe("Email address of the new user"),
+  email: z.string().describe("Email address of the new user"),
   name: z.string().describe("Display name of the new user"),
   firstName: z.string().optional().describe("First name"),
   lastName: z.string().optional().describe("Last name"),
@@ -680,7 +680,7 @@ export type CreateAdminUserInput = z.infer<typeof CreateAdminUserSchema>;
 export const UpdateAdminUserSchema = z.object({
   userId: z.string().describe("UUID of the user to update"),
   active: z.boolean().optional().describe("Whether the user is active"),
-  email: z.string().email().optional().describe("New email address"),
+  email: z.string().optional().describe("New email address"),
   firstName: z.string().optional().describe("First name"),
   lastName: z.string().optional().describe("Last name"),
   name: z.string().optional().describe("Display name"),
@@ -691,7 +691,7 @@ export const InviteUsersSchema = z.object({
   users: z
     .array(
       z.object({
-        email: z.string().email().describe("Email address"),
+        email: z.string().describe("Email address"),
         name: z.string().min(1).describe("Display name"),
       }),
     )


### PR DESCRIPTION
## Goal

Remove the `.email()` Zod validator from PactFlow admin user tool schemas. Zod v4's `.email()` generates a JSON Schema `pattern` field containing negative lookahead assertions (`(?!\.)`, `(?!.*\.\.)`), which strict JSON Schema validators reject.

Fixes #491

## Design

These schemas are MCP tool input definitions; they describe parameters to the LLM, not runtime validators. The email format constraint adds no value here and the generated pattern breaks compatibility with validators that don't support regex lookaround (notably OpenAI gpt-5.5, which rejects the entire tool list when any schema contains a lookahead pattern).

Replacing `z.string().email()` with `z.string()` is the minimal correct fix: the `describe()` annotation still communicates intent to the LLM.

## Changeset

- `src/pactflow/client/base.ts`: remove `.email()` from `CreateAdminUserSchema`, `UpdateAdminUserSchema`, and `InviteUsersSchema`
- `CHANGELOG.md`: add entry under Unreleased

## Testing

Existing test suite passes. The affected schemas have no tests that assert on the `.email()` constraint.