### PR TITLE
feat: Added constraint in the create_portal tool schema description, that allows only one Portal per organization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [PactFlow] Remove `.email()` Zod validator from PactFlow admin user tool schemas — the generated JSON Schema pattern used regex lookahead which is rejected by strict JSON Schema validators (e.g. OpenAI gpt-5.5) [#491](https://github.com/SmartBear/smartbear-mcp/issues/491)
 - [BearQ] Fix BearQ integration page not appearing in live docs [#496](https://github.com/SmartBear/smartbear-mcp/pull/496)
+- [Swagger]  Add constraint in the create_portal tool schema description, that allows only one Portal per organization.
 
 ## [0.23.0] - 2026-05-22
 

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -185,7 +185,7 @@ export const CreatePortalArgsSchema = z.object({
   swaggerHubOrganizationId: z
     .string()
     .describe(
-      "The corresponding SwaggerHub organization UUID - required for portal creation. This links the portal to your SwaggerHub organization",
+      "The corresponding Swagger organization UUID - required for portal creation. This links the portal to your Swagger organization. Only one Portal per Swagger organization is allowed.",
     ),
   openapiRenderer: z
     .string()

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -8354,7 +8354,7 @@ None",
 - offline (boolean): If true, the portal will not be visible to customers - useful for development/staging environments. Defaults to false
 - routing (string): Routing strategy for the portal - either 'browser' (client-side routing) or 'proxy' (server-side routing). Defaults to 'browser'
 - credentialsEnabled (boolean): Whether authentication credentials are enabled for accessing the portal. When true, users can authenticate to access private content. Defaults to true
-- swaggerHubOrganizationId (string) *required*: The corresponding SwaggerHub organization UUID - required for portal creation. This links the portal to your SwaggerHub organization
+- swaggerHubOrganizationId (string) *required*: The corresponding Swagger organization UUID - required for portal creation. This links the portal to your Swagger organization. Only one Portal per Swagger organization is allowed.
 - openapiRenderer (string): OpenAPI renderer type: 'SWAGGER_UI' (Swagger UI), 'ELEMENTS' (Stoplight Elements), or 'TOGGLE' (allows switching between both with Elements as default). Defaults to 'TOGGLE'
 - pageContentFormat (string): Format for page content rendering - determines how documentation pages are processed: 'HTML', 'MARKDOWN', or 'BOTH'. Defaults to 'HTML'",
     "inputSchema": [


### PR DESCRIPTION
## Goal

The goal of this PR is to add a constraint in the `create_portal` tool schema description, that will limit the number of permitted Portals per organization to one.

See [PROVCON-5309](https://smartbear.atlassian.net/browse/PROVCON-5309) for details
## Changeset

The description of `create_portal` tool schema has been changed. Beside an extra constraint, I changed the wording (SwaggerHub -> Swagger)

## Testing

The solution was tested locally:
Attempt to create another Portal in an organization that already has one, was rejected

<img width="430" height="515" alt="Screenshot 2026-05-26 at 13 22 24" src="https://github.com/user-attachments/assets/b963e3d3-a6fb-42c1-8868-4b444345c879" />



[PROVCON-5309]: https://smartbear.atlassian.net/browse/PROVCON-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ