### PR TITLE
[QTM4J] : Add Test Cycle and Automation Operations tools Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [QTM4J] Added test cycle management capabilities including create, search, and update operations.
+- [QTM4J] Add QTM4J test automation capabilities — upload result files and retrieve import history via `qtm4j_upload_automation_result` and `qtm4j_get_automation_history`. Requires `QTM4J_AUTOMATION_API_KEY`.
 
 ### Fixed
 
 - [PactFlow] Remove `.email()` Zod validator from PactFlow admin user tool schemas — the generated JSON Schema pattern used regex lookahead which is rejected by strict JSON Schema validators (e.g. OpenAI gpt-5.5) [#491](https://github.com/SmartBear/smartbear-mcp/issues/491)
 - [BearQ] Fix BearQ integration page not appearing in live docs [#496](https://github.com/SmartBear/smartbear-mcp/pull/496)
 - [Swagger]  Add constraint in the create_portal tool schema description, that allows only one Portal per organization.
+
 ## [0.23.0] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [QTM4J] Added test cycle management capabilities including create, search, and update operations.
+
 ### Fixed
 
 - [PactFlow] Remove `.email()` Zod validator from PactFlow admin user tool schemas — the generated JSON Schema pattern used regex lookahead which is rejected by strict JSON Schema validators (e.g. OpenAI gpt-5.5) [#491](https://github.com/SmartBear/smartbear-mcp/issues/491)
 - [BearQ] Fix BearQ integration page not appearing in live docs [#496](https://github.com/SmartBear/smartbear-mcp/pull/496)
 - [Swagger]  Add constraint in the create_portal tool schema description, that allows only one Portal per organization.
-
 ## [0.23.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
         "COLLABORATOR_USERNAME": "${input:collab_username}",
         "COLLABORATOR_LOGIN_TICKET": "${input:collab_login_ticket}",
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
-        "QTM4J_BASE_URL": "${input:qtm4j_base_url}"
+        "QTM4J_BASE_URL": "${input:qtm4j_base_url}",
+        "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}"
       }
     }
   },
@@ -243,6 +244,12 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
           "type": "promptString",
           "description": "US region (default): https://qtmcloud.qmetry.com. Australia region: https://syd-qtmcloud.qmetry.com.",
           "password": false
+    },
+    {
+          "id": "qtm4j_automation_api_key",
+          "type": "promptString",
+          "description": "QTM4J Automation API Key - required for automation tools, leave blank to disable them",
+          "password": true
     }
   ]
 }
@@ -283,7 +290,8 @@ Add the following configuration to your `claude_desktop_config.json` to launch t
         "COLLABORATOR_USERNAME": "your collab user name",
         "COLLABORATOR_LOGIN_TICKET": "your collab login ticket",
         "QTM4J_API_KEY": "your_qtm4j_key",
-        "QTM4J_BASE_URL": "https://qtmcloud.qmetry.com"
+        "QTM4J_BASE_URL": "https://qtmcloud.qmetry.com",
+        "QTM4J_AUTOMATION_API_KEY": "your_qtm4j_automation_api_key"
       }
     }
   }

--- a/docs/custom-words.txt
+++ b/docs/custom-words.txt
@@ -60,3 +60,4 @@ Schemathesis
 Visualise
 artefacts
 behaviour
+specflow

--- a/docs/products/SmartBear MCP Server/local-server.md
+++ b/docs/products/SmartBear MCP Server/local-server.md
@@ -596,3 +596,6 @@ Once configured, you can interact with SmartBear tools through natural language 
 -   "Update the status of SCRUM-TC-145 to Done"
 -   "Add the Release_2 label to SCRUM-TC-145 and remove Release_1"
 -   "Show me the test steps for SCRUM-TC-32"
+-   "Create a test cycle called 'Regression Suite' with High priority"
+-   "Find all in-progress test cycles in the active project"
+-   "Update the status of SCRUM-TR-101 to In Progress"

--- a/docs/products/SmartBear MCP Server/local-server.md
+++ b/docs/products/SmartBear MCP Server/local-server.md
@@ -68,7 +68,7 @@ The SmartBear MCP Server supports multiple SmartBear products, each requiring it
 
 - **QTM4J**
 
-  Generate your QTM4J API key by following the instructions [here](https://support.smartbear.com/qmetry-test-management-for-jira-cloud/docs/en/user-guide/qmetry-open-api.html).
+  Generate your QTM4J API key by following the instructions [here](https://support.smartbear.com/qmetry-test-management-for-jira-cloud/docs/en/user-guide/qmetry-open-api.html). To use automation tools, also generate a separate `QTM4J_AUTOMATION_API_KEY` from the same page.
 
 > 🔐 Store your tokens securely. They provide access to sensitive data and should be treated like passwords. You can use any combination of the supported products — tokens for unused products can be omitted.
 
@@ -118,6 +118,8 @@ export ZEPHYR_BASE_URL="https://api.zephyrscale.smartbear.com/v2"
 
 # Required for QTM4J tools
 export QTM4J_API_KEY="your-qtm4j-api-key"
+# Required for QTM4J automation tools (Upload Automation Result, Get Automation History)
+export QTM4J_AUTOMATION_API_KEY="your-qtm4j-automation-api-key"
 # Optional: Set your QTM4J base URL based on your region
 # US (default): https://qtmcloud.qmetry.com Australia: https://syd-qtmcloud.qmetry.com
 export QTM4J_BASE_URL="https://qtmcloud.qmetry.com"
@@ -159,6 +161,7 @@ Create or edit `.vscode/mcp.json` in your workspace:
         "ZEPHYR_API_TOKEN": "${input:zephyr_api_token}",
         "ZEPHYR_BASE_URL": "${input:zephyr_base_url}",
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
+        "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}",
         "QTM4J_BASE_URL": "${input:qtm4j_base_url}"
       }
     }
@@ -255,6 +258,12 @@ Create or edit `.vscode/mcp.json` in your workspace:
       "password": true
     },
     {
+      "id": "qtm4j_automation_api_key",
+      "type": "promptString",
+      "description": "QTM4J Automation API Key — required for Upload Automation Result and Get Automation History tools.",
+      "password": true
+    },
+    {
       "id": "qtm4j_base_url",
       "type": "promptString",
       "description": "US region (default): https://qtmcloud.qmetry.com. Australia region: https://syd-qtmcloud.qmetry.com.",
@@ -293,6 +302,7 @@ Add to your `mcp.json` configuration:
         "ZEPHYR_API_TOKEN": "your-zephyr-api-token",
         "ZEPHYR_BASE_URL": "https://api.zephyrscale.smartbear.com/v2",
         "QTM4J_API_KEY": "your-qtm4j-api-key",
+        "QTM4J_AUTOMATION_API_KEY": "your-qtm4j-automation-api-key",
         "QTM4J_BASE_URL": "https://qtmcloud.qmetry.com"
       }
     }
@@ -329,6 +339,7 @@ Edit your `claude_desktop_config.json` file:
         "ZEPHYR_API_TOKEN": "your-zephyr-api-token",
         "ZEPHYR_BASE_URL": "your-zephyr-base-url",
         "QTM4J_API_KEY": "your-qtm4j-api-key",
+        "QTM4J_AUTOMATION_API_KEY": "your-qtm4j-automation-api-key",
         "QTM4J_BASE_URL": "https://qtmcloud.qmetry.com"
       }
     }
@@ -369,6 +380,7 @@ export PACT_BROKER_TOKEN=your-pact-broker-token
 # export PACT_BROKER_USERNAME=your-username
 # export PACT_BROKER_PASSWORD=your-password
 export QTM4J_API_KEY="your-qtm4j-api-key"
+export QTM4J_AUTOMATION_API_KEY="your-qtm4j-automation-api-key"
 export QTM4J_BASE_URL="https://qtmcloud.qmetry.com"
 ```
 
@@ -429,6 +441,7 @@ To run the built server locally in VS Code, add the following to `.vscode/mcp.js
         "ZEPHYR_API_TOKEN": "${input:zephyr_api_token}",
         "ZEPHYR_BASE_URL": "${input:zephyr_base_url}",
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
+        "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}",
         "QTM4J_BASE_URL": "${input:qtm4j_base_url}"
       }
     }
@@ -525,6 +538,12 @@ To run the built server locally in VS Code, add the following to `.vscode/mcp.js
       "password": true
     },
     {
+      "id": "qtm4j_automation_api_key",
+      "type": "promptString",
+      "description": "QTM4J Automation API Key — required for Upload Automation Result and Get Automation History tools.",
+      "password": true
+    },
+    {
       "id": "qtm4j_base_url",
       "type": "promptString",
       "description": "US region (default): https://qtmcloud.qmetry.com. Australia region: https://syd-qtmcloud.qmetry.com.",
@@ -551,6 +570,7 @@ QMETRY_BASE_URL=https://testmanagement.qmetry.com \
 ZEPHYR_API_TOKEN=your_zephyr_token \
 ZEPHYR_BASE_URL=https://api.zephyrscale.smartbear.com/v2 \
 QTM4J_API_KEY=your_qtm4j_key \
+QTM4J_AUTOMATION_API_KEY=your_qtm4j_automation_key \
 QTM4J_BASE_URL=https://qtmcloud.qmetry.com \
 npx @modelcontextprotocol/inspector node dist/index.js
 ```
@@ -599,3 +619,5 @@ Once configured, you can interact with SmartBear tools through natural language 
 -   "Create a test cycle called 'Regression Suite' with High priority"
 -   "Find all in-progress test cycles in the active project"
 -   "Update the status of SCRUM-TR-101 to In Progress"
+-   "Upload JUnit test results to QTM4J"
+-   "Check whether last automation import succeeded"

--- a/docs/products/SmartBear MCP Server/qtm4j-integration.md
+++ b/docs/products/SmartBear MCP Server/qtm4j-integration.md
@@ -132,3 +132,79 @@ The following environment variables configure the QTM4J integration:
     - names to remove (`delete`) — e.g., `["Legacy"]`
 - **Returns**: Confirmation object with the test case key, version number updated, and `updated: true`. Any unrecognized field values are reported as warnings.
 - **Use case**: Changing priority or status, adding or removing labels/components, updating summary or description, reassigning a test case, setting estimated time.
+
+## Test Cycles
+
+### Retrieval Operations
+
+#### Search Test Cycles
+
+- **Purpose**: Search and filter test cycles within the active QTM4J project using a rich set of criteria.
+- **Parameters**:
+  - optional filter object (`filter`) containing:
+    - free-text search across key, summary, and description (`searchText`)
+    - status names to include (`status`) — e.g., `["In Progress", "To Do"]`
+    - priority names to include (`priority`) — e.g., `["High", "Medium"]`
+    - label names to include (`labels`) — e.g., `["Release_1", "Sprint 1"]`
+    - component names to include (`components`) — e.g., `["UI", "Cloud"]`
+    - folder ID to filter by (`folderId`) — numeric ID; right-click a folder in QTM4J and select "Copy Folder Id"
+    - assignee Jira account IDs (`assignee`)
+    - reporter Jira account IDs (`reporter`)
+    - automation status (`isAutomated`) — `true` for automated only, `false` for manual only
+    - planned start date range (`plannedStartDate`) — format: `dd/MMM/yyyy,dd/MMM/yyyy` e.g., `"01/Apr/2026,30/Apr/2026"`
+    - planned end date range (`plannedEndDate`) — format: `dd/MMM/yyyy,dd/MMM/yyyy`
+    - creation date range (`createdOn`) — format: `dd/MMM/yyyy,dd/MMM/yyyy`
+    - last-updated date range (`updatedOn`) — format: `dd/MMM/yyyy,dd/MMM/yyyy`
+    - AI-generated flag (`aiGenerated`)
+  - optional fields to include in each result (`fields`) — omit to return server default fields. Available: `key`, `summary`, `description`, `status`, `priority`, `assignee`, `reporter`, `isAutomated`, `plannedStartDate`, `plannedEndDate`, `labels`, `components`, `fixVersions`, `sprint`, `defectCount`, `estimatedTime`, `actualTime`, `created`, `updated`. Note: `plannedStartDate` and `plannedEndDate` are **not** in the default response — include them explicitly when needed.
+  - optional sort pattern (`sort`) — format: `fieldName:asc|desc` (default: `key:asc`). Allowed fields: `key`, `summary`, `status`, `plannedStartDate`, `plannedEndDate`, `defectCount`.
+  - optional starting position for pagination (`startAt`)
+  - optional max results per page (`maxResults`) — max 100
+- **Returns**: A paginated result with `total`, `startAt`, `maxResults`, and `data` array of test cycle objects. Each item always includes `id` and `key`; other fields depend on what was requested via `fields`.
+- **Use case**: Finding test cycles by status, priority, labels, components, or owner; filtering by planned or creation date range; searching by keyword; paginating through large result sets.
+- **Note**: Multiple values within the same filter field use OR logic; different filter fields are combined with AND.
+
+### Creation Operations
+
+#### Create Test Cycle
+
+- **Purpose**: Create a new test cycle in the active QTM4J project to group test cases for a specific execution context (sprint, release, environment, etc.).
+- **Parameters**:
+  - Test cycle summary/title (`summary`)
+  - optional description (`description`)
+  - optional priority name (`priority`) — e.g., `["High", "Medium"]`
+  - optional status name (`status`) — e.g., `["To Do", "In Progress"]`
+  - optional assignee Jira account ID (`assignee`)
+  - optional reporter Jira account ID (`reporter`)
+  - optional label names to attach (`labels`) — e.g., `["Release_1", "Sprint 1"]`
+  - optional component names to attach (`components`) — e.g., `["UI", "Cloud"]`
+  - optional planned start date (`plannedStartDate`) — format: `dd/MMM/yyyy HH:mm` e.g., `"10/May/2026 00:00"`
+  - optional planned end date (`plannedEndDate`) — format: `dd/MMM/yyyy HH:mm`
+- **Returns**: The created test cycle key (e.g., `SCRUM-TR-218`) and ID.
+- **Use case**: Creating sprint cycles, release cycles, or environment-specific cycles; organizing test cases for a planned execution window.
+- **Note**: All cycles are placed in the `MCP Generated` folder automatically.
+
+### Update Operations
+
+#### Update Test Cycle
+
+- **Purpose**: Update an existing test cycle in QTM4J using its human-readable key.
+- **Parameters**:
+  - Test cycle key in `{PROJECT_KEY}-TR-{number}` format (`key`) — e.g., `SCRUM-TR-101`. **Required.**
+  - optional updated summary (`summary`)
+  - optional updated description (`description`) — pass `null` to clear
+  - optional priority name (`priority`) — pass `null` to clear
+  - optional status name (`status`) — pass `null` to clear
+  - optional planned start date (`plannedStartDate`) — format: `dd/MMM/yyyy HH:mm`; pass `null` to clear
+  - optional planned end date (`plannedEndDate`) — format: `dd/MMM/yyyy HH:mm`; pass `null` to clear
+  - optional assignee Jira account ID (`assignee`) — pass `null` to unassign
+  - optional reporter Jira account ID (`reporter`) — pass `null` to clear
+  - optional labels add/delete object (`labels`):
+    - names to add (`add`) — e.g., `["Release_2"]`
+    - names to remove (`delete`) — e.g., `["Sprint1"]`
+  - optional components add/delete object (`components`):
+    - names to add (`add`) — e.g., `["Auth"]`
+    - names to remove (`delete`) — e.g., `["Legacy"]`
+- **Returns**: Confirmation object with the test cycle key and `updated: true`. Any unrecognized field values are reported as warnings.
+- **Use case**: Changing status or priority, updating planned dates, reassigning ownership, adding or removing labels/components, renaming a cycle, clearing a description.
+- **Note**: Only the fields you provide are changed — omitted fields are left as-is. Archived test cycles cannot be updated.

--- a/docs/products/SmartBear MCP Server/qtm4j-integration.md
+++ b/docs/products/SmartBear MCP Server/qtm4j-integration.md
@@ -15,9 +15,11 @@ The following environment variables configure the QTM4J integration:
   - US region (default): `https://qtmcloud.qmetry.com`
   - Australia region: `https://syd-qtmcloud.qmetry.com`
 
+- `QTM4J_AUTOMATION_API_KEY` (required for automation tools): A separate API key used exclusively by the automation import tools (`qtm4j_upload_automation_result` and `qtm4j_get_automation_history`). Generate your Automation API key from your QTM4J instance — refer to the [QMetry automation help documentation](https://support.smartbear.com/qmetry-test-management-for-jira-cloud/docs/en/automation/generate-api-key.html) for setup instructions.
+
 ## Prerequisites
 
-**All tools require an active project context.** Before using any test case operations, call `qtm4j_set_project_context` to set the active project for the session.
+**Most tools require an active project context.** Call `qtm4j_set_project_context` to set the active project before performing any project-specific operation. Automation tools (`qtm4j_upload_automation_result` and `qtm4j_get_automation_history`) are the exception — they work independently without any project context.
 
 # Available Tools
 
@@ -208,3 +210,46 @@ The following environment variables configure the QTM4J integration:
 - **Returns**: Confirmation object with the test cycle key and `updated: true`. Any unrecognized field values are reported as warnings.
 - **Use case**: Changing status or priority, updating planned dates, reassigning ownership, adding or removing labels/components, renaming a cycle, clearing a description.
 - **Note**: Only the fields you provide are changed — omitted fields are left as-is. Archived test cycles cannot be updated.
+
+## Automation
+
+Automation tools authenticate using `QTM4J_AUTOMATION_API_KEY` and do not require an active project context.
+
+### Upload Automation Result
+
+- **Purpose**: Upload an automation result file from disk to QTM4J and map results to a test cycle. Supports JUnit, TestNG, Cucumber, QAF, HP UFT, and SpecFlow formats. Import is asynchronous — use the returned `trackingId` with `qtm4j_get_automation_history` to check progress.
+- **Parameters**:
+  - path to the result file on disk (`filePath`) — `.xml`, `.json`, or `.zip`
+  - result file format (`format`) — one of `junit`, `testng`, `cucumber`, `qaf`, `hpuft`, `specflow`
+  - optional existing test cycle key to reuse (`testCycleToReuse`) — e.g. `SCRUM-TR-5`; if omitted, a new cycle is created
+  - optional environment name (`environment`)
+  - optional build name (`build`) — e.g. `"2.1.0"`
+  - optional ZIP flag (`isZip`) — set `true` for QAF; defaults to `false`
+  - optional flag to attach execution files (`attachFile`) — defaults to `false`
+  - optional flag to match test cases by test steps (`matchTestSteps`) — defaults to `true`
+  - optional flag to append suite/test name to the method name (`appendTestName`) — JUnit and TestNG only
+  - optional fields object (`fields`) with sub-objects:
+    - `fields.testCycle`: `summary`, `description`, `labels`, `components`, `priority`, `status`, `assignee`, `reporter`, `folderId`, `plannedStartDate`, `plannedEndDate`
+    - `fields.testCase`: `description`, `precondition`, `labels`, `components`, `priority`, `status`, `assignee`, `reporter`, `folderId`, `estimatedTime`
+    - `fields.testCaseExecution`: `comment`, `actualTime`, `executionPlannedDate`, `assignee`
+- **Returns**: `trackingId`, a status message, the uploaded file path, and the format used.
+- **Use case**: Importing CI/CD pipeline test results into QTM4J, linking results to an existing test cycle, creating new test cycles with automation results.
+- **Notes**:
+  - **Providing the result file** — three options:
+    1. **Explicit path**: provide the exact file path, e.g. `"./target/surefire-reports/TEST-results.xml"`
+    2. **Auto-discovery**: omit `filePath` and the AI scans common directories (`target/surefire-reports`, `build/reports/tests`, `reports`, `cucumber-reports`, and more). A single match is confirmed before uploading; multiple matches are listed for you to choose.
+    3. **Drag and drop**: drag the result file directly into the chat — the AI will read its contents and upload it automatically.
+  - Maximum file size is **10 MB**. Files exceeding this limit will be rejected before upload.
+  - `folderId` is a numeric ID — right-click the target folder in QTM4J and select **Copy Folder Id**.
+  - `assignee` and `reporter` require a Jira **Account ID**, not a display name or email.
+  - `fields.testCycle` is ignored when `testCycleToReuse` is provided.
+  - `plannedStartDate` and `plannedEndDate` accept natural language or standard date input — e.g. `"today"`, `"2026-05-20 10:30"`.
+
+### Get Automation History
+
+- **Purpose**: Retrieve the import history of automation result uploads with status and summary for each record.
+- **Parameters**:
+  - optional zero-indexed starting position (`startAt`) — defaults to `0`
+  - optional maximum number of records to return (`maxResults`) — defaults to `20`, max `100`
+- **Returns**: A paginated list of import records each containing tracking ID, format, process and import status, start/end times, file size, detailed message, and a summary of test cases/versions/steps created or reused and the test cycle key.
+- **Use case**: Checking whether a previous import succeeded or failed, reviewing upload history, retrieving the test cycle key created by an import.

--- a/packaging/manifest.json
+++ b/packaging/manifest.json
@@ -21,7 +21,8 @@
     "qmetry",
     "reflect",
     "swagger",
-    "zephyr"
+    "zephyr",
+    "qtm4j"
   ],
   "tools_generated": true,
   "prompts_generated": true,

--- a/packaging/manifest.json
+++ b/packaging/manifest.json
@@ -62,7 +62,10 @@
         "SWAGGER_REGISTRY_BASE_PATH": "${user_config.SWAGGER_REGISTRY_BASE_PATH}",
         "SWAGGER_UI_BASE_PATH": "${user_config.SWAGGER_UI_BASE_PATH}",
         "ZEPHYR_API_TOKEN": "${user_config.ZEPHYR_API_TOKEN}",
-        "ZEPHYR_BASE_URL": "${user_config.ZEPHYR_BASE_URL}"
+        "ZEPHYR_BASE_URL": "${user_config.ZEPHYR_BASE_URL}",
+        "QTM4J_API_KEY": "${user_config.QTM4J_API_KEY}",
+        "QTM4J_BASE_URL": "${user_config.QTM4J_BASE_URL}",
+        "QTM4J_AUTOMATION_API_KEY": "${user_config.QTM4J_AUTOMATION_API_KEY}"
       }
     }
   },
@@ -249,6 +252,14 @@
       "description": " QTM4J base URL (optional). Defaults to https://qtmcloud.qmetry.com. Override when using a self-hosted or region-specific instance.",
       "required": false,
       "sensitive": false,
+      "default": ""
+    },
+    "QTM4J_AUTOMATION_API_KEY": {
+      "type": "string",
+      "title": "QTM4J Automation API Key",
+      "description": "QTM4J Automation API key used exclusively by the automation import tools. Leave empty to disable automation tools. Learn more: https://developer.smartbear.com/smartbear-mcp/docs/qtm4j-integration",
+      "required": false,
+      "sensitive": true,
       "default": ""
     }
   }

--- a/server.json
+++ b/server.json
@@ -102,6 +102,12 @@
           "description": "QTM4J base URL (optional). Defaults to https://qtmcloud.qmetry.com. Override when using a self-hosted or region-specific instance.",
           "isRequired": false,
           "isSecret": false
+        },
+        {
+          "name": "QTM4J_AUTOMATION_API_KEY",
+          "description": "QTM4J Automation API key used exclusively by the automation import tools. Leave empty to disable automation tools. Learn more: https://developer.smartbear.com/smartbear-mcp/docs/qtm4j-integration",
+          "isRequired": false,
+          "isSecret": true
         }
       ]
     }

--- a/src/qtm4j/client.ts
+++ b/src/qtm4j/client.ts
@@ -21,6 +21,10 @@ import { ResolverRegistry } from "./resolver/resolver-registry";
  */
 const ConfigurationSchema = z.object({
   [CONFIG_KEYS.API_KEY]: z.string().describe(SCHEMA_DESCRIPTIONS.API_KEY),
+  [CONFIG_KEYS.AUTOMATION_API_KEY]: z
+    .string()
+    .optional()
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_API_KEY),
   [CONFIG_KEYS.BASE_URL]: z
     .string()
     .url()
@@ -63,6 +67,7 @@ export class Qtm4jClient implements Client {
   config = ConfigurationSchema;
 
   private _apiKey: string | undefined;
+  private _automationApiKey: string | undefined;
   private baseUrl: string = API_CONFIG.DEFAULT_BASE_URL;
   private apiClient: ApiClient | undefined;
   private resolverRegistry: ResolverRegistry | undefined;
@@ -77,12 +82,17 @@ export class Qtm4jClient implements Client {
     config: z.infer<typeof ConfigurationSchema>,
   ): Promise<void> {
     this._apiKey = config[CONFIG_KEYS.API_KEY];
+    this._automationApiKey = config[CONFIG_KEYS.AUTOMATION_API_KEY];
     if (config[CONFIG_KEYS.BASE_URL]) {
       this.baseUrl = config[CONFIG_KEYS.BASE_URL];
     }
 
-    // Initialize API client with token provider for request-scoped credentials
-    this.apiClient = new ApiClient(() => this.getAuthToken(), this.baseUrl);
+    // Initialize API client with regular and automation token providers
+    this.apiClient = new ApiClient(
+      () => this.getAuthToken(),
+      this.baseUrl,
+      () => this.getAutomationApiKey(),
+    );
 
     // Initialize resolver registry with the API client and shared cache
     this.resolverRegistry = new ResolverRegistry(
@@ -117,6 +127,14 @@ export class Qtm4jClient implements Client {
 
     // 2. Fallback to configured API key
     return this._apiKey || null;
+  }
+
+  getAutomationApiKey(): string | null {
+    const headerKey = getRequestHeader("Qtm4j-Automation-Api-Key");
+    if (headerKey) {
+      return Array.isArray(headerKey) ? headerKey[0] : headerKey;
+    }
+    return this._automationApiKey || null;
   }
 
   /**
@@ -175,6 +193,13 @@ export class Qtm4jClient implements Client {
     const { UpdateTestCase } = await import(
       "./tool/test-case/update-test-case"
     );
+    const { UploadAutomationResult } = await import(
+      "./tool/test-automation/upload-automation-result"
+    );
+    const { GetAutomationHistory } = await import(
+      "./tool/test-automation/get-automation-history"
+    );
+
     const { CreateTestCycle } = await import(
       "./tool/test-cycle/create-test-cycle"
     );
@@ -195,6 +220,8 @@ export class Qtm4jClient implements Client {
       new CreateTestCycle(this),
       new SearchTestCycles(this),
       new UpdateTestCycle(this),
+      new UploadAutomationResult(this),
+      new GetAutomationHistory(this),
     ];
 
     // Register each tool with the MCP server

--- a/src/qtm4j/client.ts
+++ b/src/qtm4j/client.ts
@@ -175,6 +175,15 @@ export class Qtm4jClient implements Client {
     const { UpdateTestCase } = await import(
       "./tool/test-case/update-test-case"
     );
+    const { CreateTestCycle } = await import(
+      "./tool/test-cycle/create-test-cycle"
+    );
+    const { SearchTestCycles } = await import(
+      "./tool/test-cycle/search-test-cycle"
+    );
+    const { UpdateTestCycle } = await import(
+      "./tool/test-cycle/update-test-cycle"
+    );
 
     const tools = [
       new GetProjects(this),
@@ -183,6 +192,9 @@ export class Qtm4jClient implements Client {
       new GetTestCases(this),
       new GetTestSteps(this),
       new UpdateTestCase(this),
+      new CreateTestCycle(this),
+      new SearchTestCycles(this),
+      new UpdateTestCycle(this),
     ];
 
     // Register each tool with the MCP server

--- a/src/qtm4j/config/constants.ts
+++ b/src/qtm4j/config/constants.ts
@@ -253,7 +253,7 @@ export const TOOL_NAMES = {
   GET_AUTOMATION_HISTORY: {
     TITLE: "Get Automation History",
     SUMMARY:
-      "Retrieve a paginated history of past automation result uploads for a QTM4J project."
+      "Retrieve a paginated history of past automation result uploads for a QTM4J project.",
   },
 
   /** Search Test Cycles tool */

--- a/src/qtm4j/config/constants.ts
+++ b/src/qtm4j/config/constants.ts
@@ -63,6 +63,15 @@ export const ENDPOINTS = {
   /** Components search endpoint */
   COMPONENTS: (projectId: number) =>
     `${API_CONFIG.API_VERSION}/projects/${projectId}/mcp/components`,
+
+  /** Automation: initiate result file import — returns pre-signed S3 upload URL + trackingId */
+  AUTOMATION_IMPORT: "/rest/api/automation/importresult",
+
+  /** Automation: poll import progress by trackingId */
+  AUTOMATION_IMPORT_TRACK: "/rest/api/automation/importresult/track",
+
+  /** Automation: paginated history of past automation result uploads */
+  AUTOMATION_HISTORY: "/rest/api/automation/importresult/history",
 } as const;
 
 /**
@@ -91,6 +100,9 @@ export const HTTP_HEADERS = {
 export const CONTENT_TYPES = {
   /** JSON content type */
   JSON: "application/json",
+
+  /** Multipart form-data content type (used for S3 automation file uploads) */
+  MULTIPART: "multipart/form-data",
 } as const;
 
 /**
@@ -161,6 +173,14 @@ export const PAGINATION = {
 } as const;
 
 /**
+ * Automation Upload Limits
+ */
+export const AUTOMATION_LIMITS = {
+  /** Maximum allowed upload file size in bytes (10 MB) */
+  MAX_FILE_SIZE_BYTES: 10 * 1024 * 1024,
+} as const;
+
+/**
  * Error Messages
  */
 export const ERROR_MESSAGES = {
@@ -170,6 +190,10 @@ export const ERROR_MESSAGES = {
   /** Request failed template */
   REQUEST_FAILED: (status: number, errorText: string) =>
     `Request failed with status ${status}: ${errorText}`,
+
+  /** Automation API key not configured */
+  AUTOMATION_API_KEY_NOT_CONFIGURED:
+    "QTM4J Automation API key not configured. Set the QTM4J_AUTOMATION_API_KEY environment variable or pass the Qtm4j-Automation-Api-Key header.",
 } as const;
 
 /**
@@ -218,6 +242,20 @@ export const TOOL_NAMES = {
       "Update an existing test case in QTM4J. Supports auto-resolving human-readable names for priority, status, labels, and components. Labels and components support add/delete operations.",
   },
 
+  /** Upload Automation Result tool */
+  UPLOAD_AUTOMATION_RESULT: {
+    TITLE: "Upload Automation Result",
+    SUMMARY:
+      "Upload an automation result file to QTM4J and map the results to a test cycle. Supports JUnit XML, TestNG XML, Cucumber JSON, QAF, HP UFT, and SpecFlow formats.",
+  },
+
+  /** Get Automation History tool */
+  GET_AUTOMATION_HISTORY: {
+    TITLE: "Get Automation History",
+    SUMMARY:
+      "Retrieve a paginated history of past automation result uploads for a QTM4J project."
+  },
+
   /** Search Test Cycles tool */
   SEARCH_TEST_CYCLES: {
     TITLE: "Search Test Cycles",
@@ -252,6 +290,9 @@ export const CONFIG_KEYS = {
   /** API key configuration key */
   API_KEY: "api_key",
 
+  /** Automation API key configuration key */
+  AUTOMATION_API_KEY: "automation_api_key",
+
   /** Base URL configuration key */
   BASE_URL: "base_url",
 } as const;
@@ -262,6 +303,10 @@ export const CONFIG_KEYS = {
 export const SCHEMA_DESCRIPTIONS = {
   /** API key description */
   API_KEY: "QTM4J API key for authentication",
+
+  /** Automation API key description */
+  AUTOMATION_API_KEY:
+    "QTM4J Automation API key for uploading automation result files. This is a separate key from the regular API key and can be found in QTM4J under Automation settings.",
 
   /** Base URL description */
   BASE_URL:
@@ -358,7 +403,68 @@ export const SCHEMA_DESCRIPTIONS = {
 
   /** Test case object description */
   TEST_CASE_OBJECT: "Test case object",
+
+  /** Automation result file path */
+  AUTOMATION_FILE_PATH:
+    "Path to the automation result file on disk. Filesystem contents can change between turns — always resolve this from a fresh scan, never from a previously seen path. Supported extensions: .xml, .json, .zip",
+
+  /** Automation result format */
+  AUTOMATION_FORMAT:
+    "Format of the result file. Supported values: cucumber, testng, junit, qaf, hpuft, specflow",
+
+  /** Test cycle to reuse */
+  AUTOMATION_TEST_CYCLE_TO_REUSE:
+    "Work key of an existing test cycle to reuse (e.g. 'TR-PRJ-1'). If omitted, a new test cycle is created.",
+
+  /** Automation environment */
+  AUTOMATION_ENVIRONMENT:
+    "Name of the environment on which the test cycle was executed (e.g. 'Chrome', 'Staging'). Defaults to 'No Environment'.",
+
+  /** Automation build */
+  AUTOMATION_BUILD:
+    "Build name or version for the test cycle execution (e.g. '1.0.0-beta'). Defaults to blank.",
+
+  /** isZip flag */
+  AUTOMATION_IS_ZIP:
+    "Set to true when uploading a ZIP archive containing result files. Required for QAF format.",
+
+  /** attachFile flag */
+  AUTOMATION_ATTACH_FILE:
+    "Set to true to upload attachments referenced in execution results.",
+
+  /** matchTestSteps flag */
+  AUTOMATION_MATCH_TEST_STEPS:
+    "true — match test cases by summary AND test steps. false — match by summary or key only.",
+
+  /** appendTestName flag */
+  AUTOMATION_APPEND_TEST_NAME:
+    "Applicable to JUnit/TestNG only. Appends suite/test name to method name in test case summary.",
+
+  /** fields object */
+  AUTOMATION_FIELDS:
+    "Additional fields to set on the test cycle, test case, and/or test case execution created during import.",
+
+  /** getAutomationHistory — pagination */
+  AUTOMATION_HISTORY_START_AT:
+    "Zero-indexed starting position for pagination (default: 0).",
+  AUTOMATION_HISTORY_MAX_RESULTS:
+    "Maximum number of records to return per page (default: 20, max: 100).",
 } as const;
+
+/**
+ * Default directories to search for automation result files when the user
+ * does not provide an explicit file path. Add entries here to support
+ * additional build tools or CI output locations.
+ */
+export const AUTOMATION_RESULT_DIRS = [
+  "target/surefire-reports",
+  "target/failsafe-reports",
+  "build/reports/tests",
+  "build/test-results",
+  "test-results",
+  "reports",
+  "cucumber-reports",
+] as const;
 
 /**
  * Response Field Names

--- a/src/qtm4j/config/constants.ts
+++ b/src/qtm4j/config/constants.ts
@@ -34,6 +34,16 @@ export const ENDPOINTS = {
   RESOLVE_TEST_CASE_IDS: (projectId: number) =>
     `${API_CONFIG.API_VERSION}/projects/${projectId}/mcp/testcases/resolve-ids`,
 
+  /** Update test cycle endpoint */
+  UPDATE_TEST_CYCLE: (id: string) =>
+    `${API_CONFIG.API_VERSION}/testcycles/${id}`,
+
+  /** Create test cycle endpoint */
+  CREATE_TEST_CYCLE: `${API_CONFIG.API_VERSION}/testcycles`,
+
+  /** Search test cycles endpoint */
+  SEARCH_TEST_CYCLES: `${API_CONFIG.API_VERSION}/testcycles/search`,
+
   /** Update test case endpoint */
   UPDATE_TEST_CASE: (id: string, versionNo: number) =>
     `${API_CONFIG.API_VERSION}/testcases/${id}/versions/${versionNo}`,
@@ -140,6 +150,12 @@ export const PAGINATION = {
   /** Maximum allowed results per request for test steps */
   MAX_ALLOWED_RESULTS_TEST_STEPS: 100,
 
+  /** Default maximum results for test cycles */
+  DEFAULT_MAX_RESULTS_TEST_CYCLES: 20,
+
+  /** Maximum allowed results per request for test cycles */
+  MAX_ALLOWED_RESULTS_TEST_CYCLES: 100,
+
   /** Minimum allowed results per request */
   MIN_ALLOWED_RESULTS: 1,
 } as const;
@@ -200,6 +216,32 @@ export const TOOL_NAMES = {
     TITLE: "Update Test Case",
     SUMMARY:
       "Update an existing test case in QTM4J. Supports auto-resolving human-readable names for priority, status, labels, and components. Labels and components support add/delete operations.",
+  },
+
+  /** Search Test Cycles tool */
+  SEARCH_TEST_CYCLES: {
+    TITLE: "Search Test Cycles",
+    SUMMARY:
+      "Search for test cycles in a QTM4J project by status, owner, folder, date range, or keyword. " +
+      "projectId is injected automatically from the active project context.",
+  },
+
+  /** Create Test Cycle tool */
+  CREATE_TEST_CYCLE: {
+    TITLE: "Create Test Cycle",
+    SUMMARY:
+      "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Always creates in the 'MCP Generated' folder. projectId is injected automatically from the active project context.",
+  },
+
+  /** Update Test Cycle tool */
+  UPDATE_TEST_CYCLE: {
+    TITLE: "Update Test Cycle",
+    SUMMARY:
+      "Update an existing test cycle in QTM4J by its human-readable key (e.g. 'SCRUM-TR-101'). " +
+      "Supports auto-resolving human-readable names for status and priority. " +
+      "Labels and components support add/delete operations. " +
+      "Only the fields you provide are changed — omitted fields are left as-is. " +
+      "projectId is injected automatically from the active project context.",
   },
 } as const;
 
@@ -343,6 +385,14 @@ export const RESPONSE_FIELDS = {
   FIELDS: "fields",
 
   SORT: "sort",
+} as const;
+
+/**
+ * Sort Defaults
+ */
+export const SORT_DEFAULTS = {
+  /** Default sort expression for test cycle search */
+  TEST_CYCLES: "key:asc",
 } as const;
 
 /**

--- a/src/qtm4j/config/field-resolution.types.ts
+++ b/src/qtm4j/config/field-resolution.types.ts
@@ -32,6 +32,7 @@ export const ResolverKeys = {
     TEST_CYCLE_STATUS: "testcycle_status",
     PRIORITY: "priority",
     TESTCASE_FOLDER: "testcase_folder",
+    TEST_CYCLE_FOLDER: "testcycle_folder",
   } as const,
 
   /**

--- a/src/qtm4j/http/api-client.ts
+++ b/src/qtm4j/http/api-client.ts
@@ -16,10 +16,12 @@ import { AuthService } from "./auth-service";
 export class ApiClient {
   private readonly baseUrl: string;
   private readonly tokenProvider: () => string | null;
+  private readonly automationTokenProvider?: () => string | null;
 
   constructor(
     tokenOrProvider: string | (() => string | null),
     baseUrl: string,
+    automationTokenProvider?: () => string | null,
   ) {
     this.baseUrl = baseUrl.trim().replace(/\/$/, EMPTY_VALUES.STRING);
 
@@ -28,6 +30,8 @@ export class ApiClient {
     } else {
       this.tokenProvider = tokenOrProvider;
     }
+
+    this.automationTokenProvider = automationTokenProvider;
   }
 
   /**
@@ -40,6 +44,18 @@ export class ApiClient {
     const token = this.tokenProvider();
     if (!token) {
       throw new ToolError(ERROR_MESSAGES.CLIENT_NOT_CONFIGURED);
+    }
+    return new AuthService(token).getAuthHeaders();
+  }
+
+  /**
+   * Get authentication headers using the automation API key.
+   * @throws ToolError if automation API key is not configured
+   */
+  private getAutomationHeaders(): Record<string, string> {
+    const token = this.automationTokenProvider?.();
+    if (!token) {
+      throw new ToolError(ERROR_MESSAGES.AUTOMATION_API_KEY_NOT_CONFIGURED);
     }
     return new AuthService(token).getAuthHeaders();
   }
@@ -116,6 +132,71 @@ export class ApiClient {
       body: JSON.stringify(body),
     });
     return await this.validateAndGetResponseBody(response);
+  }
+
+  /**
+   * Perform GET request using the automation API key (QTM4J_AUTOMATION_API_KEY).
+   * Used for automation endpoints that require the automation key instead of the regular API key.
+   * @param endpoint - API endpoint path
+   * @param params - Optional query parameters
+   * @returns Parsed response data
+   */
+  async getAutomation(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Promise<any> {
+    const response = await fetch(this.getUrl(endpoint, params), {
+      method: HTTP_METHODS.GET,
+      headers: this.getAutomationHeaders(),
+    });
+    return await this.validateAndGetResponseBody(response);
+  }
+
+  /**
+   * Perform POST request using the automation API key (QTM4J_AUTOMATION_API_KEY).
+   * Used for automation import endpoints — same apiKey header as all other APIs,
+   * but the value is the automation key instead of the regular API key.
+   * @param endpoint - API endpoint path
+   * @param body - Request body object
+   * @returns Parsed response data
+   */
+  async postAutomation(endpoint: string, body: object): Promise<any> {
+    const url = this.getUrl(endpoint);
+    const requestHeaders = {
+      ...this.getAutomationHeaders(),
+      [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+    };
+    const response = await fetch(url, {
+      method: HTTP_METHODS.POST,
+      headers: requestHeaders,
+      body: JSON.stringify(body),
+    });
+    return await this.validateAndGetResponseBody(response);
+  }
+
+  /**
+   * Upload a file as multipart/form-data using the automation API key.
+   * Content-Type is not set manually — fetch sets it with the correct multipart boundary.
+   * @param uploadUrl - Full URL returned by the automation import initiation step
+   * @param fileBuffer - Raw file contents as a Buffer
+   */
+  async uploadFileMultipart(
+    uploadUrl: string,
+    fileBuffer: Buffer,
+  ): Promise<void> {
+    const response = await fetch(uploadUrl, {
+      method: HTTP_METHODS.PUT,
+      headers: {
+        [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPES.MULTIPART,
+      },
+      body: new Uint8Array(fileBuffer),
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new ToolError(
+        ERROR_MESSAGES.REQUEST_FAILED(response.status, errorText),
+      );
+    }
   }
 
   /**

--- a/src/qtm4j/resolver/cache/cache.ts
+++ b/src/qtm4j/resolver/cache/cache.ts
@@ -28,7 +28,7 @@ export class Cache {
     if (!this.trackedKeys.has(projectKey)) {
       this.trackedKeys.set(projectKey, new Set());
     }
-    this.trackedKeys.get(projectKey)!.add(key);
+    this.trackedKeys.get(projectKey)?.add(key);
   }
 
   has(projectKey: string, fieldKey: string): boolean {

--- a/src/qtm4j/resolver/resolvers/common-attribute-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/common-attribute-resolver.ts
@@ -43,6 +43,7 @@ export class CommonAttributeResolver extends Resolver {
     if (id !== undefined) {
       body[inputField] = Number(id);
     } else {
+      delete body[inputField];
       warnings.push(
         `Skipped ${inputField} '${name}' — not available in the current project.`,
       );

--- a/src/qtm4j/resolver/resolvers/component-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/component-resolver.ts
@@ -55,6 +55,8 @@ export class ComponentResolver extends Resolver {
 
     if (ids.length > 0) {
       body[inputField] = isArray ? ids : ids[0];
+    } else {
+      delete body[inputField];
     }
   }
 

--- a/src/qtm4j/resolver/resolvers/label-resolver.ts
+++ b/src/qtm4j/resolver/resolvers/label-resolver.ts
@@ -55,6 +55,8 @@ export class LabelResolver extends Resolver {
 
     if (ids.length > 0) {
       body[inputField] = isArray ? ids : ids[0];
+    } else {
+      delete body[inputField];
     }
   }
 

--- a/src/qtm4j/schema/automation.schema.ts
+++ b/src/qtm4j/schema/automation.schema.ts
@@ -1,0 +1,216 @@
+import zod from "zod";
+import { SCHEMA_DESCRIPTIONS } from "../config/constants.ts";
+
+/** Fields that can be set on the test cycle created during import */
+const TestCycleFields = zod
+  .object({
+    labels: zod.array(zod.string()).nullable().optional(),
+    components: zod.array(zod.string()).nullable().optional(),
+    priority: zod.string().nullable().optional(),
+    status: zod.string().nullable().optional(),
+    summary: zod.string().nullable().optional(),
+    description: zod.string().nullable().optional(),
+    assignee: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Jira Account ID of the assignee. Ask the user to provide their Account ID directly.",
+      ),
+    reporter: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Jira Account ID of the reporter. Ask the user to provide their Account ID directly.",
+      ),
+    folderId: zod
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .describe(
+        "Numeric folder ID to place the test cycle in. Right-click a folder in QTM4J and select 'Copy Folder Id' to get this value.",
+      ),
+    plannedStartDate: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe("Date in 'dd/MMM/yyyy HH:mm' format, e.g. '14/May/2026 10:30'"),
+    plannedEndDate: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe("Date in 'dd/MMM/yyyy HH:mm' format, e.g. '14/May/2026 10:30'"),
+  })
+  .nullable()
+  .optional();
+
+/** Fields that can be set on test cases created/reused during import */
+const TestCaseFields = zod
+  .object({
+    labels: zod.array(zod.string()).nullable().optional(),
+    components: zod.array(zod.string()).nullable().optional(),
+    priority: zod.string().nullable().optional(),
+    status: zod.string().nullable().optional(),
+    description: zod.string().nullable().optional(),
+    precondition: zod.string().nullable().optional(),
+    assignee: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Jira Account ID of the assignee. Ask the user to provide their Account ID directly.",
+      ),
+    reporter: zod
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Jira Account ID of the reporter. Ask the user to provide their Account ID directly.",
+      ),
+    estimatedTime: zod.string().nullable().optional(),
+    folderId: zod
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .describe(
+        "Numeric folder ID to place the test cases in. Right-click a folder in QTM4J and select 'Copy Folder Id' to get this value.",
+      ),
+  })
+  .nullable()
+  .optional();
+
+/** Fields that can be set on test case executions created during import */
+const TestCaseExecutionFields = zod
+  .object({
+    comment: zod.string().nullable().optional(),
+    actualTime: zod.string().nullable().optional(),
+    executionPlannedDate: zod.string().nullable().optional(),
+    assignee: zod.string().nullable().optional(),
+  })
+  .nullable()
+  .optional();
+
+/** Input schema for the uploadAutomationResult tool */
+export const UploadAutomationResultBody = zod.object({
+  filePath: zod.string().describe(SCHEMA_DESCRIPTIONS.AUTOMATION_FILE_PATH),
+  format: zod
+    .enum(["cucumber", "testng", "junit", "qaf", "hpuft", "specflow"])
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_FORMAT),
+  testCycleToReuse: zod
+    .string()
+    .optional()
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_TEST_CYCLE_TO_REUSE),
+  environment: zod
+    .string()
+    .optional()
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_ENVIRONMENT),
+  build: zod.string().optional().describe(SCHEMA_DESCRIPTIONS.AUTOMATION_BUILD),
+  isZip: zod
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_IS_ZIP),
+  attachFile: zod
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_ATTACH_FILE),
+  matchTestSteps: zod
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_MATCH_TEST_STEPS),
+  appendTestName: zod
+    .boolean()
+    .optional()
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_APPEND_TEST_NAME),
+  fields: zod
+    .object({
+      testCycle: TestCycleFields,
+      testCase: TestCaseFields,
+      testCaseExecution: TestCaseExecutionFields,
+    })
+    .optional()
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_FIELDS),
+});
+
+export type UploadAutomationResultBodyType = zod.infer<
+  typeof UploadAutomationResultBody
+>;
+
+/** Response schema for the uploadAutomationResult tool */
+export const UploadAutomationResultResponse = zod.object({
+  trackingId: zod.string(),
+  message: zod.string(),
+  filePath: zod.string(),
+  format: zod.enum(["cucumber", "testng", "junit", "qaf", "hpuft", "specflow"]),
+});
+
+export type UploadAutomationResultResponseType = zod.infer<
+  typeof UploadAutomationResultResponse
+>;
+
+/** Input schema for the getAutomationHistory tool */
+export const GetAutomationHistoryBody = zod.object({
+  startAt: zod
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(0)
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_HISTORY_START_AT),
+  maxResults: zod
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe(SCHEMA_DESCRIPTIONS.AUTOMATION_HISTORY_MAX_RESULTS),
+});
+
+export type GetAutomationHistoryBodyType = zod.infer<
+  typeof GetAutomationHistoryBody
+>;
+
+/** Summary entry within a history record */
+const AutomationHistorySummary = zod.object({
+  testCycle: zod.string().nullable().optional(),
+  testCasesCreated: zod.number().nullable().optional(),
+  testCaseVersionsCreated: zod.number().nullable().optional(),
+  testCaseVersionsReused: zod.number().nullable().optional(),
+  testStepsCreated: zod.number().nullable().optional(),
+  testCycleIssueKey: zod.string().nullable().optional(),
+  testCycleSummary: zod.string().nullable().optional(),
+});
+
+/** A single automation history record */
+export const AutomationHistoryRecord = zod.object({
+  trackingId: zod.string().nullable().optional(),
+  fileName: zod.string().nullable().optional(),
+  format: zod.string().nullable().optional(),
+  processStatus: zod.string().nullable().optional(),
+  importStatus: zod.string().nullable().optional(),
+  startTime: zod.string().nullable().optional(),
+  endTime: zod.string().nullable().optional(),
+  fileSize: zod.number().nullable().optional(),
+  detailedMessage: zod.string().nullable().optional(),
+  extraAttributes: zod.record(zod.string(), zod.any()).nullable().optional(),
+  childFileSummaryResponses: zod.array(zod.any()).nullable().optional(),
+  summary: zod.array(AutomationHistorySummary).nullable().optional(),
+});
+
+/** Response schema for the getAutomationHistory tool */
+export const GetAutomationHistoryResponse = zod.object({
+  startAt: zod.number().nullable().optional(),
+  maxResults: zod.number().nullable().optional(),
+  total: zod.number().nullable().optional(),
+  data: zod.array(AutomationHistoryRecord).nullable().optional(),
+});
+
+export type GetAutomationHistoryResponseType = zod.infer<
+  typeof GetAutomationHistoryResponse
+>;

--- a/src/qtm4j/schema/search-test-cycle.schema.ts
+++ b/src/qtm4j/schema/search-test-cycle.schema.ts
@@ -1,0 +1,252 @@
+/**
+ * QTM4J Search Test Cycles Schemas
+ *
+ * POST /rest/api/latest/testcycles/search
+ *
+ * Filter fields are sent in the POST body; pagination (startAt, maxResults),
+ * field selection, and sort are URL query parameters.
+ * projectId is auto-injected by the tool — never passed by the LLM.
+ */
+import * as zod from "zod";
+import { PAGINATION, SORT_DEFAULTS } from "../config/constants";
+
+// Date range format: "dd/MMM/yyyy,dd/MMM/yyyy" (case-sensitive month, e.g. "02/Apr/2026,15/May/2026")
+const DATE_RANGE_REGEX =
+  /^\d{2}\/[A-Z][a-z]{2}\/\d{4},\d{2}\/[A-Z][a-z]{2}\/\d{4}$/;
+const DATE_RANGE_DESCRIPTION =
+  "Inclusive date range. Format: 'dd/MMM/yyyy,dd/MMM/yyyy' e.g. '02/Apr/2026,15/May/2026'. " +
+  "Month abbreviation is case-sensitive (Apr not apr or APR). Always provide two dates separated by a comma.";
+
+export const SearchTestCycleFilter = zod
+  .object({
+    projectId: zod
+      .number()
+      .optional()
+      .describe(
+        "Numeric project ID. Auto-injected from active project context — do not provide.",
+      ),
+    status: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Status names to include (OR logic within array). Examples: ['In Progress', 'To Do']. " +
+          "Common values: 'To Do', 'In Progress', 'Done'.",
+      ),
+    priority: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Priority names to include (OR logic within array). Examples: ['High'], ['High', 'Medium']. " +
+          "Common values: 'High', 'Medium', 'Low'.",
+      ),
+    assignee: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Jira account IDs of assignees (OR logic within array). " +
+          "Example: ['5b10a2844c20165700ede21f']. " +
+          "Multiple IDs match test cycles assigned to any of them.",
+      ),
+    reporter: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Jira account IDs of reporters (OR logic within array). " +
+          "Example: ['5b10a2844c20165700ede21f'].",
+      ),
+    folderId: zod
+      .number()
+      .optional()
+      .describe(
+        "Folder ID to restrict results to (numeric). " +
+          "Right-click a folder in QTM4J and select 'Copy Folder Id'.",
+      ),
+    labels: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Label names to include (OR logic within array). Example: ['Release_1', 'Sprint 1']. " +
+          "Use exact label names as configured in the project.",
+      ),
+    components: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Component names to include (OR logic within array). Example: ['UI', 'Cloud']. " +
+          "Use exact component names as configured in the project.",
+      ),
+    plannedStartDate: zod
+      .string()
+      .regex(
+        DATE_RANGE_REGEX,
+        "Invalid format. Use dd/MMM/yyyy,dd/MMM/yyyy e.g. 02/Apr/2026,15/May/2026",
+      )
+      .optional()
+      .describe(DATE_RANGE_DESCRIPTION),
+    plannedEndDate: zod
+      .string()
+      .regex(
+        DATE_RANGE_REGEX,
+        "Invalid format. Use dd/MMM/yyyy,dd/MMM/yyyy e.g. 02/Apr/2026,15/May/2026",
+      )
+      .optional()
+      .describe(DATE_RANGE_DESCRIPTION),
+    searchText: zod
+      .string()
+      .optional()
+      .describe(
+        "Free-text search across key, summary, and description. Case-insensitive. Example: 'regression sprint'",
+      ),
+    createdOn: zod
+      .string()
+      .regex(
+        DATE_RANGE_REGEX,
+        "Invalid format. Use dd/MMM/yyyy,dd/MMM/yyyy e.g. 01/May/2026,20/May/2026",
+      )
+      .optional()
+      .describe(
+        `Filter by creation date range (inclusive). ${DATE_RANGE_DESCRIPTION}`,
+      ),
+    updatedOn: zod
+      .string()
+      .regex(
+        DATE_RANGE_REGEX,
+        "Invalid format. Use dd/MMM/yyyy,dd/MMM/yyyy e.g. 01/May/2026,21/May/2026",
+      )
+      .optional()
+      .describe(
+        "Filter by last-updated date range (inclusive). " +
+          DATE_RANGE_DESCRIPTION,
+      ),
+    isAutomated: zod
+      .boolean()
+      .optional()
+      .describe(
+        "Automation status filter: true = automated tests only, false = manual tests only. Omit to include both.",
+      ),
+    aiGenerated: zod
+      .boolean()
+      .optional()
+      .describe(
+        "AI generation flag: true = AI-generated test cycles only, false = human-authored only. Omit to include both.",
+      ),
+  })
+  .describe(
+    "Filter criteria — multiple fields are combined with AND; multiple values within one field use OR.",
+  );
+
+const FIELDS_DESCRIPTION =
+  "Fields to include in each result object. If omitted, server returns its default set " +
+  "(NOTE: plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly when needed). " +
+  "Available fields: key, summary, description, status, priority, assignee, reporter, isAutomated, " +
+  "plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, " +
+  "estimatedTime, actualTime, created, updated. " +
+  "Example: ['key', 'summary', 'status', 'assignee', 'plannedStartDate', 'plannedEndDate']";
+
+export const SearchTestCycleBody = zod.object({
+  filter: SearchTestCycleFilter.optional(),
+  fields: zod.array(zod.string()).optional().describe(FIELDS_DESCRIPTION),
+  startAt: zod
+    .number()
+    .min(0)
+    .optional()
+    .default(PAGINATION.DEFAULT_START_AT)
+    .describe(
+      "Zero-indexed offset for pagination (URL query param). Default: 0.",
+    ),
+  maxResults: zod
+    .number()
+    .min(PAGINATION.MIN_ALLOWED_RESULTS)
+    .max(PAGINATION.MAX_ALLOWED_RESULTS_TEST_CYCLES)
+    .optional()
+    .default(PAGINATION.DEFAULT_MAX_RESULTS_TEST_CYCLES)
+    .describe(
+      `Number of results per page (URL query param). Default: ${PAGINATION.DEFAULT_MAX_RESULTS_TEST_CYCLES}. Maximum: ${PAGINATION.MAX_ALLOWED_RESULTS_TEST_CYCLES}. ` +
+        `To page through results, increment startAt by ${PAGINATION.DEFAULT_MAX_RESULTS_TEST_CYCLES} until startAt >= total.`,
+    ),
+  sort: zod
+    .string()
+    .optional()
+    .default(SORT_DEFAULTS.TEST_CYCLES)
+    .describe(
+      `Sort pattern sent as a URL query param. Format: 'fieldName:order'. Default: '${SORT_DEFAULTS.TEST_CYCLES}'. ` +
+        "Order values: 'asc' (lowest/oldest first) or 'desc' (highest/newest first). " +
+        "Sortable fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. " +
+        "Examples: 'key:asc', 'plannedStartDate:desc'",
+    ),
+});
+
+const TestCycleStatusSchema = zod.looseObject({
+  id: zod.number().optional().describe("Numeric status ID"),
+  name: zod
+    .string()
+    .optional()
+    .describe("Status display name e.g. 'In Progress'"),
+  color: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe("Hex color e.g. '#ffd351'"),
+});
+
+const TestCyclePrioritySchema = zod.looseObject({
+  id: zod.number().optional().describe("Numeric priority ID"),
+  name: zod.string().optional().describe("Priority display name e.g. 'High'"),
+  color: zod.string().nullable().optional().describe("Hex color"),
+});
+
+const TestCycleLabelSchema = zod.looseObject({
+  id: zod.number().optional(),
+  name: zod.string().optional(),
+});
+
+const TestCycleComponentSchema = zod.looseObject({
+  id: zod.number().optional(),
+  name: zod.string().optional(),
+});
+
+export const TestCycleSearchItemSchema = zod.looseObject({
+  id: zod.string().describe("Internal UID of the test cycle"),
+  key: zod.string().describe("Human-readable key e.g. 'PROJ-TR-212'"),
+  projectId: zod.number().optional().describe("Numeric project ID"),
+  summary: zod.string().optional().describe("Test cycle name / title"),
+  description: zod.string().nullable().optional(),
+  status: TestCycleStatusSchema.optional().describe(
+    "Status object (empty {} when not requested)",
+  ),
+  priority: TestCyclePrioritySchema.optional().describe(
+    "Priority object (empty {} when not requested)",
+  ),
+  assignee: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe("Assignee Jira account ID, or null if unassigned"),
+  reporter: zod.string().nullable().optional(),
+  isAutomated: zod.boolean().optional(),
+  plannedStartDate: zod.string().nullable().optional(),
+  plannedEndDate: zod.string().nullable().optional(),
+  labels: zod.array(TestCycleLabelSchema).nullable().optional(),
+  components: zod.array(TestCycleComponentSchema).nullable().optional(),
+  fixVersions: zod.array(zod.any()).nullable().optional(),
+  sprint: zod.any().nullable().optional(),
+  defectCount: zod.number().nullable().optional(),
+  estimatedTime: zod.any().nullable().optional(),
+  actualTime: zod.any().nullable().optional(),
+  created: zod.any().optional(),
+  updated: zod.any().optional(),
+  archived: zod.boolean().optional(),
+});
+
+export const SearchTestCycleResponse = zod.object({
+  startAt: zod.number().describe("Offset of this page"),
+  maxResults: zod.number().describe("Page size used for this response"),
+  total: zod.number().describe("Total matching test cycles across all pages"),
+  data: zod
+    .array(TestCycleSearchItemSchema)
+    .describe("Test cycles on this page"),
+});
+
+export type SearchTestCycleResponseType = zod.infer<
+  typeof SearchTestCycleResponse
+>;

--- a/src/qtm4j/schema/test-cycle.schema.ts
+++ b/src/qtm4j/schema/test-cycle.schema.ts
@@ -1,0 +1,83 @@
+/**
+ * QTM4J Create Test Cycle Schemas
+ *
+ * POST /rest/api/latest/testcycles
+ */
+import * as zod from "zod";
+
+/**
+ * projectId and folderId are injected automatically by the tool.
+ * priority, status, labels, and components accept human-readable names
+ * and are auto-resolved to numeric IDs before the API call.
+ */
+export const CreateTestCycleBody = zod.object({
+  summary: zod
+    .string()
+    .min(1)
+    .max(255)
+    .describe(
+      "Short title of the test cycle. Must not be blank. Max 255 chars.",
+    ),
+  description: zod
+    .string()
+    .max(65535)
+    .optional()
+    .describe("Detailed description of the test cycle. Max 65 535 characters."),
+  priority: zod
+    .string()
+    .optional()
+    .describe(
+      "Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID.",
+    ),
+  status: zod
+    .string()
+    .optional()
+    .describe(
+      "Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID.",
+    ),
+  assignee: zod.string().optional().describe("Assignee account ID"),
+  reporter: zod.string().optional().describe("Reporter account ID"),
+  labels: zod
+    .array(zod.string())
+    .optional()
+    .describe(
+      "List of label names (e.g., ['Release_1', 'Sprint 1']). Auto-resolved to IDs.",
+    ),
+  components: zod
+    .array(zod.string())
+    .optional()
+    .describe(
+      "List of component names (e.g., ['UI', 'Cloud']). Auto-resolved to IDs.",
+    ),
+  plannedStartDate: zod
+    .string()
+    .regex(/^\d{2}\/[A-Za-z]{3}\/\d{4} \d{2}:\d{2}$/)
+    .optional()
+    .describe(
+      "Planned start date. Format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Must be ≤ plannedEndDate when both are provided.",
+    ),
+  plannedEndDate: zod
+    .string()
+    .regex(/^\d{2}\/[A-Za-z]{3}\/\d{4} \d{2}:\d{2}$/)
+    .optional()
+    .describe(
+      "Planned end date. Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 00:00'. Must be ≥ plannedStartDate when both are provided.",
+    ),
+});
+
+export const CreateTestCycleResponse = zod.object({
+  id: zod
+    .string()
+    .describe(
+      "Opaque permanent identifier of the created test cycle. Use this in all subsequent API calls.",
+    ),
+  key: zod
+    .string()
+    .describe(
+      "Human-readable project-scoped key in format '<PROJECT_KEY>-TR-<number>'. e.g. 'TRWT-TR-218'.",
+    ),
+});
+
+export type CreateTestCycleResponseType = zod.infer<
+  typeof CreateTestCycleResponse
+>;

--- a/src/qtm4j/schema/update-test-cycle.schema.ts
+++ b/src/qtm4j/schema/update-test-cycle.schema.ts
@@ -1,0 +1,118 @@
+/**
+ * QTM4J Update Test Cycle Schemas
+ *
+ * PUT /rest/api/latest/testcycles/{key}
+ *
+ * The test cycle key (e.g. 'SCRUM-TR-101') is used directly as the URL path
+ * parameter — no UID resolution required.
+ * Input accepts human-readable names for status and priority (auto-resolved to IDs).
+ * Labels and components support add/delete operations with name auto-resolution.
+ */
+import * as zod from "zod";
+
+/** add/delete object for labels and components — names are auto-resolved to IDs */
+const MetadataAddDelete = zod
+  .object({
+    add: zod
+      .array(zod.string())
+      .optional()
+      .describe(
+        "Names to add (e.g., ['Regression', 'Smoke']). Auto-resolved to IDs.",
+      ),
+    delete: zod
+      .array(zod.string())
+      .optional()
+      .describe("Names to remove (e.g., ['Sprint1']). Auto-resolved to IDs."),
+  })
+  .describe(
+    "Add or remove entries by name. Both add and delete are optional — omit either to skip that operation.",
+  );
+
+const DATETIME_REGEX = /^\d{2}\/[A-Za-z]{3}\/\d{4} \d{2}:\d{2}$/;
+const DATETIME_DESCRIPTION =
+  "Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may). Pass null to clear the existing value.";
+
+export const UpdateTestCycleBody = zod.object({
+  key: zod
+    .string()
+    .describe(
+      "Test cycle key in the format '{PROJECT_KEY}-TR-{number}', e.g. 'SCRUM-TR-101'. " +
+        "Used directly as the API path parameter.",
+    ),
+  summary: zod
+    .string()
+    .min(1, "Summary cannot be blank.")
+    .max(255, "Summary must not exceed 255 characters.")
+    .optional()
+    .describe("Updated test cycle name / title. Max 255 characters."),
+  description: zod
+    .string()
+    .max(65535, "Description must not exceed 65,535 characters.")
+    .nullable()
+    .optional()
+    .describe(
+      "Updated description. Pass null to clear the existing value. Max 65 535 characters.",
+    ),
+  status: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID. Use values from set_project_context response. Pass null to clear.",
+    ),
+  priority: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID. Use values from set_project_context response. Pass null to clear.",
+    ),
+  plannedStartDate: zod
+    .string()
+    .regex(
+      DATETIME_REGEX,
+      "Invalid format. Use dd/MMM/yyyy HH:mm e.g. 15/May/2026 09:00",
+    )
+    .nullable()
+    .optional()
+    .describe(DATETIME_DESCRIPTION),
+  plannedEndDate: zod
+    .string()
+    .regex(
+      DATETIME_REGEX,
+      "Invalid format. Use dd/MMM/yyyy HH:mm e.g. 30/May/2026 18:00",
+    )
+    .nullable()
+    .optional()
+    .describe(DATETIME_DESCRIPTION),
+  assignee: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Assignee Jira account ID (e.g., '5b10a2844c20165700ede21f'). Pass null to unassign.",
+    ),
+  reporter: zod
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Reporter Jira account ID (e.g., '5b10a2844c20165700ede21f'). Pass null to clear.",
+    ),
+  labels: MetadataAddDelete.optional().describe(
+    "Labels to add or remove by name. Each name is auto-resolved to its ID.",
+  ),
+  components: MetadataAddDelete.optional().describe(
+    "Components to add or remove by name. Each name is auto-resolved to its ID.",
+  ),
+});
+
+export const UpdateTestCycleResponse = zod.object({
+  key: zod.string().describe("Human-readable key of the updated test cycle"),
+  updated: zod.literal(true).describe("Confirms the update was applied"),
+});
+
+export type UpdateTestCycleBodyType = zod.infer<typeof UpdateTestCycleBody>;
+export type UpdateTestCycleResponseType = zod.infer<
+  typeof UpdateTestCycleResponse
+>;

--- a/src/qtm4j/tool/test-automation/get-automation-history.ts
+++ b/src/qtm4j/tool/test-automation/get-automation-history.ts
@@ -1,0 +1,89 @@
+import { Tool } from "../../../common/tools.ts";
+import type { ToolParams } from "../../../common/types.ts";
+import type { Qtm4jClient } from "../../client.ts";
+import { ENDPOINTS, TOOL_NAMES } from "../../config/constants.ts";
+import {
+  GetAutomationHistoryBody,
+  GetAutomationHistoryResponse,
+  type GetAutomationHistoryResponseType,
+} from "../../schema/automation.schema.ts";
+
+export class GetAutomationHistory extends Tool<Qtm4jClient> {
+  specification: ToolParams = {
+    title: TOOL_NAMES.GET_AUTOMATION_HISTORY.TITLE,
+    summary: TOOL_NAMES.GET_AUTOMATION_HISTORY.SUMMARY,
+    readOnly: true,
+    idempotent: true,
+    inputSchema: GetAutomationHistoryBody,
+    outputSchema: GetAutomationHistoryResponse,
+    purpose:
+      "Retrieve a paginated list of past automation result uploads from QTM4J. " +
+      "Use this to review upload history, check upload statuses, and audit past CI/CD automation runs. " +
+      "No set_project_context call is required.",
+    useCases: [
+      "Review past automation result uploads for a project",
+      "Check the status of recent automation imports",
+      "Audit CI/CD automation upload history",
+      "Paginate through all historical automation uploads",
+    ],
+    examples: [
+      {
+        description:
+          "Get the first page of automation upload history (default page size 20)",
+        parameters: {},
+        expectedOutput:
+          "Paginated list of automation history records with upload status and metadata",
+      },
+      {
+        description: "Get the second page of automation upload history",
+        parameters: {
+          startAt: 20,
+          maxResults: 20,
+        },
+        expectedOutput: "Next 20 automation history records",
+      },
+      {
+        description: "Get up to 50 records starting from the beginning",
+        parameters: {
+          startAt: 0,
+          maxResults: 50,
+        },
+        expectedOutput: "Up to 50 automation history records",
+      },
+    ],
+    hints: [
+      "NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently.",
+      "PAGINATION: startAt is zero-indexed (default: 0), maxResults controls page size (default: 20, max: 100). Increment startAt by maxResults to fetch the next page.",
+      "Returns an empty data array (not an error) when no history records exist.",
+      "DISPLAY FORMAT: Show '1–N of <total>' above all cards. Render each record as a card separated by --- dividers. Each card has two sections:\n\n" +
+        "PRIMARY SECTION (always first): heading with status emoji (✅ SUCCESS / ❌ FAILED) + test cycle key and name; then format, start→end time, message, summary stats (test cases/versions created/reused/test steps), tracking ID.\n\n" +
+        "EXTRA DETAILS SECTION (at the bottom of the card, under a 'Details' sub-label): any remaining non-null fields from the record such as fileSize, extraAttributes values, etc.\n\n" +
+        "Skip any field that is null, missing, or false. NEVER show the raw fileName. NEVER use a table.",
+    ],
+    outputDescription:
+      "Paginated list of automation import history. Each record includes: format, processStatus, importStatus, startTime, endTime, trackingId, detailedMessage, and a summary array. " +
+      "summary[0] contains: testCycleIssueKey, testCycleSummary, testCasesCreated, testCaseVersionsCreated, testCaseVersionsReused, testStepsCreated. " +
+      "Render as individual cards separated by dividers, NOT a table. Show '1–N of total' count above. Never show raw fileName.",
+  };
+
+  handle = async (rawArgs: any) => {
+    const args = GetAutomationHistoryBody.parse(rawArgs);
+    const apiClient = this.client.getApiClient();
+
+    const response = await apiClient.getAutomation(
+      ENDPOINTS.AUTOMATION_HISTORY,
+      {
+        startAt: args.startAt,
+        maxResults: args.maxResults,
+      },
+    );
+
+    const result: GetAutomationHistoryResponseType =
+      GetAutomationHistoryResponse.parse(response);
+
+    return {
+      structuredContent: result,
+      content: [],
+    };
+  };
+}

--- a/src/qtm4j/tool/test-automation/upload-automation-result.ts
+++ b/src/qtm4j/tool/test-automation/upload-automation-result.ts
@@ -1,0 +1,186 @@
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+import { Tool, ToolError } from "../../../common/tools.ts";
+import type { ToolParams } from "../../../common/types.ts";
+import type { Qtm4jClient } from "../../client.ts";
+import {
+  AUTOMATION_LIMITS,
+  AUTOMATION_RESULT_DIRS,
+  ENDPOINTS,
+  TOOL_NAMES,
+} from "../../config/constants.ts";
+import {
+  UploadAutomationResultBody,
+  UploadAutomationResultResponse,
+  type UploadAutomationResultResponseType,
+} from "../../schema/automation.schema.ts";
+
+/** Supported file extensions */
+const SUPPORTED_EXTENSIONS = new Set([".xml", ".json", ".zip"]);
+
+export class UploadAutomationResult extends Tool<Qtm4jClient> {
+  specification: ToolParams = {
+    title: TOOL_NAMES.UPLOAD_AUTOMATION_RESULT.TITLE,
+    summary: TOOL_NAMES.UPLOAD_AUTOMATION_RESULT.SUMMARY,
+    readOnly: false,
+    idempotent: false,
+    inputSchema: UploadAutomationResultBody,
+    outputSchema: UploadAutomationResultResponse,
+    purpose:
+      "Upload an automation result file from disk to QTM4J and map results to a test cycle. " +
+      "No set_project_context call is required — this tool works independently of any project context. " +
+      `When the user asks to upload or import automation results, search these directories: ${AUTOMATION_RESULT_DIRS.join(", ")}. ` +
+      "Infer the format from the file name where possible; confirm with the user only when the format is ambiguous. " +
+      "Returns a trackingId to track the asynchronous import progress.",
+    useCases: [
+      "Upload automation results to QTM4J",
+      "Import test results from a CI/CD pipeline run",
+      "Link test results to an existing test cycle",
+      "Create a new test cycle from automation results",
+      "Upload JUnit, TestNG, Cucumber, QAF, HP UFT, or SpecFlow result files",
+    ],
+    examples: [
+      {
+        description:
+          "User says 'upload my test results to QTM4J' — scan workspace, find single result file, confirm and upload",
+        parameters: {
+          filePath: "./target/surefire-reports/TEST-results.xml",
+          format: "junit",
+        },
+        expectedOutput:
+          "trackingId returned; import processing started in QTM4J",
+      },
+      {
+        description: "User wants results linked to an existing test cycle",
+        parameters: {
+          filePath: "./reports/cucumber.json",
+          format: "cucumber",
+          testCycleToReuse: "TR-PRJ-5",
+          environment: "Chrome",
+          build: "2.1.0",
+        },
+        expectedOutput: "Results mapped to test cycle TR-PRJ-5",
+      },
+      {
+        description: "Upload QAF ZIP and set test cycle metadata",
+        parameters: {
+          filePath: "./results/qaf-results.zip",
+          format: "qaf",
+          isZip: true,
+          fields: {
+            testCycle: {
+              summary: "Regression Run 2024-Q1",
+              labels: ["regression"],
+              priority: "High",
+            },
+          },
+        },
+        expectedOutput:
+          "ZIP uploaded; test cycle created with summary, labels, and priority",
+      },
+      {
+        description:
+          "User provides an unrecognised priority value — do NOT silently map to a similar word; ask the user first",
+        parameters: {
+          filePath: "./reports/cucumber.json",
+          format: "cucumber",
+          fields: { testCycle: { priority: "critical" } },
+        },
+        expectedOutput:
+          "Tool is NOT called yet. Inform the user that 'critical' was not recognised as a valid priority and ask them to confirm the correct value (e.g. from the available options). Do not map 'critical' to 'Blocker' or any other value without explicit user confirmation.",
+      },
+    ],
+    hints: [
+      "NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently — never prompt the user for project information.",
+      `FILE DISCOVERY: Always do a fresh scan — never reuse a path from a previous turn. If no path is provided, search in order: ${AUTOMATION_RESULT_DIRS.join(", ")}. If exactly one file is found, show the path and inferred format to the user and confirm before uploading. If multiple files are found, list them all and wait for the user to pick one. If nothing is found, ask for the path. Never pick or upload silently.`,
+      "FORMAT INFERENCE: .json → cucumber (unambiguous). For .xml, infer from the file name — 'junit'/'surefire' → junit, 'testng' → testng, 'specflow' → specflow, 'hpuft'/'uft' → hpuft. For .zip, ALWAYS set isZip: true, but do NOT assume qaf — the zip could contain junit, testng, or cucumber results; if the format cannot be determined from the file name, ask the user. If the file name gives no clear signal for .xml either, ask the user to confirm the format.",
+      "TEST CYCLE: Only ask for testCycleToReuse if the user explicitly wants to link to an existing cycle. If not mentioned, omit it — QTM4J creates a new test cycle automatically.",
+      "DATE FORMAT: plannedStartDate and plannedEndDate in fields.testCycle MUST be formatted as 'dd/MMM/yyyy HH:mm' (e.g. '14/May/2026 10:30'). Convert any user-provided date (ISO, natural language, relative) to this exact format before sending.",
+      "FOLDER ID: folderId is a numeric ID. Apply it ONLY to the level the user specifies; if unspecified, default to fields.testCycle only — never copy it to both levels. Get the ID from the user directly (right-click folder in QTM4J → 'Copy Folder Id').",
+      "ASSIGNEE / REPORTER: assignee and reporter in fields.testCycle and fields.testCase require a Jira Account ID (not a display name or email). Ask the user to provide their Account ID directly.",
+      "FIELD MAPPING CONFIRMATION: Apply formatting transformations (case correction, date/time conversion) automatically. Only ask for user confirmation when you cannot find a recognised match and need to substitute an unrecognised value with a guessed alternative — never silently substitute in that case.",
+      "TRACKING: Import processing is asynchronous. To check status, call get_automation_history and find the record whose trackingId matches the one returned from this tool.",
+    ],
+    outputDescription:
+      "trackingId to poll import status, a message from the API, the filePath uploaded, and the format used.",
+  };
+
+  handle = async (rawArgs: any) => {
+    const args = UploadAutomationResultBody.parse(rawArgs);
+    const { filePath, format, isZip, fields, ...rest } = args;
+
+    // Validate file extension
+    const ext = extname(filePath).toLowerCase();
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      throw new ToolError(
+        `Unsupported file extension '${ext}'. Supported extensions: .xml, .json, .zip`,
+      );
+    }
+
+    // QAF requires a ZIP
+    if (format === "qaf" && !isZip) {
+      throw new ToolError(
+        "QAF format requires a ZIP file. Set isZip: true and provide a .zip file.",
+      );
+    }
+
+    // Read file from disk
+    let fileBuffer: Buffer;
+    try {
+      fileBuffer = await readFile(filePath);
+    } catch (err: any) {
+      throw new ToolError(
+        `Could not read file at '${filePath}': ${err.message}`,
+      );
+    }
+
+    // Enforce maximum file size
+    if (fileBuffer.byteLength > AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES) {
+      const sizeMB = (fileBuffer.byteLength / (1024 * 1024)).toFixed(2);
+      throw new ToolError(
+        `File is too large (${sizeMB} MB). Maximum allowed size is 10 MB.`,
+      );
+    }
+
+    const apiClient = this.client.getApiClient();
+
+    // Step 1 — POST with automation API key to get upload URL and trackingId
+    const importBody: Record<string, unknown> = {
+      format,
+      isZip: isZip ?? false,
+      ...rest,
+      ...(fields ? { fields } : {}),
+    };
+
+    const initResponse = await apiClient.postAutomation(
+      ENDPOINTS.AUTOMATION_IMPORT,
+      importBody,
+    );
+
+    const uploadUrl: string | undefined = initResponse?.url;
+    const trackingId: string | undefined = initResponse?.trackingId;
+
+    if (!uploadUrl || !trackingId) {
+      throw new ToolError(
+        "QTM4J did not return a valid upload URL. Check your API key and project configuration.",
+      );
+    }
+
+    // Step 2 — PUT file as raw binary with Content-Type: multipart/form-data to the pre-signed S3 URL
+    await apiClient.uploadFileMultipart(uploadUrl, fileBuffer);
+
+    const result: UploadAutomationResultResponseType = {
+      trackingId,
+      message:
+        initResponse.message ??
+        "File uploaded successfully. Import is processing.",
+      filePath,
+      format,
+    };
+
+    return {
+      structuredContent: UploadAutomationResultResponse.parse(result),
+      content: [],
+    };
+  };
+}

--- a/src/qtm4j/tool/test-cycle/create-test-cycle.ts
+++ b/src/qtm4j/tool/test-cycle/create-test-cycle.ts
@@ -1,0 +1,127 @@
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { Qtm4jClient } from "../../client";
+import { ENDPOINTS, TOOL_NAMES } from "../../config/constants";
+import { InputField, ResolverKeys } from "../../config/field-resolution.types";
+import {
+  CreateTestCycleBody,
+  CreateTestCycleResponse,
+  type CreateTestCycleResponseType,
+} from "../../schema/test-cycle.schema";
+
+// Maps each input field to its resolver key. Add entries here to resolve new fields.
+const FIELD_CONFIG: Record<string, string> = {
+  [InputField.PRIORITY]: ResolverKeys.CommonAttribute.PRIORITY,
+  [InputField.STATUS]: ResolverKeys.CommonAttribute.TEST_CYCLE_STATUS,
+  [InputField.FOLDER]: ResolverKeys.CommonAttribute.TEST_CYCLE_FOLDER,
+  [InputField.LABELS]: ResolverKeys.SearchableField.LABEL,
+  [InputField.COMPONENTS]: ResolverKeys.SearchableField.COMPONENTS,
+};
+
+/**
+ * CreateTestCycle Tool
+ *
+ * Creates a new test cycle in QTM4J. All cycles are placed in the
+ * 'MCP Generated' folder automatically.
+ *
+ * Resolved fields (driven by FIELD_CONFIG):
+ *   - priority → numeric ID via CommonAttribute resolver
+ *   - status → numeric ID via TEST_CYCLE_STATUS resolver
+ *   - folderId → resolved to 'MCP Generated' folder ID
+ *   - labels → numeric IDs via SearchableField resolver
+ *   - components → numeric IDs via SearchableField resolver
+ *
+ * Safety: if any field fails to resolve, the cycle is still created without that
+ * field, and a warning is returned alongside the response.
+ */
+export class CreateTestCycle extends Tool<Qtm4jClient> {
+  // ─── Tool Specification ────────────────────────────────────────────────────
+
+  specification: ToolParams = {
+    title: TOOL_NAMES.CREATE_TEST_CYCLE.TITLE,
+    summary: TOOL_NAMES.CREATE_TEST_CYCLE.SUMMARY,
+    readOnly: false,
+    idempotent: false,
+    inputSchema: CreateTestCycleBody,
+    outputSchema: CreateTestCycleResponse,
+    purpose:
+      "Create a new test cycle in QTM4J. " +
+      "projectId is auto-injected from the active project context. " +
+      "priority, status, labels, and components are auto-resolved from human-readable names.",
+    useCases: [
+      "Create a test cycle with summary, priority, status, labels, or components",
+      "Set planned start and end dates on a new test cycle",
+    ],
+    examples: [
+      {
+        description:
+          "Create a simple test cycle (project must be set via set_project_context first)",
+        parameters: { summary: "Smoke Test Cycle" },
+        expectedOutput: "Test cycle created with key 'SCRUM-TR-xxx'",
+      },
+      {
+        description:
+          "Create a test cycle with priority, status, labels, and components",
+        parameters: {
+          summary: "Regression Suite – Sprint 42",
+          description:
+            "End-to-end regression covering payment and checkout modules.",
+          priority: "High",
+          status: "To Do",
+          labels: ["Release_1", "Sprint 1"],
+          components: ["UI", "Cloud"],
+          plannedStartDate: "10/May/2026 00:00",
+          plannedEndDate: "15/May/2026 00:00",
+        },
+        expectedOutput:
+          "Test cycle created with resolved priority, status, labels, and components",
+      },
+    ],
+    hints: [
+      "PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project.",
+      "If any priority, status, label, or component name cannot be resolved, the cycle is still created but a warning is returned. Suggest the closest available value from the set_project_context response and ask the user to confirm before retrying.",
+      "All cycles are placed in the 'MCP Generated' folder — do not pass folderId.",
+      "Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
+    ],
+    outputDescription:
+      "JSON object with the new test cycle's id and key (e.g. 'TRWT-TR-218'). Warnings included if any fields were skipped.",
+  };
+
+  // ─── Handle Implementation ──────────────────────────────────────────────────
+
+  handle = async (rawArgs: any) => {
+    const fieldResolver = this.client.getResolverRegistry();
+    const context = fieldResolver.requireProjectContext();
+
+    // Inject projectId and default folderId before resolution.
+    const body: Record<string, unknown> = {
+      ...(CreateTestCycleBody.parse(rawArgs) as Record<string, unknown>),
+      projectId: context.projectId,
+      folderId: "MCP Generated",
+    };
+    const warnings: string[] = [];
+
+    // Resolve all configured fields (priority, status, folderId, labels, components).
+    await Promise.all(
+      Object.entries(FIELD_CONFIG).map(([inputField, resolverKey]) =>
+        fieldResolver
+          .getResolver(resolverKey)
+          .resolve(inputField, resolverKey, body, context, warnings),
+      ),
+    );
+
+    const response = await this.client
+      .getApiClient()
+      .post(ENDPOINTS.CREATE_TEST_CYCLE, body);
+    const validated: CreateTestCycleResponseType =
+      CreateTestCycleResponse.parse(response);
+
+    return {
+      structuredContent: validated,
+      content:
+        warnings.length > 0
+          ? [{ type: "text" as const, text: `Note: ${warnings.join(" | ")}` }]
+          : [],
+    };
+  };
+}

--- a/src/qtm4j/tool/test-cycle/search-test-cycle.ts
+++ b/src/qtm4j/tool/test-cycle/search-test-cycle.ts
@@ -1,0 +1,168 @@
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { Qtm4jClient } from "../../client";
+import { ENDPOINTS, RESPONSE_FIELDS, TOOL_NAMES } from "../../config/constants";
+import {
+  SearchTestCycleBody,
+  SearchTestCycleResponse,
+  type SearchTestCycleResponseType,
+} from "../../schema/search-test-cycle.schema";
+
+/**
+ * SearchTestCycles Tool
+ *
+ * Searches and filters test cycles in a QTM4J project.
+ * Filter fields are sent in the POST body; pagination, sort, and field-selection
+ * are passed as URL query parameters — the same pattern as SearchTestCases.
+ */
+export class SearchTestCycles extends Tool<Qtm4jClient> {
+  specification: ToolParams = {
+    title: TOOL_NAMES.SEARCH_TEST_CYCLES.TITLE,
+    summary: TOOL_NAMES.SEARCH_TEST_CYCLES.SUMMARY,
+    readOnly: true,
+    idempotent: true,
+    inputSchema: SearchTestCycleBody,
+    outputSchema: SearchTestCycleResponse,
+    purpose:
+      "Search and filter test cycles in a QTM4J project. " +
+      "projectId is auto-injected from the active project context — do not provide it.",
+    useCases: [
+      "Find test cycles by status, priority, assignee, reporter, or folder",
+      "Find test cycles by planned execution date range (plannedStartDate / plannedEndDate)",
+      "Find test cycles created or updated within a date range (createdOn / updatedOn)",
+      "Search test cycles by keyword across key, summary, and description",
+      "Paginate, sort, and select specific response fields",
+    ],
+    examples: [
+      {
+        description: "Find all in-progress and to-do cycles",
+        parameters: { filter: { status: ["In Progress", "To Do"] } },
+        expectedOutput: "Paginated list of matching test cycles",
+      },
+      {
+        description: "Find cycles owned by a specific user",
+        parameters: { filter: { assignee: ["5b10a2844c20165700ede21f"] } },
+        expectedOutput: "Test cycles assigned to that user",
+      },
+      {
+        description:
+          "Find cycles with planned start date in a range, requesting date fields explicitly",
+        parameters: {
+          filter: { plannedStartDate: "01/Apr/2026,30/Apr/2026" },
+          fields: [
+            "key",
+            "summary",
+            "status",
+            "assignee",
+            "plannedStartDate",
+            "plannedEndDate",
+          ],
+        },
+        expectedOutput:
+          "Cycles with planned start date in April 2026 including date fields",
+      },
+      {
+        description:
+          "Keyword search with sort, pagination, and selected fields",
+        parameters: {
+          filter: { searchText: "regression" },
+          fields: ["key", "summary", "status", "assignee"],
+          sort: "plannedStartDate:asc",
+          startAt: 0,
+          maxResults: 25,
+        },
+        expectedOutput:
+          "Cycles matching 'regression', sorted by planned start date",
+      },
+      {
+        description: "Find cycles created last week",
+        parameters: {
+          filter: { createdOn: "01/May/2026,07/May/2026" },
+          fields: ["key", "summary", "status", "assignee"],
+          sort: "key:asc",
+        },
+        expectedOutput: "Test cycles created between 01 May and 07 May 2026",
+      },
+      {
+        description: "Find high-priority cycles updated recently by reporter",
+        parameters: {
+          filter: {
+            priority: ["High"],
+            reporter: ["5b10a2844c20165700ede21f"],
+            updatedOn: "01/May/2026,21/May/2026",
+          },
+          fields: ["key", "summary", "status", "priority", "assignee"],
+        },
+        expectedOutput:
+          "High-priority cycles updated in May 2026 reported by that user",
+      },
+      {
+        description: "All filters combined with explicit field selection",
+        parameters: {
+          filter: {
+            status: ["In Progress"],
+            priority: ["High", "Medium"],
+            assignee: ["5b10a2844c20165700ede21f"],
+            folderId: 109987,
+            plannedStartDate: "02/Apr/2026,15/May/2026",
+            searchText: "regression",
+          },
+          fields: [
+            "key",
+            "summary",
+            "status",
+            "priority",
+            "assignee",
+            "plannedStartDate",
+          ],
+          sort: "plannedStartDate:asc",
+          maxResults: 25,
+        },
+        expectedOutput:
+          "Test cycles matching all specified filters with selected fields",
+      },
+    ],
+    hints: [
+      "PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project.",
+      "SUPPORTED FILTER FIELDS: status, priority, assignee, reporter, folderId, labels, components, plannedStartDate, plannedEndDate, searchText, createdOn, updatedOn, isAutomated, aiGenerated. Do NOT use any other filter field names.",
+      "DATE FILTERS: createdOn = creation date; updatedOn = last-updated date; plannedStartDate / plannedEndDate = planned execution window. Format: 'dd/MMM/yyyy,dd/MMM/yyyy' e.g. '01/May/2026,21/May/2026'. Month is case-sensitive. 'Created last week' → createdOn, NOT plannedStartDate.",
+      "FIELDS: Pass as an array to select what to return. plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly. Available: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated.",
+      "REQUEST STRUCTURE: filter → request body; fields, sort, startAt, maxResults → URL query params.",
+      "SORT: Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Format: 'fieldName:asc' or 'fieldName:desc' e.g. 'plannedStartDate:asc'.",
+      "FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up.",
+    ],
+    outputDescription:
+      "JSON object with total (matching cycles across all pages), startAt, maxResults, and data (array of test cycle objects for this page). " +
+      "Each item always has id and key. Other fields depend on what was requested via the fields parameter.",
+  };
+
+  handle = async (rawArgs: any) => {
+    const args = SearchTestCycleBody.parse(rawArgs);
+    const context = this.client.getResolverRegistry().requireProjectContext();
+
+    // Inject projectId into the filter body — never exposed to the LLM.
+    if (!args.filter) args.filter = {};
+    args.filter.projectId = context.projectId;
+
+    // Pagination, sort, and field selection are URL query params, not body fields.
+    const params = new URLSearchParams();
+    if (args.fields?.length)
+      params.set(RESPONSE_FIELDS.FIELDS, args.fields.join(","));
+    params.set(RESPONSE_FIELDS.START_AT, String(args.startAt));
+    params.set(RESPONSE_FIELDS.MAX_RESULTS, String(args.maxResults));
+    params.set(RESPONSE_FIELDS.SORT, args.sort);
+
+    const endpoint = `${ENDPOINTS.SEARCH_TEST_CYCLES}?${params.toString()}`;
+    const response = await this.client
+      .getApiClient()
+      .post(endpoint, { filter: args.filter });
+
+    const validated: SearchTestCycleResponseType =
+      SearchTestCycleResponse.parse(response);
+
+    return {
+      structuredContent: validated,
+      content: [],
+    };
+  };
+}

--- a/src/qtm4j/tool/test-cycle/update-test-cycle.ts
+++ b/src/qtm4j/tool/test-cycle/update-test-cycle.ts
@@ -1,0 +1,228 @@
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { Qtm4jClient } from "../../client";
+import { ENDPOINTS, TOOL_NAMES } from "../../config/constants";
+import {
+  InputField,
+  type ProjectContext,
+  ResolverKeys,
+} from "../../config/field-resolution.types";
+import type { Resolver } from "../../resolver/resolvers/resolver.ts";
+import {
+  UpdateTestCycleBody,
+  UpdateTestCycleResponse,
+} from "../../schema/update-test-cycle.schema";
+
+// Scalar fields resolved from human-readable name → numeric ID.
+const SIMPLE_FIELD_CONFIG: Record<string, string> = {
+  [InputField.PRIORITY]: ResolverKeys.CommonAttribute.PRIORITY,
+  [InputField.STATUS]: ResolverKeys.CommonAttribute.TEST_CYCLE_STATUS,
+};
+
+// Add/delete metadata fields resolved from name arrays → ID arrays.
+const ADD_DELETE_FIELD_CONFIG: Record<string, string> = {
+  [InputField.LABELS]: ResolverKeys.SearchableField.LABEL,
+  [InputField.COMPONENTS]: ResolverKeys.SearchableField.COMPONENTS,
+};
+
+/**
+ * Resolves a { add? delete? } object of name strings to { add? delete? } of
+ * numeric IDs. Names that cannot be resolved are skipped with a warning.
+ */
+async function resolveAddDelete(
+  resolver: Resolver,
+  inputField: string,
+  resolverKey: string,
+  field: { add?: string[]; delete?: string[] },
+  context: ProjectContext,
+  warnings: string[],
+): Promise<{ add?: number[]; delete?: number[] }> {
+  const result: { add?: number[]; delete?: number[] } = {};
+
+  for (const op of ["add", "delete"] as const) {
+    const names = field[op];
+    if (!names?.length) continue;
+
+    const tempBody: Record<string, unknown> = { [inputField]: names };
+    await resolver.resolve(
+      inputField,
+      resolverKey,
+      tempBody,
+      context,
+      warnings,
+    );
+
+    const val = tempBody[inputField];
+    if (Array.isArray(val) && val.length > 0 && typeof val[0] === "number") {
+      result[op] = val as number[];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * UpdateTestCycle Tool
+ *
+ * Updates an existing test cycle via PUT /testcycles/{key}.
+ * The human-readable key (e.g. 'SCRUM-TR-101') is used directly as the path param —
+ * no UID resolution step is required for test cycles.
+ * Only the fields provided in the request are changed; omitted fields remain as-is.
+ * Resolves human-readable names to IDs for priority and status.
+ * Labels and components use the add/delete pattern to atomically add or remove entries.
+ * Nullable fields (description, assignee, reporter, plannedStartDate, plannedEndDate)
+ * accept explicit null to clear the value on the server.
+ */
+export class UpdateTestCycle extends Tool<Qtm4jClient> {
+  specification: ToolParams = {
+    title: TOOL_NAMES.UPDATE_TEST_CYCLE.TITLE,
+    summary: TOOL_NAMES.UPDATE_TEST_CYCLE.SUMMARY,
+    readOnly: false,
+    idempotent: true,
+    inputSchema: UpdateTestCycleBody,
+    outputSchema: UpdateTestCycleResponse,
+    purpose:
+      "Update an existing test cycle in QTM4J by its human-readable key (e.g. 'SCRUM-TR-101'). " +
+      "Only provided fields are changed — omitted fields stay unchanged. " +
+      "Status and priority are auto-resolved from human-readable names. " +
+      "Labels and components use add/delete objects.",
+    useCases: [
+      "Update summary, status, priority, planned dates, assignee, or reporter",
+      "Clear a nullable field by passing null (e.g. description: null removes text, assignee: null unassigns owner)",
+      "Add or remove labels and components atomically without affecting other entries",
+      "Apply multiple field updates in a single call",
+    ],
+    examples: [
+      {
+        description: "Rename a test cycle",
+        parameters: {
+          key: "SCRUM-TR-101",
+          summary: "Regression Cycle - Sprint 12 Updated",
+        },
+        expectedOutput: "Test cycle updated with new summary",
+      },
+      {
+        description: "Change status and update planned dates",
+        parameters: {
+          key: "SCRUM-TR-101",
+          status: "In Progress",
+          plannedStartDate: "01/May/2026 09:00",
+          plannedEndDate: "31/May/2026 18:00",
+        },
+        expectedOutput: "Test cycle status and planned dates updated",
+      },
+      {
+        description: "Add a label and remove an old one",
+        parameters: {
+          key: "SCRUM-TR-101",
+          labels: { add: ["Regression", "Smoke"], delete: ["Sprint1"] },
+        },
+        expectedOutput:
+          "Test cycle updated — Regression and Smoke labels added, Sprint1 removed",
+      },
+      {
+        description: "Clear the description text",
+        parameters: {
+          key: "SCRUM-TR-101",
+          description: null,
+        },
+        expectedOutput: "Test cycle description cleared",
+      },
+      {
+        description: "Unassign the owner and clear planned dates",
+        parameters: {
+          key: "SCRUM-TR-101",
+          assignee: null,
+          plannedStartDate: null,
+          plannedEndDate: null,
+        },
+        expectedOutput: "Test cycle owner unassigned and planned dates cleared",
+      },
+      {
+        description: "Full update with all fields",
+        parameters: {
+          key: "SCRUM-TR-101",
+          summary: "Final Regression Cycle",
+          description: "Updated for sprint 12.",
+          status: "In Progress",
+          priority: "High",
+          plannedStartDate: "15/May/2026 09:00",
+          plannedEndDate: "30/May/2026 18:00",
+          assignee: "5b10a2844c20165700ede21f",
+          labels: { add: ["Regression"], delete: ["Sprint1"] },
+          components: { add: ["Backend"], delete: ["Frontend"] },
+        },
+        expectedOutput: "Test cycle updated with all specified fields",
+      },
+    ],
+    hints: [
+      "PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project.",
+      "KEY FORMAT: '{PROJECT_KEY}-TR-{number}' — e.g. 'SCRUM-TR-101'.",
+      "Pass explicit null to CLEAR a nullable field — e.g. description: null removes the description text, assignee: null unassigns the owner, plannedStartDate: null removes the date. Omitting a field leaves it unchanged.",
+      "Status and priority are auto-resolved from human-readable names loaded by set_project_context. If a name cannot be resolved, the cycle is still updated and a warning is returned.",
+      "Labels and components use add/delete — names are auto-resolved to IDs. Both operations can be combined in a single call.",
+      "Date format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may or MAY).",
+      "Archived test cycles cannot be updated — the server returns 400. Unarchive first if needed.",
+    ],
+    outputDescription:
+      "Confirmation object with the test cycle key and updated: true. Warnings are included if any field names could not be resolved.",
+  };
+
+  handle = async (rawArgs: any) => {
+    const args = UpdateTestCycleBody.parse(rawArgs);
+    const fieldResolver = this.client.getResolverRegistry();
+    const context = fieldResolver.requireProjectContext();
+    const warnings: string[] = [];
+
+    // Separate path param (key) and add/delete fields from scalar body fields.
+    // undefined values are stripped automatically by JSON.stringify before the request.
+    const { key: _key, labels, components, ...scalarArgs } = args;
+    const body: Record<string, unknown> = { ...scalarArgs };
+
+    // Resolve scalar names (status, priority) → numeric IDs.
+    // Null values pass through untouched (resolver skips non-string values).
+    await Promise.all(
+      Object.entries(SIMPLE_FIELD_CONFIG).map(([inputField, resolverKey]) =>
+        fieldResolver
+          .getResolver(resolverKey)
+          .resolve(inputField, resolverKey, body, context, warnings),
+      ),
+    );
+
+    // Resolve add/delete metadata fields (labels, components).
+    for (const [inputField, resolverKey] of Object.entries(
+      ADD_DELETE_FIELD_CONFIG,
+    )) {
+      const field = args[inputField as keyof typeof args] as
+        | { add?: string[]; delete?: string[] }
+        | undefined;
+      if (!field) continue;
+
+      const resolvedField = await resolveAddDelete(
+        fieldResolver.getResolver(resolverKey),
+        inputField,
+        resolverKey,
+        field,
+        context,
+        warnings,
+      );
+      if (Object.keys(resolvedField).length > 0)
+        body[inputField] = resolvedField;
+    }
+
+    await this.client
+      .getApiClient()
+      .put(ENDPOINTS.UPDATE_TEST_CYCLE(args.key), body);
+
+    return {
+      structuredContent: UpdateTestCycleResponse.parse({
+        key: args.key,
+        updated: true,
+      }),
+      content:
+        warnings.length > 0
+          ? [{ type: "text" as const, text: `Note: ${warnings.join(" | ")}` }]
+          : [],
+    };
+  };
+}

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -7411,6 +7411,68 @@ Expected Output: Test cycle created with resolved priority, status, labels, and 
     ],
     "title": "QTM4J: Create Test Cycle",
   },
+  "qtm4j_get_automation_history": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QTM4J: Get Automation History",
+    },
+    "description": "Retrieve a paginated history of past automation result uploads for a QTM4J project. Supports filtering by test cycle, source label, date range, uploader, and status.
+
+**Parameters:**
+- startAt (number): Zero-indexed starting position for pagination (default: 0). (default: 0)
+- maxResults (number): Maximum number of records to return per page (default: 20, max: 100). (default: 20)
+
+**Output Description:** Paginated list of automation import history. Each record includes: format, processStatus, importStatus, startTime, endTime, trackingId, detailedMessage, and a summary array. summary[0] contains: testCycleIssueKey, testCycleSummary, testCasesCreated, testCaseVersionsCreated, testCaseVersionsReused, testStepsCreated. Render as individual cards separated by dividers, NOT a table. Show '1–N of total' count above. Never show raw fileName.
+
+**Use Cases:** 1. Review past automation result uploads for a project 2. Check the status of recent automation imports 3. Audit CI/CD automation upload history 4. Paginate through all historical automation uploads
+
+**Examples:**
+1. Get the first page of automation upload history (default page size 20)
+\`\`\`json
+{}
+\`\`\`
+Expected Output: Paginated list of automation history records with upload status and metadata
+
+2. Get the second page of automation upload history
+\`\`\`json
+{
+  "startAt": 20,
+  "maxResults": 20
+}
+\`\`\`
+Expected Output: Next 20 automation history records
+
+3. Get up to 50 records starting from the beginning
+\`\`\`json
+{
+  "startAt": 0,
+  "maxResults": 50
+}
+\`\`\`
+Expected Output: Up to 50 automation history records
+
+**Hints:** 1. NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently. 2. PAGINATION: startAt is zero-indexed (default: 0), maxResults controls page size (default: 20, max: 100). Increment startAt by maxResults to fetch the next page. 3. Returns an empty data array (not an error) when no history records exist. 4. DISPLAY FORMAT: Show '1–N of <total>' above all cards. Render each record as a card separated by --- dividers. Each card has two sections:
+
+PRIMARY SECTION (always first): heading with status emoji (✅ SUCCESS / ❌ FAILED) + test cycle key and name; then format, start→end time, message, summary stats (test cases/versions created/reused/test steps), tracking ID.
+
+EXTRA DETAILS SECTION (at the bottom of the card, under a 'Details' sub-label): any remaining non-null fields from the record such as fileSize, extraAttributes values, etc.
+
+Skip any field that is null, missing, or false. NEVER show the raw fileName. NEVER use a table.",
+    "inputSchema": [
+      "maxResults",
+      "startAt",
+    ],
+    "outputSchema": [
+      "data",
+      "maxResults",
+      "startAt",
+      "total",
+    ],
+    "title": "QTM4J: Get Automation History",
+  },
   "qtm4j_get_projects": {
     "annotations": {
       "destructiveHint": false,
@@ -8404,6 +8466,94 @@ Expected Output: Test cycle updated with all specified fields
       "updated",
     ],
     "title": "QTM4J: Update Test Cycle",
+  },
+  "qtm4j_upload_automation_result": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QTM4J: Upload Automation Result",
+    },
+    "description": "Upload an automation result file to QTM4J and map the results to a test cycle. Supports JUnit XML, TestNG XML, Cucumber JSON, QAF, HP UFT, and SpecFlow formats.
+
+**Parameters:**
+- filePath (string) *required*: Absolute or relative path to the automation result file on disk (e.g. './target/surefire-reports/TEST-results.xml'). Supported extensions: .xml, .json, .zip
+- format (enum) *required*: Format of the result file. Supported values: cucumber, testng, junit, qaf, hpuft, specflow
+- testCycleToReuse (string): Work key of an existing test cycle to reuse (e.g. 'TR-PRJ-1'). If omitted, a new test cycle is created.
+- environment (string): Name of the environment on which the test cycle was executed (e.g. 'Chrome', 'Staging'). Defaults to 'No Environment'.
+- build (string): Build name or version for the test cycle execution (e.g. '1.0.0-beta'). Defaults to blank.
+- isZip (boolean): Set to true when uploading a ZIP archive containing result files. Required for QAF format. (default: false)
+- attachFile (boolean): Set to true to upload attachments referenced in execution results. (default: false)
+- matchTestSteps (boolean): true — match test cases by summary AND test steps. false — match by summary or key only. (default: true)
+- appendTestName (boolean): Applicable to JUnit/TestNG only. Appends suite/test name to method name in test case summary.
+- fields (object): Additional fields to set on the test cycle, test case, and/or test case execution created during import.
+
+**Output Description:** trackingId to poll import status, a message from the API, the filePath uploaded, and the format used.
+
+**Use Cases:** 1. Upload automation results to QTM4J 2. Import test results from a CI/CD pipeline run 3. Link test results to an existing test cycle 4. Create a new test cycle from automation results 5. Upload JUnit, TestNG, Cucumber, QAF, HP UFT, or SpecFlow result files
+
+**Examples:**
+1. User says 'upload my test results to QTM4J' — scan workspace, find single result file, confirm and upload
+\`\`\`json
+{
+  "filePath": "./target/surefire-reports/TEST-results.xml",
+  "format": "junit"
+}
+\`\`\`
+Expected Output: trackingId returned; import processing started in QTM4J
+
+2. User wants results linked to an existing test cycle
+\`\`\`json
+{
+  "filePath": "./reports/cucumber.json",
+  "format": "cucumber",
+  "testCycleToReuse": "TR-PRJ-5",
+  "environment": "Chrome",
+  "build": "2.1.0"
+}
+\`\`\`
+Expected Output: Results mapped to test cycle TR-PRJ-5
+
+3. Upload QAF ZIP and set test cycle metadata
+\`\`\`json
+{
+  "filePath": "./results/qaf-results.zip",
+  "format": "qaf",
+  "isZip": true,
+  "fields": {
+    "testCycle": {
+      "summary": "Regression Run 2024-Q1",
+      "labels": [
+        "regression"
+      ],
+      "priority": "High"
+    }
+  }
+}
+\`\`\`
+Expected Output: ZIP uploaded; test cycle created with summary, labels, and priority
+
+**Hints:** 1. NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently — never prompt the user for project information. 2. FILE DISCOVERY: Always do a fresh scan — never reuse a path from a previous turn. If no path is provided, search in order: target/surefire-reports, target/failsafe-reports, build/reports/tests, build/test-results, test-results, reports, cucumber-reports. If multiple files are found, list them all and wait for the user to pick one before uploading. If nothing is found, ask for the path. Never pick silently. 3. FORMAT INFERENCE: .json → cucumber, .zip → qaf (unambiguous). For .xml, infer from the file name — 'junit'/'surefire' → junit, 'testng' → testng, 'specflow' → specflow, 'hpuft'/'uft' → hpuft. If the file name gives no clear signal, ask the user to confirm the format. 4. TEST CYCLE: Only ask for testCycleToReuse if the user explicitly wants to link to an existing cycle. If not mentioned, omit it — QTM4J creates a new test cycle automatically. 5. DATE FORMAT: plannedStartDate and plannedEndDate in fields.testCycle MUST be formatted as 'dd/MMM/yyyy HH:mm' (e.g. '14/May/2026 10:30'). Convert any user-provided date (ISO, natural language, relative) to this exact format before sending. 6. FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up. 7. ASSIGNEE / REPORTER: assignee and reporter in fields.testCycle and fields.testCase require a Jira Account ID (not a display name or email). Ask the user to provide their Account ID directly. 8. Import processing is asynchronous — use the returned trackingId to poll progress.",
+    "inputSchema": [
+      "appendTestName",
+      "attachFile",
+      "build",
+      "environment",
+      "fields",
+      "filePath",
+      "format",
+      "isZip",
+      "matchTestSteps",
+      "testCycleToReuse",
+    ],
+    "outputSchema": [
+      "filePath",
+      "format",
+      "message",
+      "trackingId",
+    ],
+    "title": "QTM4J: Upload Automation Result",
   },
   "reflect_add_prompt_step": {
     "annotations": {

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -7336,6 +7336,81 @@ Expected Output: Test case created with resolved labels/components/priority/stat
     ],
     "title": "QTM4J: Create Test Case",
   },
+  "qtm4j_create_test_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QTM4J: Create Test Cycle",
+    },
+    "description": "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Always creates in the 'MCP Generated' folder. projectId is injected automatically from the active project context.
+
+**Parameters:**
+- summary (string) *required*: Short title of the test cycle. Must not be blank. Max 255 chars.
+- description (string): Detailed description of the test cycle. Max 65 535 characters.
+- priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID via set_project_context.
+- status (string): Status name (e.g., 'To Do', 'In Progress'). Auto-resolved to ID via set_project_context.
+- assignee (string): Assignee account ID
+- reporter (string): Jira account UUID of the reporter. Default: the calling user.
+- labels (array): List of label names (e.g., ['Release_1', 'Sprint 1']). Auto-resolved to IDs.
+- components (array): List of component names (e.g., ['UI', 'Cloud']). Auto-resolved to IDs.
+- plannedStartDate (string): Planned start date. Format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Must be ≤ plannedEndDate when both are provided.
+- plannedEndDate (string): Planned end date. Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 00:00'. Must be ≥ plannedStartDate when both are provided.
+
+**Output Description:** JSON object with the new test cycle's id and key (e.g. 'TRWT-TR-218'). Warnings included if any fields were skipped.
+
+**Use Cases:** 1. Create a test cycle with summary, priority, status, labels, or components 2. Set planned start and end dates on a new test cycle
+
+**Examples:**
+1. Create a simple test cycle (project must be set via set_project_context first)
+\`\`\`json
+{
+  "summary": "Smoke Test Cycle"
+}
+\`\`\`
+Expected Output: Test cycle created with key 'SCRUM-TR-xxx'
+
+2. Create a test cycle with priority, status, labels, and components
+\`\`\`json
+{
+  "summary": "Regression Suite – Sprint 42",
+  "description": "End-to-end regression covering payment and checkout modules.",
+  "priority": "High",
+  "status": "To Do",
+  "labels": [
+    "Release_1",
+    "Sprint 1"
+  ],
+  "components": [
+    "UI",
+    "Cloud"
+  ],
+  "plannedStartDate": "10/May/2026 00:00",
+  "plannedEndDate": "15/May/2026 00:00"
+}
+\`\`\`
+Expected Output: Test cycle created with resolved priority, status, labels, and components
+
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. Priority and status are resolved from names loaded by set_project_context. Unresolvable names are skipped with a warning; the cycle is still created. 3. Labels and components are resolved on demand. Unresolvable names are skipped with a warning. 4. All cycles are placed in the 'MCP Generated' folder — do not pass folderId. 5. Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
+    "inputSchema": [
+      "assignee",
+      "components",
+      "description",
+      "labels",
+      "plannedEndDate",
+      "plannedStartDate",
+      "priority",
+      "reporter",
+      "status",
+      "summary",
+    ],
+    "outputSchema": [
+      "id",
+      "key",
+    ],
+    "title": "QTM4J: Create Test Cycle",
+  },
   "qtm4j_get_projects": {
     "annotations": {
       "destructiveHint": false,
@@ -7875,6 +7950,178 @@ Expected Output: Test cases executed in the past week with their pass rates and 
     ],
     "title": "QTM4J: Search Test Cases",
   },
+  "qtm4j_search_test_cycles": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "QTM4J: Search Test Cycles",
+    },
+    "description": "Search for test cycles in a QTM4J project by status, owner, folder, date range, or keyword. projectId is injected automatically from the active project context.
+
+**Parameters:**
+- filter (object): Filter criteria — fields are combined with AND; multiple values within one field use OR.
+- fields (array): Fields to include in each result object. If omitted, server returns its default set (NOTE: plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly when needed). Available fields: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated. Example: ['key', 'summary', 'status', 'assignee', 'plannedStartDate', 'plannedEndDate']
+- startAt (number): Zero-based page offset. Default: 0. (default: 0)
+- maxResults (number): Results per page. Default: 20. Maximum: 100. (default: 20)
+- sort (string): Sort expression. Format: '<fieldName>:<asc|desc>'. Default: 'key:asc'. Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Example: 'plannedStartDate:asc' (default: "key:asc")
+
+**Output Description:** JSON object with total (matching cycles across all pages), startAt, maxResults, and data (array of test cycle objects for this page). Each item always has id and key. Other fields depend on what was requested via the fields parameter.
+
+**Use Cases:** 1. Find test cycles by status, priority, assignee, reporter, or folder 2. Find test cycles by planned execution date range (plannedStartDate / plannedEndDate) 3. Find test cycles created or updated within a date range (createdOn / updatedOn) 4. Search test cycles by keyword across key, summary, and description 5. Paginate, sort, and select specific response fields
+
+**Examples:**
+1. Find all in-progress and to-do cycles
+\`\`\`json
+{
+  "filter": {
+    "status": [
+      "In Progress",
+      "To Do"
+    ]
+  }
+}
+\`\`\`
+Expected Output: Paginated list of matching test cycles
+
+2. Find cycles owned by a specific user
+\`\`\`json
+{
+  "filter": {
+    "assignee": [
+      "5b10a2844c20165700ede21f"
+    ]
+  }
+}
+\`\`\`
+Expected Output: Test cycles assigned to that user
+
+3. Find cycles with planned start date in a range, requesting date fields explicitly
+\`\`\`json
+{
+  "filter": {
+    "plannedStartDate": "01/Apr/2026,30/Apr/2026"
+  },
+  "fields": [
+    "key",
+    "summary",
+    "status",
+    "assignee",
+    "plannedStartDate",
+    "plannedEndDate"
+  ]
+}
+\`\`\`
+Expected Output: Cycles with planned start date in April 2026 including date fields
+
+4. Keyword search with sort, pagination, and selected fields
+\`\`\`json
+{
+  "filter": {
+    "searchText": "regression"
+  },
+  "fields": [
+    "key",
+    "summary",
+    "status",
+    "assignee"
+  ],
+  "sort": "plannedStartDate:asc",
+  "startAt": 0,
+  "maxResults": 25
+}
+\`\`\`
+Expected Output: Cycles matching 'regression', sorted by planned start date
+
+5. Find cycles created last week
+\`\`\`json
+{
+  "filter": {
+    "createdOn": "01/May/2026,07/May/2026"
+  },
+  "fields": [
+    "key",
+    "summary",
+    "status",
+    "assignee"
+  ],
+  "sort": "key:asc"
+}
+\`\`\`
+Expected Output: Test cycles created between 01 May and 07 May 2026
+
+6. Find high-priority cycles updated recently by reporter
+\`\`\`json
+{
+  "filter": {
+    "priority": [
+      "High"
+    ],
+    "reporter": [
+      "5b10a2844c20165700ede21f"
+    ],
+    "updatedOn": "01/May/2026,21/May/2026"
+  },
+  "fields": [
+    "key",
+    "summary",
+    "status",
+    "priority",
+    "assignee"
+  ]
+}
+\`\`\`
+Expected Output: High-priority cycles updated in May 2026 reported by that user
+
+7. All filters combined with explicit field selection
+\`\`\`json
+{
+  "filter": {
+    "status": [
+      "In Progress"
+    ],
+    "priority": [
+      "High",
+      "Medium"
+    ],
+    "assignee": [
+      "5b10a2844c20165700ede21f"
+    ],
+    "folderId": 109987,
+    "plannedStartDate": "02/Apr/2026,15/May/2026",
+    "searchText": "regression"
+  },
+  "fields": [
+    "key",
+    "summary",
+    "status",
+    "priority",
+    "assignee",
+    "plannedStartDate"
+  ],
+  "sort": "plannedStartDate:asc",
+  "maxResults": 25
+}
+\`\`\`
+Expected Output: Test cycles matching all specified filters with selected fields
+
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. SUPPORTED FILTER FIELDS: status, priority, assignee, reporter, folderId, labels, components, plannedStartDate, plannedEndDate, searchText, createdOn, updatedOn, isAutomated, aiGenerated. Do NOT use any other filter field names. 3. DATE FILTERS: createdOn = creation date; updatedOn = last-updated date; plannedStartDate / plannedEndDate = planned execution window. Format: 'dd/MMM/yyyy,dd/MMM/yyyy' e.g. '01/May/2026,21/May/2026'. Month is case-sensitive. 'Created last week' → createdOn, NOT plannedStartDate. 4. FIELDS: Pass as an array to select what to return. plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly. Available: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated. 5. REQUEST STRUCTURE: filter → request body; fields, sort, startAt, maxResults → URL query params. 6. SORT: Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Format: '<field>:<asc|desc>'. created and updated are NOT valid sort fields. 7. FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up.",
+    "inputSchema": [
+      "fields",
+      "filter",
+      "maxResults",
+      "sort",
+      "startAt",
+    ],
+    "outputSchema": [
+      "data",
+      "maxResults",
+      "startAt",
+      "total",
+    ],
+    "title": "QTM4J: Search Test Cycles",
+  },
   "qtm4j_set_project_context": {
     "annotations": {
       "destructiveHint": false,
@@ -8021,6 +8268,142 @@ Expected Output: Version 2 of test case updated with new assignee and estimated 
       "versionNo",
     ],
     "title": "QTM4J: Update Test Case",
+  },
+  "qtm4j_update_test_cycle": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "QTM4J: Update Test Cycle",
+    },
+    "description": "Update an existing test cycle in QTM4J by its human-readable key (e.g. 'SCRUM-TR-101'). Supports auto-resolving human-readable names for status and priority. Labels and components support add/delete operations. Only the fields you provide are changed — omitted fields are left as-is. projectId is injected automatically from the active project context.
+
+**Parameters:**
+- key (string) *required*: Test cycle key in the format '{PROJECT_KEY}-TR-{number}', e.g. 'SCRUM-TR-101'. Used directly as the API path parameter.
+- summary (string): Updated test cycle name / title. Max 255 characters.
+- description (string): Updated description. Pass null to clear the existing value. Max 65 535 characters.
+- status (string): Status name (e.g., 'To Do', 'In Progress'). Auto-resolved to ID. Pass null to clear.
+- priority (string): Priority name (e.g., 'High', 'Medium'). Auto-resolved to ID. Pass null to reset to project default.
+- plannedStartDate (string): Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may). Pass null to clear the existing value.
+- plannedEndDate (string): Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may). Pass null to clear the existing value.
+- assignee (string): Assignee Jira account ID (e.g., '5b10a2844c20165700ede21f'). Pass null to unassign.
+- reporter (string): Reporter Jira account ID (e.g., '5b10a2844c20165700ede21f'). Pass null to clear.
+- labels (object): Labels to add or remove by name. Each name is auto-resolved to its ID.
+- components (object): Components to add or remove by name. Each name is auto-resolved to its ID.
+
+**Output Description:** Confirmation object with the test cycle UID, key, and updated: true. Warnings are included if any field names could not be resolved.
+
+**Use Cases:** 1. Update summary, status, priority, planned dates, assignee, or reporter 2. Clear a nullable field by passing null (e.g. description: null removes text, assignee: null unassigns owner) 3. Add or remove labels and components atomically without affecting other entries 4. Apply multiple field updates in a single call
+
+**Examples:**
+1. Rename a test cycle
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "summary": "Regression Cycle - Sprint 12 Updated"
+}
+\`\`\`
+Expected Output: Test cycle updated with new summary
+
+2. Change status and update planned dates
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "status": "In Progress",
+  "plannedStartDate": "01/May/2026 09:00",
+  "plannedEndDate": "31/May/2026 18:00"
+}
+\`\`\`
+Expected Output: Test cycle status and planned dates updated
+
+3. Add a label and remove an old one
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "labels": {
+    "add": [
+      "Regression",
+      "Smoke"
+    ],
+    "delete": [
+      "Sprint1"
+    ]
+  }
+}
+\`\`\`
+Expected Output: Test cycle updated — Regression and Smoke labels added, Sprint1 removed
+
+4. Clear the description text
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "description": null
+}
+\`\`\`
+Expected Output: Test cycle description cleared
+
+5. Unassign the owner and clear planned dates
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "assignee": null,
+  "plannedStartDate": null,
+  "plannedEndDate": null
+}
+\`\`\`
+Expected Output: Test cycle owner unassigned and planned dates cleared
+
+6. Full update with all fields
+\`\`\`json
+{
+  "key": "SCRUM-TR-101",
+  "summary": "Final Regression Cycle",
+  "description": "Updated for sprint 12.",
+  "status": "In Progress",
+  "priority": "High",
+  "plannedStartDate": "15/May/2026 09:00",
+  "plannedEndDate": "30/May/2026 18:00",
+  "assignee": "5b10a2844c20165700ede21f",
+  "labels": {
+    "add": [
+      "Regression"
+    ],
+    "delete": [
+      "Sprint1"
+    ]
+  },
+  "components": {
+    "add": [
+      "Backend"
+    ],
+    "delete": [
+      "Frontend"
+    ]
+  }
+}
+\`\`\`
+Expected Output: Test cycle updated with all specified fields
+
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. KEY FORMAT: '{PROJECT_KEY}-TR-{number}' — e.g. 'SCRUM-TR-101'. 3. Pass explicit null to CLEAR a nullable field — e.g. description: null removes the description text, assignee: null unassigns the owner, plannedStartDate: null removes the date. Omitting a field leaves it unchanged. 4. Status and priority are auto-resolved from human-readable names loaded by set_project_context. Unresolvable names are skipped with a warning; remaining fields still update. 5. Labels and components use add/delete — names are auto-resolved to IDs. Both operations can be combined in a single call. 6. Date format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may or MAY). 7. Archived test cycles cannot be updated — the server returns 400. Unarchive first if needed.",
+    "inputSchema": [
+      "assignee",
+      "components",
+      "description",
+      "key",
+      "labels",
+      "plannedEndDate",
+      "plannedStartDate",
+      "priority",
+      "reporter",
+      "status",
+      "summary",
+    ],
+    "outputSchema": [
+      "key",
+      "updated",
+    ],
+    "title": "QTM4J: Update Test Cycle",
   },
   "reflect_add_prompt_step": {
     "annotations": {

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -7349,10 +7349,10 @@ Expected Output: Test case created with resolved labels/components/priority/stat
 **Parameters:**
 - summary (string) *required*: Short title of the test cycle. Must not be blank. Max 255 chars.
 - description (string): Detailed description of the test cycle. Max 65 535 characters.
-- priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID via set_project_context.
-- status (string): Status name (e.g., 'To Do', 'In Progress'). Auto-resolved to ID via set_project_context.
+- priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID.
+- status (string): Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID.
 - assignee (string): Assignee account ID
-- reporter (string): Jira account UUID of the reporter. Default: the calling user.
+- reporter (string): Reporter account ID
 - labels (array): List of label names (e.g., ['Release_1', 'Sprint 1']). Auto-resolved to IDs.
 - components (array): List of component names (e.g., ['UI', 'Cloud']). Auto-resolved to IDs.
 - plannedStartDate (string): Planned start date. Format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Must be ≤ plannedEndDate when both are provided.
@@ -7392,7 +7392,7 @@ Expected Output: Test cycle created with key 'SCRUM-TR-xxx'
 \`\`\`
 Expected Output: Test cycle created with resolved priority, status, labels, and components
 
-**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. Priority and status are resolved from names loaded by set_project_context. Unresolvable names are skipped with a warning; the cycle is still created. 3. Labels and components are resolved on demand. Unresolvable names are skipped with a warning. 4. All cycles are placed in the 'MCP Generated' folder — do not pass folderId. 5. Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. If any priority, status, label, or component name cannot be resolved, the cycle is still created but a warning is returned. Suggest the closest available value from the set_project_context response and ask the user to confirm before retrying. 3. All cycles are placed in the 'MCP Generated' folder — do not pass folderId. 4. Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
     "inputSchema": [
       "assignee",
       "components",
@@ -7419,7 +7419,7 @@ Expected Output: Test cycle created with resolved priority, status, labels, and 
       "readOnlyHint": true,
       "title": "QTM4J: Get Automation History",
     },
-    "description": "Retrieve a paginated history of past automation result uploads for a QTM4J project. Supports filtering by test cycle, source label, date range, uploader, and status.
+    "description": "Retrieve a paginated history of past automation result uploads for a QTM4J project.
 
 **Parameters:**
 - startAt (number): Zero-indexed starting position for pagination (default: 0). (default: 0)
@@ -8023,11 +8023,11 @@ Expected Output: Test cases executed in the past week with their pass rates and 
     "description": "Search for test cycles in a QTM4J project by status, owner, folder, date range, or keyword. projectId is injected automatically from the active project context.
 
 **Parameters:**
-- filter (object): Filter criteria — fields are combined with AND; multiple values within one field use OR.
+- filter (object): Filter criteria — multiple fields are combined with AND; multiple values within one field use OR.
 - fields (array): Fields to include in each result object. If omitted, server returns its default set (NOTE: plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly when needed). Available fields: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated. Example: ['key', 'summary', 'status', 'assignee', 'plannedStartDate', 'plannedEndDate']
-- startAt (number): Zero-based page offset. Default: 0. (default: 0)
-- maxResults (number): Results per page. Default: 20. Maximum: 100. (default: 20)
-- sort (string): Sort expression. Format: '<fieldName>:<asc|desc>'. Default: 'key:asc'. Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Example: 'plannedStartDate:asc' (default: "key:asc")
+- startAt (number): Zero-indexed offset for pagination (URL query param). Default: 0. (default: 0)
+- maxResults (number): Number of results per page (URL query param). Default: 20. Maximum: 100. To page through results, increment startAt by 20 until startAt >= total. (default: 20)
+- sort (string): Sort pattern sent as a URL query param. Format: 'fieldName:order'. Default: 'key:asc'. Order values: 'asc' (lowest/oldest first) or 'desc' (highest/newest first). Sortable fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Examples: 'key:asc', 'plannedStartDate:desc' (default: "key:asc")
 
 **Output Description:** JSON object with total (matching cycles across all pages), startAt, maxResults, and data (array of test cycle objects for this page). Each item always has id and key. Other fields depend on what was requested via the fields parameter.
 
@@ -8168,7 +8168,7 @@ Expected Output: High-priority cycles updated in May 2026 reported by that user
 \`\`\`
 Expected Output: Test cycles matching all specified filters with selected fields
 
-**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. SUPPORTED FILTER FIELDS: status, priority, assignee, reporter, folderId, labels, components, plannedStartDate, plannedEndDate, searchText, createdOn, updatedOn, isAutomated, aiGenerated. Do NOT use any other filter field names. 3. DATE FILTERS: createdOn = creation date; updatedOn = last-updated date; plannedStartDate / plannedEndDate = planned execution window. Format: 'dd/MMM/yyyy,dd/MMM/yyyy' e.g. '01/May/2026,21/May/2026'. Month is case-sensitive. 'Created last week' → createdOn, NOT plannedStartDate. 4. FIELDS: Pass as an array to select what to return. plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly. Available: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated. 5. REQUEST STRUCTURE: filter → request body; fields, sort, startAt, maxResults → URL query params. 6. SORT: Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Format: '<field>:<asc|desc>'. created and updated are NOT valid sort fields. 7. FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up.",
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. SUPPORTED FILTER FIELDS: status, priority, assignee, reporter, folderId, labels, components, plannedStartDate, plannedEndDate, searchText, createdOn, updatedOn, isAutomated, aiGenerated. Do NOT use any other filter field names. 3. DATE FILTERS: createdOn = creation date; updatedOn = last-updated date; plannedStartDate / plannedEndDate = planned execution window. Format: 'dd/MMM/yyyy,dd/MMM/yyyy' e.g. '01/May/2026,21/May/2026'. Month is case-sensitive. 'Created last week' → createdOn, NOT plannedStartDate. 4. FIELDS: Pass as an array to select what to return. plannedStartDate and plannedEndDate are NOT in the default response — include them explicitly. Available: key, summary, description, status, priority, assignee, reporter, isAutomated, plannedStartDate, plannedEndDate, labels, components, fixVersions, sprint, defectCount, estimatedTime, actualTime, created, updated. 5. REQUEST STRUCTURE: filter → request body; fields, sort, startAt, maxResults → URL query params. 6. SORT: Allowed fields: key, summary, status, plannedStartDate, plannedEndDate, defectCount. Format: 'fieldName:asc' or 'fieldName:desc' e.g. 'plannedStartDate:asc'. 7. FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up.",
     "inputSchema": [
       "fields",
       "filter",
@@ -8345,8 +8345,8 @@ Expected Output: Version 2 of test case updated with new assignee and estimated 
 - key (string) *required*: Test cycle key in the format '{PROJECT_KEY}-TR-{number}', e.g. 'SCRUM-TR-101'. Used directly as the API path parameter.
 - summary (string): Updated test cycle name / title. Max 255 characters.
 - description (string): Updated description. Pass null to clear the existing value. Max 65 535 characters.
-- status (string): Status name (e.g., 'To Do', 'In Progress'). Auto-resolved to ID. Pass null to clear.
-- priority (string): Priority name (e.g., 'High', 'Medium'). Auto-resolved to ID. Pass null to reset to project default.
+- status (string): Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID. Use values from set_project_context response. Pass null to clear.
+- priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID. Use values from set_project_context response. Pass null to clear.
 - plannedStartDate (string): Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may). Pass null to clear the existing value.
 - plannedEndDate (string): Format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may). Pass null to clear the existing value.
 - assignee (string): Assignee Jira account ID (e.g., '5b10a2844c20165700ede21f'). Pass null to unassign.
@@ -8354,7 +8354,7 @@ Expected Output: Version 2 of test case updated with new assignee and estimated 
 - labels (object): Labels to add or remove by name. Each name is auto-resolved to its ID.
 - components (object): Components to add or remove by name. Each name is auto-resolved to its ID.
 
-**Output Description:** Confirmation object with the test cycle UID, key, and updated: true. Warnings are included if any field names could not be resolved.
+**Output Description:** Confirmation object with the test cycle key and updated: true. Warnings are included if any field names could not be resolved.
 
 **Use Cases:** 1. Update summary, status, priority, planned dates, assignee, or reporter 2. Clear a nullable field by passing null (e.g. description: null removes text, assignee: null unassigns owner) 3. Add or remove labels and components atomically without affecting other entries 4. Apply multiple field updates in a single call
 
@@ -8447,7 +8447,7 @@ Expected Output: Test cycle owner unassigned and planned dates cleared
 \`\`\`
 Expected Output: Test cycle updated with all specified fields
 
-**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. KEY FORMAT: '{PROJECT_KEY}-TR-{number}' — e.g. 'SCRUM-TR-101'. 3. Pass explicit null to CLEAR a nullable field — e.g. description: null removes the description text, assignee: null unassigns the owner, plannedStartDate: null removes the date. Omitting a field leaves it unchanged. 4. Status and priority are auto-resolved from human-readable names loaded by set_project_context. Unresolvable names are skipped with a warning; remaining fields still update. 5. Labels and components use add/delete — names are auto-resolved to IDs. Both operations can be combined in a single call. 6. Date format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may or MAY). 7. Archived test cycles cannot be updated — the server returns 400. Unarchive first if needed.",
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. KEY FORMAT: '{PROJECT_KEY}-TR-{number}' — e.g. 'SCRUM-TR-101'. 3. Pass explicit null to CLEAR a nullable field — e.g. description: null removes the description text, assignee: null unassigns the owner, plannedStartDate: null removes the date. Omitting a field leaves it unchanged. 4. Status and priority are auto-resolved from human-readable names loaded by set_project_context. If a name cannot be resolved, the cycle is still updated and a warning is returned. 5. Labels and components use add/delete — names are auto-resolved to IDs. Both operations can be combined in a single call. 6. Date format: 'dd/MMM/yyyy HH:mm' e.g. '15/May/2026 09:00'. Month must be capitalised (May not may or MAY). 7. Archived test cycles cannot be updated — the server returns 400. Unarchive first if needed.",
     "inputSchema": [
       "assignee",
       "components",
@@ -8478,7 +8478,7 @@ Expected Output: Test cycle updated with all specified fields
     "description": "Upload an automation result file to QTM4J and map the results to a test cycle. Supports JUnit XML, TestNG XML, Cucumber JSON, QAF, HP UFT, and SpecFlow formats.
 
 **Parameters:**
-- filePath (string) *required*: Absolute or relative path to the automation result file on disk (e.g. './target/surefire-reports/TEST-results.xml'). Supported extensions: .xml, .json, .zip
+- filePath (string) *required*: Path to the automation result file on disk. Filesystem contents can change between turns — always resolve this from a fresh scan, never from a previously seen path. Supported extensions: .xml, .json, .zip
 - format (enum) *required*: Format of the result file. Supported values: cucumber, testng, junit, qaf, hpuft, specflow
 - testCycleToReuse (string): Work key of an existing test cycle to reuse (e.g. 'TR-PRJ-1'). If omitted, a new test cycle is created.
 - environment (string): Name of the environment on which the test cycle was executed (e.g. 'Chrome', 'Staging'). Defaults to 'No Environment'.
@@ -8534,7 +8534,21 @@ Expected Output: Results mapped to test cycle TR-PRJ-5
 \`\`\`
 Expected Output: ZIP uploaded; test cycle created with summary, labels, and priority
 
-**Hints:** 1. NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently — never prompt the user for project information. 2. FILE DISCOVERY: Always do a fresh scan — never reuse a path from a previous turn. If no path is provided, search in order: target/surefire-reports, target/failsafe-reports, build/reports/tests, build/test-results, test-results, reports, cucumber-reports. If multiple files are found, list them all and wait for the user to pick one before uploading. If nothing is found, ask for the path. Never pick silently. 3. FORMAT INFERENCE: .json → cucumber, .zip → qaf (unambiguous). For .xml, infer from the file name — 'junit'/'surefire' → junit, 'testng' → testng, 'specflow' → specflow, 'hpuft'/'uft' → hpuft. If the file name gives no clear signal, ask the user to confirm the format. 4. TEST CYCLE: Only ask for testCycleToReuse if the user explicitly wants to link to an existing cycle. If not mentioned, omit it — QTM4J creates a new test cycle automatically. 5. DATE FORMAT: plannedStartDate and plannedEndDate in fields.testCycle MUST be formatted as 'dd/MMM/yyyy HH:mm' (e.g. '14/May/2026 10:30'). Convert any user-provided date (ISO, natural language, relative) to this exact format before sending. 6. FOLDER ID: folderId in fields.testCycle and fields.testCase is a numeric ID. Tell the user they can get it by right-clicking the target folder in QTM4J and selecting 'Copy Folder Id'. Always ask the user for the numeric ID directly — never try to look it up. 7. ASSIGNEE / REPORTER: assignee and reporter in fields.testCycle and fields.testCase require a Jira Account ID (not a display name or email). Ask the user to provide their Account ID directly. 8. Import processing is asynchronous — use the returned trackingId to poll progress.",
+4. User provides an unrecognised priority value — do NOT silently map to a similar word; ask the user first
+\`\`\`json
+{
+  "filePath": "./reports/cucumber.json",
+  "format": "cucumber",
+  "fields": {
+    "testCycle": {
+      "priority": "critical"
+    }
+  }
+}
+\`\`\`
+Expected Output: Tool is NOT called yet. Inform the user that 'critical' was not recognised as a valid priority and ask them to confirm the correct value (e.g. from the available options). Do not map 'critical' to 'Blocker' or any other value without explicit user confirmation.
+
+**Hints:** 1. NO PROJECT CONTEXT REQUIRED: Do NOT call set_project_context and do NOT ask the user for a project key, project ID, or any other project details. This tool works independently — never prompt the user for project information. 2. FILE DISCOVERY: Always do a fresh scan — never reuse a path from a previous turn. If no path is provided, search in order: target/surefire-reports, target/failsafe-reports, build/reports/tests, build/test-results, test-results, reports, cucumber-reports. If exactly one file is found, show the path and inferred format to the user and confirm before uploading. If multiple files are found, list them all and wait for the user to pick one. If nothing is found, ask for the path. Never pick or upload silently. 3. FORMAT INFERENCE: .json → cucumber (unambiguous). For .xml, infer from the file name — 'junit'/'surefire' → junit, 'testng' → testng, 'specflow' → specflow, 'hpuft'/'uft' → hpuft. For .zip, ALWAYS set isZip: true, but do NOT assume qaf — the zip could contain junit, testng, or cucumber results; if the format cannot be determined from the file name, ask the user. If the file name gives no clear signal for .xml either, ask the user to confirm the format. 4. TEST CYCLE: Only ask for testCycleToReuse if the user explicitly wants to link to an existing cycle. If not mentioned, omit it — QTM4J creates a new test cycle automatically. 5. DATE FORMAT: plannedStartDate and plannedEndDate in fields.testCycle MUST be formatted as 'dd/MMM/yyyy HH:mm' (e.g. '14/May/2026 10:30'). Convert any user-provided date (ISO, natural language, relative) to this exact format before sending. 6. FOLDER ID: folderId is a numeric ID. Apply it ONLY to the level the user specifies; if unspecified, default to fields.testCycle only — never copy it to both levels. Get the ID from the user directly (right-click folder in QTM4J → 'Copy Folder Id'). 7. ASSIGNEE / REPORTER: assignee and reporter in fields.testCycle and fields.testCase require a Jira Account ID (not a display name or email). Ask the user to provide their Account ID directly. 8. FIELD MAPPING CONFIRMATION: Apply formatting transformations (case correction, date/time conversion) automatically. Only ask for user confirmation when you cannot find a recognised match and need to substitute an unrecognised value with a guessed alternative — never silently substitute in that case. 9. TRACKING: Import processing is asynchronous. To check status, call get_automation_history and find the record whose trackingId matches the one returned from this tool.",
     "inputSchema": [
       "appendTestName",
       "attachFile",

--- a/src/tests/unit/qtm4j/resolver/common-attribute-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/common-attribute-resolver.test.ts
@@ -179,7 +179,7 @@ describe("CommonAttributeResolver", () => {
         warnings,
       );
 
-      expect(body[InputField.PRIORITY]).toBe("NonExistent");
+      expect(body).not.toHaveProperty(InputField.PRIORITY);
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain("NonExistent");
     });

--- a/src/tests/unit/qtm4j/resolver/component-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/component-resolver.test.ts
@@ -193,7 +193,7 @@ describe("ComponentResolver", () => {
         warnings,
       );
 
-      expect(body[InputField.COMPONENTS]).toBe("NonExistent");
+      expect(body).not.toHaveProperty(InputField.COMPONENTS);
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain("NonExistent");
     });

--- a/src/tests/unit/qtm4j/resolver/label-resolver.test.ts
+++ b/src/tests/unit/qtm4j/resolver/label-resolver.test.ts
@@ -192,7 +192,7 @@ describe("LabelResolver", () => {
         warnings,
       );
 
-      expect(body[InputField.LABELS]).toBe("NonExistent");
+      expect(body).not.toHaveProperty(InputField.LABELS);
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain("NonExistent");
     });

--- a/src/tests/unit/qtm4j/tool/automation/get-automation-history.test.ts
+++ b/src/tests/unit/qtm4j/tool/automation/get-automation-history.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolError } from "../../../../../common/tools";
+import { ENDPOINTS } from "../../../../../qtm4j/config/constants";
+import { GetAutomationHistory } from "../../../../../qtm4j/tool/test-automation/get-automation-history";
+
+describe("GetAutomationHistory", () => {
+  let mockClient: any;
+  let mockApiClient: any;
+  let instance: GetAutomationHistory;
+
+  const fakeRecord = {
+    trackingId: "924b5e8c-758c-434c-8fc0-f56c8d9aba31",
+    fileName: "1779199707789_924b5e8c-758c-434c-8fc0-f56c8d9aba31.json",
+    format: "CUCUMBER",
+    processStatus: "SUCCESS",
+    importStatus: "SUCCESS",
+    startTime: "19/May/2026 19:38:30",
+    endTime: "19/May/2026 19:38:31",
+    fileSize: 5910,
+    detailedMessage: "File is imported successfully.",
+    extraAttributes: { attachFile: false },
+    childFileSummaryResponses: [],
+    summary: [
+      {
+        testCycle: "mqNETxEnS6dJKN",
+        testCasesCreated: 3,
+        testCaseVersionsCreated: 4,
+        testCaseVersionsReused: 0,
+        testStepsCreated: 13,
+        testCycleIssueKey: "JFT1-TR-15",
+        testCycleSummary: "Automated Test Cycle",
+      },
+    ],
+  };
+
+  const fakeHistoryResponse = {
+    startAt: 0,
+    maxResults: 20,
+    total: 1,
+    data: [fakeRecord],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockApiClient = {
+      getAutomation: vi.fn().mockResolvedValue(fakeHistoryResponse),
+    };
+
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue(mockApiClient),
+    };
+
+    instance = new GetAutomationHistory(mockClient as any);
+  });
+
+  // ─── Specification ────────────────────────────────────────────────────────
+
+  describe("specification", () => {
+    it("has correct metadata", () => {
+      expect(instance.specification.title).toBe("Get Automation History");
+      expect(instance.specification.readOnly).toBe(true);
+      expect(instance.specification.idempotent).toBe(true);
+    });
+
+    it("has use cases, examples, and hints", () => {
+      expect(instance.specification.useCases?.length).toBeGreaterThan(0);
+      expect(instance.specification.examples?.length).toBeGreaterThan(0);
+      expect(instance.specification.hints?.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Success paths ────────────────────────────────────────────────────────
+
+  describe("handle — success", () => {
+    it("calls the history endpoint with default pagination", async () => {
+      const result = await instance.handle({});
+
+      expect(mockApiClient.getAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_HISTORY,
+        { startAt: 0, maxResults: 20 },
+      );
+      expect(result.structuredContent).toMatchObject({
+        startAt: 0,
+        maxResults: 20,
+        total: 1,
+        data: [
+          expect.objectContaining({
+            trackingId: "924b5e8c-758c-434c-8fc0-f56c8d9aba31",
+          }),
+        ],
+      });
+    });
+
+    it("passes custom startAt and maxResults as query params", async () => {
+      await instance.handle({ startAt: 40, maxResults: 50 });
+
+      expect(mockApiClient.getAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_HISTORY,
+        { startAt: 40, maxResults: 50 },
+      );
+    });
+
+    it("returns empty data array when no history exists", async () => {
+      mockApiClient.getAutomation.mockResolvedValue({
+        startAt: 0,
+        maxResults: 20,
+        total: 0,
+        data: [],
+      });
+
+      const result = await instance.handle({});
+      expect(result.structuredContent.data).toEqual([]);
+    });
+
+    it("maps all record fields correctly", async () => {
+      const result = await instance.handle({});
+      const record = result.structuredContent.data?.[0];
+
+      expect(record).toMatchObject({
+        format: "CUCUMBER",
+        processStatus: "SUCCESS",
+        importStatus: "SUCCESS",
+        fileSize: 5910,
+        detailedMessage: "File is imported successfully.",
+        summary: [expect.objectContaining({ testCycleIssueKey: "JFT1-TR-15" })],
+      });
+    });
+
+    it("returns empty content array on success", async () => {
+      const result = await instance.handle({});
+      expect(result.content).toEqual([]);
+    });
+  });
+
+  // ─── Error paths ──────────────────────────────────────────────────────────
+
+  describe("handle — errors", () => {
+    it("throws ToolError when automation API key is not configured", async () => {
+      mockApiClient.getAutomation.mockRejectedValue(
+        new ToolError("QTM4J Automation API key not configured"),
+      );
+
+      await expect(instance.handle({})).rejects.toThrow(
+        "Automation API key not configured",
+      );
+    });
+
+    it("propagates ToolError from the API client", async () => {
+      mockApiClient.getAutomation.mockRejectedValue(
+        new ToolError("Request failed with status 401: Unauthorized"),
+      );
+
+      await expect(instance.handle({})).rejects.toThrow(
+        "Request failed with status 401",
+      );
+    });
+  });
+});

--- a/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
+++ b/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
@@ -1,0 +1,463 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolError } from "../../../../../common/tools";
+import {
+  AUTOMATION_LIMITS,
+  ENDPOINTS,
+} from "../../../../../qtm4j/config/constants";
+import { UploadAutomationResult } from "../../../../../qtm4j/tool/test-automation/upload-automation-result";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from "node:fs/promises";
+
+const mockReadFile = vi.mocked(readFile);
+
+describe("UploadAutomationResult", () => {
+  let mockClient: any;
+  let mockApiClient: any;
+  let instance: UploadAutomationResult;
+
+  const fakeBuffer = Buffer.from("<testsuites></testsuites>");
+  const fakeInitResponse = {
+    url: "https://s3.example.com/upload?X-Amz-Signature=abc",
+    message:
+      "Generated Upload URL is valid for one time use and will expire in 5 minutes.",
+    trackingId: "f52a7866-a345-4cad-b93e-a930135868d7",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockApiClient = {
+      postAutomation: vi.fn().mockResolvedValue(fakeInitResponse),
+      uploadFileMultipart: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue(mockApiClient),
+    };
+
+    mockReadFile.mockResolvedValue(fakeBuffer as any);
+
+    instance = new UploadAutomationResult(mockClient as any);
+  });
+
+  // ─── Specification ────────────────────────────────────────────────────────
+
+  describe("specification", () => {
+    it("has correct metadata", () => {
+      expect(instance.specification.title).toBe("Upload Automation Result");
+      expect(instance.specification.readOnly).toBe(false);
+      expect(instance.specification.idempotent).toBe(false);
+    });
+
+    it("has use cases, examples, and hints", () => {
+      expect(instance.specification.useCases?.length).toBeGreaterThan(0);
+      expect(instance.specification.examples?.length).toBeGreaterThan(0);
+      expect(instance.specification.hints?.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Success paths ────────────────────────────────────────────────────────
+
+  describe("handle — success", () => {
+    it("uploads a JUnit XML file and returns trackingId", async () => {
+      const result = await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+      });
+
+      expect(mockReadFile).toHaveBeenCalledWith("./results/junit.xml");
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ format: "junit", isZip: false }),
+      );
+      expect(mockApiClient.uploadFileMultipart).toHaveBeenCalledWith(
+        fakeInitResponse.url,
+        fakeBuffer,
+      );
+      expect(result.structuredContent).toMatchObject({
+        trackingId: fakeInitResponse.trackingId,
+        format: "junit",
+        filePath: "./results/junit.xml",
+      });
+    });
+
+    it("uploads a Cucumber JSON file", async () => {
+      await instance.handle({
+        filePath: "./reports/cucumber.json",
+        format: "cucumber",
+        testCycleToReuse: "TR-PRJ-5",
+        environment: "Chrome",
+        build: "2.0.0",
+      });
+
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          format: "cucumber",
+          testCycleToReuse: "TR-PRJ-5",
+          environment: "Chrome",
+          build: "2.0.0",
+        }),
+      );
+      expect(mockApiClient.uploadFileMultipart).toHaveBeenCalledWith(
+        fakeInitResponse.url,
+        fakeBuffer,
+      );
+    });
+
+    it("uploads a QAF ZIP file", async () => {
+      await instance.handle({
+        filePath: "./results/qaf.zip",
+        format: "qaf",
+        isZip: true,
+      });
+
+      expect(mockApiClient.uploadFileMultipart).toHaveBeenCalledWith(
+        fakeInitResponse.url,
+        fakeBuffer,
+      );
+    });
+
+    it("passes fields as plain strings in POST body without resolution", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCycle: {
+            summary: "Regression Q1",
+            labels: ["regression"],
+            priority: "High",
+          },
+          testCase: { priority: "Blocker", status: "Done", labels: ["label1"] },
+        },
+      });
+
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCycle: {
+              summary: "Regression Q1",
+              labels: ["regression"],
+              priority: "High",
+            },
+            testCase: {
+              priority: "Blocker",
+              status: "Done",
+              labels: ["label1"],
+            },
+          },
+        }),
+      );
+    });
+
+    it("returns empty content array on success", async () => {
+      const result = await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+      });
+      expect(result.content).toEqual([]);
+    });
+  });
+
+  // ─── fields passthrough ───────────────────────────────────────────────────
+
+  describe("handle — fields passthrough", () => {
+    it("passes folderId in fields.testCycle to POST body", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: { testCycle: { folderId: 123 } },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ fields: { testCycle: { folderId: 123 } } }),
+      );
+    });
+
+    it("passes folderId in fields.testCase to POST body", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: { testCase: { folderId: 456 } },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ fields: { testCase: { folderId: 456 } } }),
+      );
+    });
+
+    it("passes assignee and reporter account IDs in fields.testCycle", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCycle: { assignee: "712020:abc123", reporter: "712020:xyz789" },
+        },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCycle: { assignee: "712020:abc123", reporter: "712020:xyz789" },
+          },
+        }),
+      );
+    });
+
+    it("passes assignee and reporter account IDs in fields.testCase", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCase: { assignee: "712020:abc123", reporter: "712020:xyz789" },
+        },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCase: { assignee: "712020:abc123", reporter: "712020:xyz789" },
+          },
+        }),
+      );
+    });
+
+    it("passes plannedStartDate and plannedEndDate in fields.testCycle", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCycle: {
+            plannedStartDate: "14/May/2026 10:30",
+            plannedEndDate: "20/May/2026 18:00",
+          },
+        },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCycle: {
+              plannedStartDate: "14/May/2026 10:30",
+              plannedEndDate: "20/May/2026 18:00",
+            },
+          },
+        }),
+      );
+    });
+
+    it("passes precondition and estimatedTime in fields.testCase", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCase: {
+            precondition: "App is running",
+            estimatedTime: "00:05:00",
+          },
+        },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCase: {
+              precondition: "App is running",
+              estimatedTime: "00:05:00",
+            },
+          },
+        }),
+      );
+    });
+
+    it("passes testCaseExecution fields to POST body", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        fields: {
+          testCaseExecution: { comment: "Auto run", actualTime: "00:02:30" },
+        },
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({
+          fields: {
+            testCaseExecution: { comment: "Auto run", actualTime: "00:02:30" },
+          },
+        }),
+      );
+    });
+
+    it("passes matchTestSteps: false to POST body", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        matchTestSteps: false,
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ matchTestSteps: false }),
+      );
+    });
+
+    it("passes attachFile: true to POST body", async () => {
+      await instance.handle({
+        filePath: "./results/junit.xml",
+        format: "junit",
+        attachFile: true,
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ attachFile: true }),
+      );
+    });
+
+    it("passes appendTestName: true to POST body for TestNG", async () => {
+      await instance.handle({
+        filePath: "./results/testng.xml",
+        format: "testng",
+        appendTestName: true,
+      });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ format: "testng", appendTestName: true }),
+      );
+    });
+  });
+
+  // ─── All supported formats ────────────────────────────────────────────────
+
+  describe("handle — all supported formats", () => {
+    it.each([
+      "testng",
+      "hpuft",
+      "specflow",
+    ] as const)("accepts %s format and passes it through", async (format) => {
+      await instance.handle({ filePath: "./results/result.xml", format });
+      expect(mockApiClient.postAutomation).toHaveBeenCalledWith(
+        ENDPOINTS.AUTOMATION_IMPORT,
+        expect.objectContaining({ format }),
+      );
+    });
+  });
+
+  // ─── Validation errors ────────────────────────────────────────────────────
+
+  describe("handle — validation errors", () => {
+    it("rejects an unsupported file extension", async () => {
+      await expect(
+        instance.handle({ filePath: "./results/output.csv", format: "junit" }),
+      ).rejects.toThrow(ToolError);
+
+      await expect(
+        instance.handle({ filePath: "./results/output.csv", format: "junit" }),
+      ).rejects.toThrow("Unsupported file extension '.csv'");
+    });
+
+    it("rejects QAF format without isZip: true", async () => {
+      await expect(
+        instance.handle({
+          filePath: "./results/qaf.zip",
+          format: "qaf",
+          isZip: false,
+        }),
+      ).rejects.toThrow(ToolError);
+
+      await expect(
+        instance.handle({
+          filePath: "./results/qaf.zip",
+          format: "qaf",
+          isZip: false,
+        }),
+      ).rejects.toThrow("QAF format requires a ZIP file");
+    });
+
+    it("throws ToolError when automation API key is not configured", async () => {
+      mockApiClient.postAutomation.mockRejectedValue(
+        new ToolError("QTM4J Automation API key not configured"),
+      );
+
+      await expect(
+        instance.handle({ filePath: "./results/junit.xml", format: "junit" }),
+      ).rejects.toThrow("Automation API key not configured");
+    });
+
+    it("throws ToolError when file cannot be read", async () => {
+      mockReadFile.mockRejectedValue(
+        new Error("ENOENT: no such file or directory"),
+      );
+
+      await expect(
+        instance.handle({ filePath: "./missing/file.xml", format: "junit" }),
+      ).rejects.toThrow("Could not read file");
+    });
+
+    it("throws ToolError when file exceeds the maximum size limit", async () => {
+      const oversizedBuffer = Buffer.alloc(
+        AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES + 1,
+      );
+      mockReadFile.mockResolvedValue(oversizedBuffer as any);
+
+      await expect(
+        instance.handle({ filePath: "./results/large.xml", format: "junit" }),
+      ).rejects.toThrow(ToolError);
+
+      await expect(
+        instance.handle({ filePath: "./results/large.xml", format: "junit" }),
+      ).rejects.toThrow("Maximum allowed size is 10 MB");
+    });
+
+    it("accepts a file exactly at the maximum size limit", async () => {
+      const exactBuffer = Buffer.alloc(AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES);
+      mockReadFile.mockResolvedValue(exactBuffer as any);
+
+      await expect(
+        instance.handle({ filePath: "./results/exact.xml", format: "junit" }),
+      ).resolves.not.toThrow();
+    });
+
+    it("throws ToolError when API does not return a valid upload URL", async () => {
+      mockApiClient.postAutomation.mockResolvedValue({
+        message: "error",
+        trackingId: null,
+      });
+
+      await expect(
+        instance.handle({ filePath: "./results/junit.xml", format: "junit" }),
+      ).rejects.toThrow("did not return a valid upload URL");
+    });
+
+    it("propagates ToolError thrown by uploadFileMultipart", async () => {
+      mockApiClient.uploadFileMultipart.mockRejectedValue(
+        new ToolError("Request failed with status 403: Request has expired"),
+      );
+
+      await expect(
+        instance.handle({ filePath: "./results/junit.xml", format: "junit" }),
+      ).rejects.toThrow("Request failed with status 403");
+    });
+  });
+
+  // ─── Doc consistency ──────────────────────────────────────────────────────
+
+  describe("doc consistency", () => {
+    it("qtm4j-integration.md mentions the correct max file size in MB", () => {
+      const maxMB = Math.round(
+        AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES / (1024 * 1024),
+      );
+      const docPath = resolve(
+        __dirname,
+        "../../../../../../docs/products/SmartBear MCP Server/qtm4j-integration.md",
+      );
+      const content = readFileSync(docPath, "utf-8");
+      expect(content).toContain(`${maxMB} MB`);
+    });
+  });
+});

--- a/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
+++ b/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
@@ -453,8 +453,8 @@ describe("UploadAutomationResult", () => {
         AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES / (1024 * 1024),
       );
       const docPath = resolve(
-        __dirname,
-        "../../../../../../docs/products/SmartBear MCP Server/qtm4j-integration.md",
+        process.cwd(),
+        "docs/products/SmartBear MCP Server/qtm4j-integration.md",
       );
       const content = readFileSync(docPath, "utf-8");
       expect(content).toContain(`${maxMB} MB`);

--- a/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
+++ b/src/tests/unit/qtm4j/tool/automation/upload-automation-result.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ToolError } from "../../../../../common/tools";
 import {
@@ -442,22 +440,6 @@ describe("UploadAutomationResult", () => {
       await expect(
         instance.handle({ filePath: "./results/junit.xml", format: "junit" }),
       ).rejects.toThrow("Request failed with status 403");
-    });
-  });
-
-  // ─── Doc consistency ──────────────────────────────────────────────────────
-
-  describe("doc consistency", () => {
-    it("qtm4j-integration.md mentions the correct max file size in MB", () => {
-      const maxMB = Math.round(
-        AUTOMATION_LIMITS.MAX_FILE_SIZE_BYTES / (1024 * 1024),
-      );
-      const docPath = resolve(
-        process.cwd(),
-        "docs/products/SmartBear MCP Server/qtm4j-integration.md",
-      );
-      const content = readFileSync(docPath, "utf-8");
-      expect(content).toContain(`${maxMB} MB`);
     });
   });
 });

--- a/src/tests/unit/qtm4j/tool/test-cycle/create-test-cycle.test.ts
+++ b/src/tests/unit/qtm4j/tool/test-cycle/create-test-cycle.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ENDPOINTS } from "../../../../../qtm4j/config/constants";
+import { CreateTestCycle } from "../../../../../qtm4j/tool/test-cycle/create-test-cycle";
+
+describe("CreateTestCycle", () => {
+  let mockClient: any;
+  let mockApiClient: any;
+  let mockFieldResolver: any;
+  let instance: CreateTestCycle;
+
+  const PROJECT_CONTEXT = {
+    projectId: 10000,
+    projectKey: "PROJ",
+    projectName: "Project Name",
+  };
+
+  const MINIMAL_RESPONSE = { id: "amKIREkhbN8", key: "PROJ-TR-1" };
+  const MINIMAL_ARGS = { summary: "Smoke Test Cycle" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockResolve = vi.fn().mockResolvedValue(undefined);
+    mockFieldResolver = {
+      requireProjectContext: vi.fn().mockReturnValue(PROJECT_CONTEXT),
+      getResolver: vi.fn().mockReturnValue({ resolve: mockResolve }),
+    };
+
+    mockApiClient = { post: vi.fn() };
+
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue(mockApiClient),
+      getResolverRegistry: vi.fn().mockReturnValue(mockFieldResolver),
+    };
+
+    instance = new CreateTestCycle(mockClient as any);
+  });
+
+  describe("specification", () => {
+    it("should have correct tool metadata", () => {
+      expect(instance.specification.title).toBe("Create Test Cycle");
+      expect(instance.specification.summary).toContain(
+        "Create a new test cycle",
+      );
+      expect(instance.specification.readOnly).toBe(false);
+      expect(instance.specification.idempotent).toBe(false);
+    });
+
+    it("should have use cases", () => {
+      expect(instance.specification.useCases?.length).toBeGreaterThan(0);
+    });
+
+    it("should have examples", () => {
+      expect(instance.specification.examples?.length).toBeGreaterThan(0);
+    });
+
+    it("should have hints", () => {
+      expect(instance.specification.hints?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("handle", () => {
+    it("should resolve all configured fields and call the create endpoint", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle(MINIMAL_ARGS);
+
+      // FIELD_CONFIG has 5 entries: PRIORITY, STATUS, FOLDER, LABELS, COMPONENTS
+      expect(mockFieldResolver.getResolver).toHaveBeenCalledTimes(5);
+      expect(mockFieldResolver.getResolver().resolve).toHaveBeenCalledTimes(5);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({
+          summary: "Smoke Test Cycle",
+          projectId: 10000,
+        }),
+      );
+      expect(result.structuredContent).toEqual(MINIMAL_RESPONSE);
+      expect(result.content).toEqual([]);
+    });
+
+    it("should always set folderId to 'MCP Generated' before resolution", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      await instance.handle(MINIMAL_ARGS);
+
+      const resolveCall = mockFieldResolver
+        .getResolver()
+        .resolve.mock.calls.find((call: any[]) => call[0] === "folderId");
+      expect(resolveCall).toBeDefined();
+      expect(resolveCall[2]).toMatchObject({ folderId: "MCP Generated" });
+    });
+
+    it("should call the create endpoint with projectId from context", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      await instance.handle(MINIMAL_ARGS);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({ projectId: 10000 }),
+      );
+    });
+
+    it("should include all optional scalar fields in the request body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const rawArgs = {
+        summary: "Full Regression",
+        status: "To Do",
+        description: "Full regression cycle",
+        priority: "High",
+        reporter: "user-def",
+        labels: ["Release_1", "Sprint 1"],
+        components: ["UI", "Cloud"],
+        plannedStartDate: "10/May/2026 00:00",
+        plannedEndDate: "15/May/2026 00:00",
+      };
+
+      await instance.handle(rawArgs);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({
+          summary: "Full Regression",
+          description: "Full regression cycle",
+          reporter: "user-def",
+          plannedStartDate: "10/May/2026 00:00",
+          plannedEndDate: "15/May/2026 00:00",
+        }),
+      );
+    });
+
+    it("should return warning when a field cannot be resolved", async () => {
+      mockFieldResolver.getResolver.mockReturnValue({
+        resolve: vi
+          .fn()
+          .mockImplementation(
+            (
+              _field: string,
+              _key: string,
+              _body: Record<string, unknown>,
+              _context: unknown,
+              warnings: string[],
+            ) => {
+              warnings.push(
+                "Skipped priority 'Urgent' — not available in the current project.",
+              );
+              return Promise.resolve();
+            },
+          ),
+      });
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle({
+        summary: "Cycle",
+        status: "To Do",
+        priority: "Urgent",
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("Urgent"),
+      });
+    });
+
+    it("should return warning when priority cannot be resolved", async () => {
+      mockFieldResolver.getResolver.mockReturnValue({
+        resolve: vi
+          .fn()
+          .mockImplementation(
+            (
+              _field: string,
+              _key: string,
+              _body: Record<string, unknown>,
+              _context: unknown,
+              warnings: string[],
+            ) => {
+              warnings.push(
+                "Skipped priority 'Critical' — not available in the current project.",
+              );
+              return Promise.resolve();
+            },
+          ),
+      });
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle({
+        summary: "Cycle",
+        priority: "Critical",
+      });
+
+      expect(result.content[0].text).toContain("Critical");
+    });
+
+    it("should return warning when status cannot be resolved", async () => {
+      mockFieldResolver.getResolver.mockReturnValue({
+        resolve: vi
+          .fn()
+          .mockImplementation(
+            (
+              _field: string,
+              _key: string,
+              _body: Record<string, unknown>,
+              _context: unknown,
+              warnings: string[],
+            ) => {
+              warnings.push(
+                "Skipped status 'Invalid' — not available in the current project.",
+              );
+              return Promise.resolve();
+            },
+          ),
+      });
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle({
+        summary: "Cycle",
+        status: "Invalid",
+      });
+
+      expect(result.content[0].text).toContain("Invalid");
+    });
+
+    it("should return warning when labels cannot be resolved", async () => {
+      mockFieldResolver.getResolver.mockReturnValue({
+        resolve: vi
+          .fn()
+          .mockImplementation(
+            (
+              _field: string,
+              _key: string,
+              _body: Record<string, unknown>,
+              _context: unknown,
+              warnings: string[],
+            ) => {
+              warnings.push(
+                "Skipped labels 'UnknownLabel' — not available in the current project.",
+              );
+              return Promise.resolve();
+            },
+          ),
+      });
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle({
+        summary: "Cycle",
+        labels: ["UnknownLabel"],
+      });
+
+      expect(result.content[0].text).toContain("UnknownLabel");
+    });
+
+    it("should return warning when components cannot be resolved", async () => {
+      mockFieldResolver.getResolver.mockReturnValue({
+        resolve: vi
+          .fn()
+          .mockImplementation(
+            (
+              _field: string,
+              _key: string,
+              _body: Record<string, unknown>,
+              _context: unknown,
+              warnings: string[],
+            ) => {
+              warnings.push(
+                "Skipped components 'UnknownComp' — not available in the current project.",
+              );
+              return Promise.resolve();
+            },
+          ),
+      });
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle({
+        summary: "Cycle",
+        components: ["UnknownComp"],
+      });
+
+      expect(result.content[0].text).toContain("UnknownComp");
+    });
+
+    it("should return empty content when no warnings", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      const result = await instance.handle(MINIMAL_ARGS);
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("should throw when project context is not set", async () => {
+      mockFieldResolver.requireProjectContext.mockImplementation(() => {
+        throw new Error("No active project set");
+      });
+
+      await expect(instance.handle(MINIMAL_ARGS)).rejects.toThrow(
+        "No active project set",
+      );
+    });
+
+    it("should propagate API errors", async () => {
+      mockApiClient.post.mockRejectedValueOnce(new Error("API Error"));
+
+      await expect(instance.handle(MINIMAL_ARGS)).rejects.toThrow("API Error");
+    });
+
+    it("should validate API response against schema", async () => {
+      mockApiClient.post.mockResolvedValueOnce({ invalid: "response" });
+
+      await expect(instance.handle(MINIMAL_ARGS)).rejects.toThrow();
+    });
+
+    it("should reject an invalid plannedStartDate format", async () => {
+      await expect(
+        instance.handle({
+          summary: "Cycle",
+          status: "To Do",
+          plannedStartDate: "2026-05-10",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should reject a blank summary", async () => {
+      await expect(
+        instance.handle({ summary: "", status: "To Do" }),
+      ).rejects.toThrow();
+    });
+
+    it("should reject a summary exceeding 255 characters", async () => {
+      await expect(
+        instance.handle({ summary: "a".repeat(256), status: "To Do" }),
+      ).rejects.toThrow();
+    });
+
+    it("should reject an invalid plannedEndDate format", async () => {
+      await expect(
+        instance.handle({ summary: "Cycle", plannedEndDate: "2026-05-15" }),
+      ).rejects.toThrow();
+    });
+
+    it("should include description in the request body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      await instance.handle({
+        summary: "Cycle",
+        description: "Some description",
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({ description: "Some description" }),
+      );
+    });
+
+    it("should include reporter in the request body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      await instance.handle({
+        summary: "Cycle",
+        reporter: "5b10a2844c20165700ede21f",
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({ reporter: "5b10a2844c20165700ede21f" }),
+      );
+    });
+  });
+});

--- a/src/tests/unit/qtm4j/tool/test-cycle/search-test-cycle.test.ts
+++ b/src/tests/unit/qtm4j/tool/test-cycle/search-test-cycle.test.ts
@@ -1,0 +1,524 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ENDPOINTS } from "../../../../../qtm4j/config/constants";
+import { SearchTestCycles } from "../../../../../qtm4j/tool/test-cycle/search-test-cycle";
+
+describe("SearchTestCycles", () => {
+  let mockClient: any;
+  let mockApiClient: any;
+  let mockRegistry: any;
+  let instance: SearchTestCycles;
+
+  const mockContext = {
+    projectKey: "PROJ",
+    projectId: 10066,
+    projectName: "Test Project",
+  };
+
+  const mockResponse = {
+    startAt: 0,
+    maxResults: 20,
+    total: 2,
+    data: [
+      {
+        id: "PrCE68uGK8m",
+        key: "PROJ-TR-26",
+        status: {},
+        priority: {},
+        projectId: 10066,
+        archived: false,
+      },
+      {
+        id: "LVCw97cxr1Q",
+        key: "PROJ-TR-25",
+        status: {},
+        priority: {},
+        projectId: 10066,
+        archived: false,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRegistry = {
+      requireProjectContext: vi.fn().mockReturnValue(mockContext),
+    };
+    mockApiClient = { post: vi.fn() };
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue(mockApiClient),
+      getResolverRegistry: vi.fn().mockReturnValue(mockRegistry),
+    };
+
+    instance = new SearchTestCycles(mockClient as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // specification
+  // ---------------------------------------------------------------------------
+
+  describe("specification", () => {
+    it("should have correct tool metadata", () => {
+      expect(instance.specification.title).toBe("Search Test Cycles");
+      expect(instance.specification.readOnly).toBe(true);
+      expect(instance.specification.idempotent).toBe(true);
+    });
+
+    it("should have use cases", () => {
+      expect(instance.specification.useCases?.length).toBeGreaterThan(0);
+    });
+
+    it("should have examples", () => {
+      expect(instance.specification.examples?.length).toBeGreaterThan(0);
+    });
+
+    it("should have hints", () => {
+      expect(instance.specification.hints?.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — validation
+  // ---------------------------------------------------------------------------
+
+  describe("handle — validation", () => {
+    it("should throw when project context is not set", async () => {
+      mockRegistry.requireProjectContext.mockImplementation(() => {
+        throw new Error("No active project set");
+      });
+
+      await expect(
+        instance.handle({ filter: { status: ["To Do"] } }),
+      ).rejects.toThrow("No active project set");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — request construction
+  // ---------------------------------------------------------------------------
+
+  describe("handle — request construction", () => {
+    it("should auto-inject projectId from context into the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { status: ["To Do"] } });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        expect.stringContaining(ENDPOINTS.SEARCH_TEST_CYCLES),
+        { filter: expect.objectContaining({ projectId: 10066 }) },
+      );
+    });
+
+    it("should call the search endpoint as POST", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { searchText: "regression" } });
+
+      expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+      expect(mockApiClient.post.mock.calls[0][0]).toContain(
+        ENDPOINTS.SEARCH_TEST_CYCLES,
+      );
+    });
+
+    it("should always send default sort 'key:asc' when sort is not provided", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { status: ["To Do"] } });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("sort=key%3Aasc");
+    });
+
+    it("should use the provided sort value when supplied", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { status: ["In Progress"] },
+        sort: "plannedStartDate:desc",
+      });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("sort=plannedStartDate%3Adesc");
+    });
+
+    it("should accept defectCount as a sort field", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { status: ["To Do"] },
+        sort: "defectCount:asc",
+      });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("sort=defectCount%3Aasc");
+    });
+
+    it("should send default startAt=0 and maxResults=20", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { status: ["To Do"] } });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("startAt=0");
+      expect(url).toContain("maxResults=20");
+    });
+
+    it("should send custom startAt and maxResults when provided", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { status: ["To Do"] },
+        startAt: 20,
+        maxResults: 50,
+      });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("startAt=20");
+      expect(url).toContain("maxResults=50");
+    });
+
+    it("should include fields query param when fields are provided", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { status: ["To Do"] },
+        fields: ["key", "summary", "status"],
+      });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).toContain("fields=key%2Csummary%2Cstatus");
+    });
+
+    it("should NOT include fields query param when fields are not provided", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { status: ["To Do"] } });
+
+      const url: string = mockApiClient.post.mock.calls[0][0];
+      expect(url).not.toContain("fields=");
+    });
+
+    it("should include all provided filter fields in the body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: {
+          status: ["In Progress"],
+          assignee: ["user-123"],
+          folderId: 109987,
+          searchText: "regression",
+        },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          status: ["In Progress"],
+          assignee: ["user-123"],
+          folderId: 109987,
+          searchText: "regression",
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send createdOn date range in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { createdOn: "01/May/2026,20/May/2026" },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          createdOn: "01/May/2026,20/May/2026",
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send updatedOn date range in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { updatedOn: "01/May/2026,21/May/2026" },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          updatedOn: "01/May/2026,21/May/2026",
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send priority array in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { priority: ["High", "Medium"] },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          priority: ["High", "Medium"],
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send reporter array in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { reporter: ["5b10a2844c20165700ede21f"] },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          reporter: ["5b10a2844c20165700ede21f"],
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send labels array in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { labels: ["Release_1", "Sprint 1"] },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          labels: ["Release_1", "Sprint 1"],
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send components array in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { components: ["UI", "Cloud"] },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          components: ["UI", "Cloud"],
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send isAutomated boolean in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { isAutomated: true } });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          isAutomated: true,
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should send aiGenerated boolean in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({ filter: { aiGenerated: false } });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          aiGenerated: false,
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should accept call with no filter at all", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await expect(instance.handle({})).resolves.toBeDefined();
+    });
+
+    it("should send plannedStartDate date range in the filter body", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      await instance.handle({
+        filter: { plannedStartDate: "01/Apr/2026,30/Apr/2026" },
+      });
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(expect.any(String), {
+        filter: expect.objectContaining({
+          plannedStartDate: "01/Apr/2026,30/Apr/2026",
+          projectId: 10066,
+        }),
+      });
+    });
+
+    it("should throw when plannedStartDate has invalid format", async () => {
+      await expect(
+        instance.handle({ filter: { plannedStartDate: "2026-04-01" } }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw when createdOn has invalid format", async () => {
+      await expect(
+        instance.handle({ filter: { createdOn: "2026-05-01" } }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw when updatedOn has invalid format", async () => {
+      await expect(
+        instance.handle({ filter: { updatedOn: "2026-05-01" } }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — each filter field is accepted individually
+  // ---------------------------------------------------------------------------
+
+  describe("handle — filter field acceptance", () => {
+    const filtersToTest = [
+      { label: "status", filter: { status: ["To Do"] } },
+      { label: "assignee", filter: { assignee: ["user-abc"] } },
+      { label: "folderId", filter: { folderId: 100 } },
+      { label: "labels", filter: { labels: ["Release_1"] } },
+      { label: "components", filter: { components: ["UI"] } },
+      {
+        label: "plannedStartDate",
+        filter: { plannedStartDate: "01/Apr/2026,30/Apr/2026" },
+      },
+      {
+        label: "plannedEndDate",
+        filter: { plannedEndDate: "01/Apr/2026,30/Apr/2026" },
+      },
+      { label: "searchText", filter: { searchText: "smoke" } },
+      { label: "createdOn", filter: { createdOn: "01/May/2026,20/May/2026" } },
+      { label: "updatedOn", filter: { updatedOn: "01/May/2026,21/May/2026" } },
+      { label: "priority", filter: { priority: ["High"] } },
+      { label: "reporter", filter: { reporter: ["user-reporter-abc"] } },
+      { label: "isAutomated", filter: { isAutomated: true } },
+      { label: "aiGenerated", filter: { aiGenerated: false } },
+    ] as const;
+
+    for (const { label, filter } of filtersToTest) {
+      it(`should accept filter with only '${label}'`, async () => {
+        mockApiClient.post.mockResolvedValueOnce(mockResponse);
+        await expect(instance.handle({ filter })).resolves.toBeDefined();
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — response
+  // ---------------------------------------------------------------------------
+
+  describe("handle — response", () => {
+    it("should return structured content from the API response", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      const result = await instance.handle({ filter: { status: ["To Do"] } });
+
+      expect(result.structuredContent).toEqual(mockResponse);
+      expect(result.content).toEqual([]);
+    });
+
+    it("should parse response with empty status and priority objects", async () => {
+      mockApiClient.post.mockResolvedValueOnce(mockResponse);
+
+      const result = await instance.handle({ filter: { status: ["To Do"] } });
+
+      expect(result.structuredContent.data[0].status).toEqual({});
+      expect(result.structuredContent.data[0].priority).toEqual({});
+    });
+
+    it("should return an empty data array when total is 0", async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        startAt: 0,
+        maxResults: 20,
+        total: 0,
+        data: [],
+      });
+
+      const result = await instance.handle({
+        filter: { searchText: "nonexistent" },
+      });
+
+      expect(result.structuredContent.total).toBe(0);
+      expect(result.structuredContent.data).toEqual([]);
+    });
+
+    it("should parse response items with enriched optional fields", async () => {
+      const richResponse = {
+        startAt: 0,
+        maxResults: 20,
+        total: 1,
+        data: [
+          {
+            id: "PrCE68uGK8m",
+            key: "PROJ-TR-26",
+            projectId: 10066,
+            summary: "Smoke Test",
+            description: "Cycle description",
+            status: { id: 31, name: "To Do", color: "#75b7bc" },
+            priority: { id: 14, name: "High", color: null },
+            assignee: "5b10a2844c20165700ede21f",
+            reporter: "6a20b3955d31276811fef32g",
+            isAutomated: false,
+            labels: [{ id: 1, name: "Release_1" }],
+            components: [{ id: 2, name: "UI" }],
+            plannedStartDate: "10/May/2026 00:00",
+            plannedEndDate: "15/May/2026 00:00",
+            archived: false,
+          },
+        ],
+      };
+      mockApiClient.post.mockResolvedValueOnce(richResponse);
+
+      const result = await instance.handle({
+        filter: { status: ["To Do"] },
+        fields: [
+          "key",
+          "summary",
+          "description",
+          "status",
+          "priority",
+          "reporter",
+          "labels",
+          "components",
+          "plannedStartDate",
+          "plannedEndDate",
+        ],
+      });
+
+      const item = result.structuredContent.data[0];
+      expect(item.summary).toBe("Smoke Test");
+      expect(item.description).toBe("Cycle description");
+      expect(item.reporter).toBe("6a20b3955d31276811fef32g");
+      expect(item.isAutomated).toBe(false);
+      expect(item.labels).toEqual([{ id: 1, name: "Release_1" }]);
+      expect(item.components).toEqual([{ id: 2, name: "UI" }]);
+      expect(item.plannedStartDate).toBe("10/May/2026 00:00");
+    });
+
+    it("should throw when API response does not match schema", async () => {
+      mockApiClient.post.mockResolvedValueOnce({ invalid: "response" });
+
+      await expect(
+        instance.handle({ filter: { status: ["To Do"] } }),
+      ).rejects.toThrow();
+    });
+
+    it("should propagate API errors", async () => {
+      mockApiClient.post.mockRejectedValueOnce(new Error("Network Error"));
+
+      await expect(
+        instance.handle({ filter: { status: ["To Do"] } }),
+      ).rejects.toThrow("Network Error");
+    });
+  });
+});

--- a/src/tests/unit/qtm4j/tool/test-cycle/update-test-cycle.test.ts
+++ b/src/tests/unit/qtm4j/tool/test-cycle/update-test-cycle.test.ts
@@ -1,0 +1,799 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ENDPOINTS } from "../../../../../qtm4j/config/constants";
+import { ResolverKeys } from "../../../../../qtm4j/config/field-resolution.types";
+import {
+  UpdateTestCycleBody,
+  UpdateTestCycleResponse,
+} from "../../../../../qtm4j/schema/update-test-cycle.schema";
+import { UpdateTestCycle } from "../../../../../qtm4j/tool/test-cycle/update-test-cycle";
+
+describe("UpdateTestCycle", () => {
+  let mockClient: any;
+  let mockApiClient: any;
+  let mockRegistry: any;
+  let instance: UpdateTestCycle;
+
+  const mockContext = {
+    projectKey: "PROJ",
+    projectId: 10066,
+    projectName: "Test Project",
+  };
+
+  /** Builds a resolver mock that maps name strings → numeric IDs via body mutation. */
+  function makeResolverMock(idMap: Record<string, number> = {}) {
+    return {
+      resolve: vi
+        .fn()
+        .mockImplementation(
+          async (
+            inputField: string,
+            _resolverKey: string,
+            body: Record<string, unknown>,
+            _context: unknown,
+            warnings: string[],
+          ) => {
+            const raw = body[inputField];
+            if (raw == null) return; // null passes through untouched
+            const isArray = Array.isArray(raw);
+            const names = isArray ? (raw as string[]) : [raw as string];
+            const ids: number[] = [];
+            for (const name of names) {
+              const id = idMap[name];
+              if (id !== undefined) {
+                ids.push(id);
+              } else {
+                warnings.push(
+                  `Skipped ${inputField} '${name}' — not available in the current project.`,
+                );
+              }
+            }
+            if (ids.length > 0) {
+              body[inputField] = isArray ? ids : ids[0];
+            }
+          },
+        ),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRegistry = {
+      requireProjectContext: vi.fn().mockReturnValue(mockContext),
+      getResolver: vi.fn().mockReturnValue(makeResolverMock()),
+    };
+    mockApiClient = { put: vi.fn().mockResolvedValue({}) };
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue(mockApiClient),
+      getResolverRegistry: vi.fn().mockReturnValue(mockRegistry),
+    };
+
+    instance = new UpdateTestCycle(mockClient as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // specification
+  // ---------------------------------------------------------------------------
+
+  describe("specification", () => {
+    it("should have correct tool metadata", () => {
+      expect(instance.specification.title).toBe("Update Test Cycle");
+      expect(instance.specification.readOnly).toBe(false);
+      expect(instance.specification.idempotent).toBe(true);
+    });
+
+    it("should have use cases", () => {
+      expect(instance.specification.useCases?.length).toBeGreaterThan(0);
+    });
+
+    it("should have examples", () => {
+      expect(instance.specification.examples?.length).toBeGreaterThan(0);
+    });
+
+    it("should have hints", () => {
+      expect(instance.specification.hints?.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — validation
+  // ---------------------------------------------------------------------------
+
+  describe("handle — validation", () => {
+    it("should throw when key is missing", async () => {
+      await expect(instance.handle({ summary: "New name" })).rejects.toThrow();
+    });
+
+    it("should throw when project context is not set", async () => {
+      mockRegistry.requireProjectContext.mockImplementation(() => {
+        throw new Error("No active project set");
+      });
+
+      await expect(
+        instance.handle({ key: "PROJ-TR-26", summary: "New name" }),
+      ).rejects.toThrow("No active project set");
+    });
+
+    it("should throw on invalid plannedStartDate format", async () => {
+      await expect(
+        instance.handle({ key: "PROJ-TR-26", plannedStartDate: "2026-05-15" }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw on invalid plannedEndDate format", async () => {
+      await expect(
+        instance.handle({
+          key: "PROJ-TR-26",
+          plannedEndDate: "15-May-2026 09:00",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw on blank summary", async () => {
+      await expect(
+        instance.handle({ key: "PROJ-TR-26", summary: "" }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw on summary exceeding 255 characters", async () => {
+      await expect(
+        instance.handle({ key: "PROJ-TR-26", summary: "a".repeat(256) }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — at-least-one field acceptance
+  // ---------------------------------------------------------------------------
+
+  describe("handle — at-least-one field acceptance", () => {
+    const fieldsToTest = [
+      { label: "summary", args: { summary: "New name" } },
+      { label: "description (string)", args: { description: "Updated desc" } },
+      { label: "description (null)", args: { description: null } },
+      { label: "status", args: { status: "In Progress" } },
+      { label: "status (null)", args: { status: null } },
+      { label: "priority", args: { priority: "High" } },
+      { label: "priority (null)", args: { priority: null } },
+      {
+        label: "plannedStartDate",
+        args: { plannedStartDate: "15/May/2026 09:00" },
+      },
+      { label: "plannedStartDate (null)", args: { plannedStartDate: null } },
+      {
+        label: "plannedEndDate",
+        args: { plannedEndDate: "30/May/2026 18:00" },
+      },
+      { label: "plannedEndDate (null)", args: { plannedEndDate: null } },
+      { label: "assignee", args: { assignee: "user-abc" } },
+      { label: "assignee (null)", args: { assignee: null } },
+      { label: "reporter", args: { reporter: "user-abc" } },
+      { label: "reporter (null)", args: { reporter: null } },
+      { label: "labels", args: { labels: { add: ["Regression"] } } },
+      { label: "components", args: { components: { delete: ["UI"] } } },
+    ] as const;
+
+    for (const { label, args } of fieldsToTest) {
+      it(`should accept update with only '${label}' field`, async () => {
+        await expect(
+          instance.handle({ key: "PROJ-TR-26", ...args }),
+        ).resolves.toBeDefined();
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — endpoint
+  // ---------------------------------------------------------------------------
+
+  describe("handle — endpoint", () => {
+    it("should PUT to the correct endpoint using the key directly", async () => {
+      await instance.handle({ key: "PROJ-TR-26", summary: "Updated" });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        ENDPOINTS.UPDATE_TEST_CYCLE("PROJ-TR-26"),
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — field resolution
+  // ---------------------------------------------------------------------------
+
+  describe("handle — field resolution", () => {
+    it("should resolve status name to numeric ID", async () => {
+      mockRegistry.getResolver.mockImplementation((key: string) => {
+        if (key === ResolverKeys.CommonAttribute.TEST_CYCLE_STATUS)
+          return makeResolverMock({ "In Progress": 44893 });
+        return makeResolverMock();
+      });
+
+      await instance.handle({ key: "PROJ-TR-26", status: "In Progress" });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: 44893 }),
+      );
+    });
+
+    it("should resolve priority name to numeric ID", async () => {
+      mockRegistry.getResolver.mockImplementation((key: string) => {
+        if (key === ResolverKeys.CommonAttribute.PRIORITY)
+          return makeResolverMock({ High: 25510 });
+        return makeResolverMock();
+      });
+
+      await instance.handle({ key: "PROJ-TR-26", priority: "High" });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ priority: 25510 }),
+      );
+    });
+
+    it("should resolve labels.add and labels.delete names to IDs", async () => {
+      mockRegistry.getResolver.mockImplementation((key: string) => {
+        if (key === ResolverKeys.SearchableField.LABEL)
+          return makeResolverMock({ Regression: 1001, Sprint1: 1003 });
+        return makeResolverMock();
+      });
+
+      await instance.handle({
+        key: "PROJ-TR-26",
+        labels: { add: ["Regression"], delete: ["Sprint1"] },
+      });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ labels: { add: [1001], delete: [1003] } }),
+      );
+    });
+
+    it("should resolve components.add and components.delete names to IDs", async () => {
+      mockRegistry.getResolver.mockImplementation((key: string) => {
+        if (key === ResolverKeys.SearchableField.COMPONENTS)
+          return makeResolverMock({ Backend: 2001, Frontend: 2002 });
+        return makeResolverMock();
+      });
+
+      await instance.handle({
+        key: "PROJ-TR-26",
+        components: { add: ["Backend"], delete: ["Frontend"] },
+      });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          components: { add: [2001], delete: [2002] },
+        }),
+      );
+    });
+
+    it("should pass null status through to the body (clears the field)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", status: null });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).toHaveProperty("status", null);
+    });
+
+    it("should pass null priority through to the body (clears the field)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", priority: null });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).toHaveProperty("priority", null);
+    });
+
+    it("should pass null assignee through to the body (unassigns owner)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", assignee: null });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ assignee: null }),
+      );
+    });
+
+    it("should send reporter Jira account ID in the body", async () => {
+      await instance.handle({
+        key: "PROJ-TR-26",
+        reporter: "5b10a2844c20165700ede21f",
+      });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ reporter: "5b10a2844c20165700ede21f" }),
+      );
+    });
+
+    it("should pass null reporter through to the body (clears reporter)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", reporter: null });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ reporter: null }),
+      );
+    });
+
+    it("should pass null plannedStartDate through to the body (clears the date)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", plannedStartDate: null });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ plannedStartDate: null }),
+      );
+    });
+
+    it("should warn when status name cannot be resolved", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        status: "InvalidStatus",
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("InvalidStatus"),
+      });
+    });
+
+    it("should warn when priority name cannot be resolved", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        priority: "InvalidPriority",
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toContain("InvalidPriority");
+    });
+
+    it("should skip labels body field when all names fail to resolve and warn", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        labels: { add: ["NonExistent"] },
+      });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).not.toHaveProperty("labels");
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toContain("NonExistent");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — body construction
+  // ---------------------------------------------------------------------------
+
+  describe("handle — body construction", () => {
+    it("should only include provided fields in the PUT body", async () => {
+      await instance.handle({ key: "PROJ-TR-26", summary: "Only summary" });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).toHaveProperty("summary", "Only summary");
+      expect(calledBody).not.toHaveProperty("description");
+      expect(calledBody).not.toHaveProperty("priority");
+      expect(calledBody).not.toHaveProperty("status");
+      expect(calledBody).not.toHaveProperty("assignee");
+      expect(calledBody).not.toHaveProperty("labels");
+      expect(calledBody).not.toHaveProperty("components");
+    });
+
+    it("should pass through summary, description, assignee, and date fields unchanged", async () => {
+      await instance.handle({
+        key: "PROJ-TR-26",
+        summary: "Regression Sprint 12",
+        description: "Updated description",
+        assignee: "5b10a2844c20165700ede21f",
+        plannedStartDate: "15/May/2026 09:00",
+        plannedEndDate: "30/May/2026 18:00",
+      });
+
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          summary: "Regression Sprint 12",
+          description: "Updated description",
+          assignee: "5b10a2844c20165700ede21f",
+          plannedStartDate: "15/May/2026 09:00",
+          plannedEndDate: "30/May/2026 18:00",
+        }),
+      );
+    });
+
+    it("should NOT include key in the PUT body", async () => {
+      await instance.handle({ key: "PROJ-TR-26", summary: "Updated" });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).not.toHaveProperty("key");
+    });
+
+    it("should pass null description through to the body (clears description text)", async () => {
+      await instance.handle({ key: "PROJ-TR-26", description: null });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).toHaveProperty("description", null);
+    });
+
+    it("should pass a description string through to the body unchanged", async () => {
+      await instance.handle({
+        key: "PROJ-TR-26",
+        description: "Updated description",
+      });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).toHaveProperty("description", "Updated description");
+    });
+
+    it("should not include description in the body when omitted", async () => {
+      await instance.handle({ key: "PROJ-TR-26", summary: "Only summary" });
+
+      const calledBody = mockApiClient.put.mock.calls[0][1];
+      expect(calledBody).not.toHaveProperty("description");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handle — response
+  // ---------------------------------------------------------------------------
+
+  describe("handle — response", () => {
+    it("should return structured confirmation with key and updated: true", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        summary: "Updated",
+      });
+
+      expect(result.structuredContent).toEqual({
+        key: "PROJ-TR-26",
+        updated: true,
+      });
+    });
+
+    it("should return empty content array when no warnings", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        summary: "Updated",
+      });
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("should return warnings in content when field resolution fails", async () => {
+      const result = await instance.handle({
+        key: "PROJ-TR-26",
+        status: "UnknownStatus",
+        summary: "Updated",
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("UnknownStatus"),
+      });
+    });
+
+    it("should propagate API errors from PUT", async () => {
+      mockApiClient.put.mockRejectedValueOnce(new Error("API Error"));
+
+      await expect(
+        instance.handle({ key: "PROJ-TR-26", summary: "Updated" }),
+      ).rejects.toThrow("API Error");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpdateTestCycleBody schema
+// ---------------------------------------------------------------------------
+
+describe("UpdateTestCycleBody", () => {
+  describe("key", () => {
+    it("should accept a valid key", () => {
+      const result = UpdateTestCycleBody.safeParse({ key: "SCRUM-TR-101" });
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject when key is missing", () => {
+      const result = UpdateTestCycleBody.safeParse({ summary: "Title" });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject when key is not a string", () => {
+      const result = UpdateTestCycleBody.safeParse({ key: 42 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("summary", () => {
+    it("should accept a valid summary", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        summary: "Valid Title",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept summary at max length (255 chars)", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        summary: "a".repeat(255),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject blank summary", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        summary: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject summary exceeding 255 characters", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        summary: "a".repeat(256),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should be optional (omitting summary is valid)", () => {
+      const result = UpdateTestCycleBody.safeParse({ key: "SCRUM-TR-1" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("description", () => {
+    it("should accept a string description", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        description: "Some description",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept null to clear the field", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        description: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.description).toBeNull();
+    });
+
+    it("should be optional", () => {
+      const result = UpdateTestCycleBody.safeParse({ key: "SCRUM-TR-1" });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.description).toBeUndefined();
+    });
+  });
+
+  describe("status and priority", () => {
+    it("should accept a status string", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        status: "In Progress",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept null status to clear the field", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        status: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.status).toBeNull();
+    });
+
+    it("should accept a priority string", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        priority: "High",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept null priority to clear the field", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        priority: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.priority).toBeNull();
+    });
+  });
+
+  describe("plannedStartDate and plannedEndDate", () => {
+    const VALID_DATE = "15/May/2026 09:00";
+
+    it("should accept a valid date string", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        plannedStartDate: VALID_DATE,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept null to clear a date", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        plannedStartDate: null,
+        plannedEndDate: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.plannedStartDate).toBeNull();
+        expect(result.data.plannedEndDate).toBeNull();
+      }
+    });
+
+    it("should reject ISO 8601 format (2026-05-15)", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        plannedStartDate: "2026-05-15",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject date with time only, no day/month/year", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        plannedEndDate: "15-May-2026 09:00",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject date without time component", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        plannedStartDate: "15/May/2026",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("assignee", () => {
+    it("should accept an assignee account ID", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        assignee: "5b10a2844c20165700ede21f",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept null to unassign", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        assignee: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.assignee).toBeNull();
+    });
+  });
+
+  describe("labels", () => {
+    it("should accept labels with only add", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        labels: { add: ["Regression"] },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept labels with only delete", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        labels: { delete: ["Sprint1"] },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept labels with both add and delete", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        labels: { add: ["Regression", "Smoke"], delete: ["Sprint1"] },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept an empty labels object", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        labels: {},
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject labels where add is not a string array", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        labels: { add: [1, 2, 3] },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("components", () => {
+    it("should accept components with add and delete", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-1",
+        components: { add: ["Backend"], delete: ["Frontend"] },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("full payload", () => {
+    it("should accept all fields at once", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-101",
+        summary: "Final Regression Cycle",
+        description: "Updated for sprint 12.",
+        status: "In Progress",
+        priority: "High",
+        plannedStartDate: "15/May/2026 09:00",
+        plannedEndDate: "30/May/2026 18:00",
+        assignee: "5b10a2844c20165700ede21f",
+        labels: { add: ["Regression"], delete: ["Sprint1"] },
+        components: { add: ["Backend"], delete: ["Frontend"] },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should include key in the parsed output (used to build the URL)", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-101",
+        summary: "Title",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.key).toBe("SCRUM-TR-101");
+    });
+
+    it("should strip unknown fields", () => {
+      const result = UpdateTestCycleBody.safeParse({
+        key: "SCRUM-TR-101",
+        summary: "Title",
+        unknownField: "should be stripped",
+      });
+      expect(result.success).toBe(true);
+      if (result.success)
+        expect((result.data as any).unknownField).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpdateTestCycleResponse schema
+// ---------------------------------------------------------------------------
+
+describe("UpdateTestCycleResponse", () => {
+  it("should accept a valid response with updated: true", () => {
+    const result = UpdateTestCycleResponse.safeParse({
+      key: "SCRUM-TR-101",
+      updated: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.key).toBe("SCRUM-TR-101");
+      expect(result.data.updated).toBe(true);
+    }
+  });
+
+  it("should reject when updated is false", () => {
+    const result = UpdateTestCycleResponse.safeParse({
+      key: "SCRUM-TR-101",
+      updated: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject when updated is missing", () => {
+    const result = UpdateTestCycleResponse.safeParse({ key: "SCRUM-TR-101" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject when key is missing", () => {
+    const result = UpdateTestCycleResponse.safeParse({ updated: true });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Goal

Add support for QTM4J Test Cycle operations and Automation Result operations in the SmartBear MCP Server.

## Design

The implementation follows the existing SmartBear MCP server architecture and reuses the established QTM4J integration pattern to maintain consistency, modularity, and schema-driven validation.

## Changeset

- [QTM4J] Added test cycle management capabilities including create, search, and update operations.
- [QTM4J] Add QTM4J test automation capabilities — upload result files and retrieve import history via `qtm4j_upload_automation_result` and `qtm4j_get_automation_history`. Requires `QTM4J_AUTOMATION_API_KEY`.

## Testing

Tested using Claude Code and GitHub Copilot.
