### PR TITLE
[BearQ] fix BearQ docs page visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [PactFlow] Remove `.email()` Zod validator from PactFlow admin user tool schemas — the generated JSON Schema pattern used regex lookahead which is rejected by strict JSON Schema validators (e.g. OpenAI gpt-5.5) [#491](https://github.com/SmartBear/smartbear-mcp/issues/491)
+- [BearQ] Fix BearQ integration page not appearing in live docs [#496](https://github.com/SmartBear/smartbear-mcp/pull/496)
 
 ## [0.23.0] - 2026-05-22
 
 ### Added
 
-- [BearQ] Add BearQ integration with 11 tools for AI-powered QA: run regression tests, run/refine test cases and functional areas, expand the application model, chat with the QA lead agent, and manage async tasks (`get_task`, `get_task_status`, `wait_for_task`, `stop_task`) [#479](https://github.com/SmartBear/smartbear-mcp/pull/479)
+- [BearQ] Add BearQ integration with 11 tools for AI-powered QA: run regression tests, run/refine test cases and functional areas, expand the application model, chat with the QA lead agent, and manage async tasks (`get_task`, `get_task_status`, `wait_for_task`, `stop_task`) [#485](https://github.com/SmartBear/smartbear-mcp/pull/485)
 
 ## [0.22.0] - 2026-05-21
 

--- a/docs/products/SmartBear MCP Server/manifest.json
+++ b/docs/products/SmartBear MCP Server/manifest.json
@@ -147,6 +147,14 @@
       "contentUrl": "qtm4j-integration.md"
     },
     {
+      "order": 9,
+      "parent": "mcp-server-capabilities",
+      "name": "BearQ Integration",
+      "slug": "bearq-integration",
+      "type": "markdown",
+      "contentUrl": "bearq-integration.md"
+    },
+    {
       "order": 3,
       "parent": "",
       "name": "Best Practices",


### PR DESCRIPTION
## Goal

BearQ integration page was missing from live docs

## Design

N/A

## Changeset

- Add `bearq-integration.md` entry to `manifest.json` under `mcp-server-capabilities`
- Extra: fixed old BearQ changelog PR link from #479 to #485

## Testing

N/A