### PR TITLE
feat: allow setting client name in MCP_TOOLSETS

### DIFF
--- a/src/common/client-registry.ts
+++ b/src/common/client-registry.ts
@@ -9,36 +9,43 @@ import { fullyUnwrapZodType, isOptionalType } from "./zod-utils";
  */
 class ClientRegistry {
   private entries: Client[] = [];
-  private enabledClients: Set<string> | null = null;
+  private enabledClients: Set<string>;
 
   /**
-   * Configure which clients should be enabled based on MCP_CLIENTS env var
+   * Configure which clients should be enabled based on MCP_CLIENTS env var and MCP_TOOLSETS (to enable any referenced clients)
    * If not set or empty, all clients are enabled
    * If set, should be comma-separated list of client names (case-insensitive)
    */
   constructor() {
-    const enabledClientsEnv = process.env.MCP_CLIENTS?.trim();
-
-    if (!enabledClientsEnv) {
-      // Empty or not set = all clients enabled
-      this.enabledClients = null;
-      return;
+    let enabledClientsStr = "";
+    if (process.env.MCP_CLIENTS) {
+      enabledClientsStr = process.env.MCP_CLIENTS.trim();
+    }
+    enabledClientsStr += ",";
+    if (process.env.MCP_TOOLSETS) {
+      enabledClientsStr += process.env.MCP_TOOLSETS.trim();
     }
 
     // Parse comma-separated list and normalize to lowercase for comparison
     this.enabledClients = new Set(
-      enabledClientsEnv
+      enabledClientsStr
+        .trim()
         .split(",")
-        .map((name) => name.trim().toLowerCase())
+        .map((name) => {
+          if (name.includes(":")) {
+            return name.split(":")[0].trim().toLowerCase();
+          }
+          return name.trim().toLowerCase();
+        })
         .filter((name) => name.length > 0),
     );
   }
 
   /**
-   * Check if a client is enabled based on MCP_CLIENTS configuration
+   * Check if a client is enabled based on client filtering configuration
    */
   private isClientEnabled(name: string): boolean {
-    if (this.enabledClients === null) {
+    if (this.enabledClients.size === 0) {
       return true; // All clients enabled
     }
     return this.enabledClients.has(name.toLowerCase());

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -295,32 +295,39 @@ export class SmartBearMcpServer extends McpServer {
   /**
    * The tool is enabled if:
    * - No enabled toolsets are defined on the server, or
+   * - The client is included in the enabled toolsets list, or
    * - The toolset is included in the enabled toolsets list, or
-   * - The toolset is in the client's default list and there is at least one toolset enabled for the client
+   * - The toolset is in the client's default list and there is at least one specific toolset enabled for the client
    * @param client
    * @param toolset
    * @returns whether to register the tool based on enabled toolsets configuration
    */
-  private isToolEnabled(client: Client, toolset: string): boolean {
+  isToolEnabled(client: Client, toolset: string): boolean {
     if (!this.enabledToolsets) {
       return true;
     }
-    const toolsetName =
-      `${client.configPrefix}:${toolset.replace(/[\s\-_]/g, "")}`.toLowerCase();
-    if (this.enabledToolsets.includes(toolsetName)) {
-      return true;
-    }
-    const someToolsEnabledForClient = this.enabledToolsets?.some(
-      (ts) =>
-        ts.split(":")[0].toLowerCase() === client.configPrefix.toLowerCase(),
+    const clientPrefix = client.configPrefix.toLowerCase();
+    const clientIsEnabled = this.enabledToolsets.some(
+      (ts) => !ts.includes(":") && ts === clientPrefix,
     );
-    if (
-      someToolsEnabledForClient &&
-      client.defaultToolsets?.includes(toolset)
-    ) {
+    if (clientIsEnabled) {
       return true;
     }
-    return false;
+
+    const toolsetEntries = this.enabledToolsets.filter(
+      (ts) => ts.includes(":") && ts.split(":")[0] === clientPrefix,
+    );
+    if (toolsetEntries.length === 0) {
+      return false;
+    }
+
+    const toolsetName =
+      `${clientPrefix}:${toolset.replace(/[\s\-_]/g, "")}`.toLowerCase();
+
+    return (
+      toolsetEntries.includes(toolsetName) ||
+      (client.defaultToolsets || [])?.includes(toolset)
+    );
   }
 
   private getDescription(params: ToolParams): string {

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -761,7 +761,7 @@ export function getQueryStringName(clientPrefix: string, key: string): string {
 function getHttpHeaders(): string[] {
   const headers = new Set<string>();
 
-  // Use getAll() to respect MCP_ENABLED_CLIENTS filtering
+  // Use getAll() to respect client filtering
   for (const entry of clientRegistry.getAll()) {
     for (const configKey of Object.keys(entry.config.shape)) {
       headers.add(getHeaderName(entry.configPrefix, configKey));

--- a/src/tests/unit/common/client-registry.test.ts
+++ b/src/tests/unit/common/client-registry.test.ts
@@ -16,6 +16,7 @@ describe("ClientRegistry", () => {
     // Mock server
     mockServer = {
       addClient: vi.fn(),
+      isClientEnabled: vi.fn().mockReturnValue(true),
     } as any;
 
     // Spy on console.warn to verify warning messages

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -797,6 +797,30 @@ describe("SmartBearMcpServer", () => {
       expect(registerToolSpy).toHaveBeenCalledTimes(2);
     });
 
+    it("should register all tools when just the client name is in toolsets", async () => {
+      await setupServer("test-product");
+
+      const resultA = registerFn(
+        { title: "Tool A", summary: "A", toolset: "groupA" },
+        vi.fn(),
+      );
+
+      expect(resultA).not.toBeNull();
+      expect(registerToolSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not register any tools when a different client is enabled in toolsets", async () => {
+      await setupServer("another-test-product");
+
+      const resultA = registerFn(
+        { title: "Tool A", summary: "A", toolset: "groupA" },
+        vi.fn(),
+      );
+
+      expect(resultA).toBeNull();
+      expect(registerToolSpy).not.toHaveBeenCalled();
+    });
+
     it("should match toolsets case-insensitively", async () => {
       await setupServer("Test-Product:GroupA");
 
@@ -830,6 +854,76 @@ describe("SmartBearMcpServer", () => {
       // biome-ignore lint/complexity/useLiteralKeys: accessing internal method for test
       const rawShape = server["schemaToRawShape"](undefined);
       expect(rawShape).toBeUndefined();
+    });
+  });
+
+  describe("isToolEnabled", () => {
+    const mockClient = {
+      name: "Test Product",
+      configPrefix: "test-product",
+      capabilityPrefix: "test_product",
+      config: z.object({}),
+      configure: vi.fn(),
+      isConfigured: vi.fn(),
+      registerTools: vi.fn(),
+    };
+
+    it("should enable all tools when no toolsets are configured", () => {
+      const server = new SmartBearMcpServer();
+      expect(server.isToolEnabled(mockClient, "anything")).toBe(true);
+    });
+
+    it("should enable tool when client is listed", () => {
+      const server = new SmartBearMcpServer("test-product");
+      expect(server.isToolEnabled(mockClient, "anything")).toBe(true);
+    });
+
+    it("should enable tool when its toolset matches an enabled entry", () => {
+      const server = new SmartBearMcpServer("test-product:errors");
+      expect(server.isToolEnabled(mockClient, "errors")).toBe(true);
+    });
+
+    it("should disable tool when its toolset does not match any enabled entry", () => {
+      const server = new SmartBearMcpServer("test-product:errors");
+      expect(server.isToolEnabled(mockClient, "releases")).toBe(false);
+    });
+
+    it("should disable tool when client prefix does not match any enabled toolset", () => {
+      const server = new SmartBearMcpServer("other-product:errors");
+      expect(server.isToolEnabled(mockClient, "errors")).toBe(false);
+    });
+
+    it("should handle toolset name normalization (spaces, hyphens, underscores)", () => {
+      const server = new SmartBearMcpServer("test-product:mytools");
+      expect(server.isToolEnabled(mockClient, "my-tools")).toBe(true);
+      expect(server.isToolEnabled(mockClient, "my_tools")).toBe(true);
+      expect(server.isToolEnabled(mockClient, "my tools")).toBe(true);
+    });
+
+    it("should be case-insensitive", () => {
+      const server = new SmartBearMcpServer("Test-Product:Errors");
+      expect(server.isToolEnabled(mockClient, "errors")).toBe(true);
+    });
+
+    it("should enable default toolsets when specific toolsets are configured for the client", () => {
+      const client = { ...mockClient, defaultToolsets: ["default-set"] };
+      const server = new SmartBearMcpServer("test-product:errors");
+      expect(server.isToolEnabled(client, "default-set")).toBe(true);
+    });
+
+    it("should not enable default toolsets when no specific toolsets are configured for the client", () => {
+      const client = { ...mockClient, defaultToolsets: ["default-set"] };
+      const server = new SmartBearMcpServer("other-product:errors");
+      expect(server.isToolEnabled(client, "default-set")).toBe(false);
+    });
+
+    it("should support multiple toolset entries for the same client", () => {
+      const server = new SmartBearMcpServer(
+        "test-product:errors,test-product:releases",
+      );
+      expect(server.isToolEnabled(mockClient, "errors")).toBe(true);
+      expect(server.isToolEnabled(mockClient, "releases")).toBe(true);
+      expect(server.isToolEnabled(mockClient, "other")).toBe(false);
     });
   });
 });

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -281,6 +281,7 @@ describe("newServer (OAuth flow)", () => {
           setElicitationSupported: vi.fn(),
           cleanupSession: vi.fn(),
           server: { elicitInput: vi.fn() },
+          isClientEnabled: () => true,
         }) as any,
     );
 
@@ -320,6 +321,7 @@ describe("newServer (OAuth flow)", () => {
           setElicitationSupported: vi.fn(),
           cleanupSession: vi.fn(),
           server: { elicitInput: vi.fn() },
+          isClientEnabled: () => true,
         }) as any,
     );
 
@@ -356,6 +358,7 @@ describe("newServer (OAuth flow)", () => {
           setElicitationSupported: vi.fn(),
           cleanupSession: vi.fn(),
           server: { elicitInput: vi.fn() },
+          isClientEnabled: () => true,
         }) as any,
     );
 
@@ -387,6 +390,7 @@ describe("newServer (OAuth flow)", () => {
           setElicitationSupported: vi.fn(),
           cleanupSession: vi.fn(),
           server: { elicitInput: vi.fn() },
+          isClientEnabled: () => true,
         }) as any,
     );
 
@@ -428,6 +432,7 @@ describe("newServer (OAuth flow)", () => {
           setElicitationSupported: vi.fn(),
           cleanupSession: vi.fn(),
           server: { elicitInput: vi.fn() },
+          isClientEnabled: () => true,
         }) as any,
     );
 
@@ -685,6 +690,7 @@ describe("handleStreamableHttpRequest (session routing)", () => {
         setElicitationSupported: vi.fn(),
         cleanupSession: vi.fn(),
         server: { elicitInput: vi.fn() },
+        isClientEnabled: () => true,
       } as any;
     });
 


### PR DESCRIPTION
## Goal

Addendum to #474 that allows users to specify a client name as a toolset:

e.g. `"MCP_TOOLSETS": "collaborator"`

## Design

This overlaps somewhat with `MCP_CLIENTS` environment variable, which is primarily used to control the clients that are running in http mode. `MCP_TOOLSETS` is subservient to that, but is also read by the client registry so that it's aware which clients are enabled when providing allowed headers and printing help.

## Changeset

* Expanded `isToolEnabled` with the new logic
* Read `MCP_TOOLSETS` in the client registry for filtering clients  

## Testing

New unit tests and manual checking of logic.
