### PR TITLE
chore: add remote urls to server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -111,5 +111,19 @@
         }
       ]
     }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://swagger.mcp.smartbear.com/mcp"
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://bugsnag.mcp.smartbear.com/mcp"
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://zephyr.mcp.smartbear.com/mcp"
+    }
   ]
 }


### PR DESCRIPTION
## Goal

  Surface the existing SmartBear-hosted Remote MCP Servers (Swagger, BugSnag, Zephyr) in the MCP Registry entry for `com.smartbear/smartbear-mcp`, so its more visible for users that they can connect to them directly via URL — without installing the npm package, running Node.js, or managing API tokens.

  ## Design

  Added a `remotes` array to `server.json` alongside the existing `packages` block. 
  
  ## Changeset

  - `server.json`: added `remotes` with three `streamable-http` entries:
    - `https://swagger.mcp.smartbear.com/mcp`
    - `https://bugsnag.mcp.smartbear.com/mcp`
    - `https://zephyr.mcp.smartbear.com/mcp`

  ## Testing

  - No code changes; nothing to run.
