### PR TITLE
Include transport type in User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Swagger] Add Swagger Functional Testing integration with `list_tests` tool for discovering available API tests. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+- [Common] Added transport mode (stdio/http) to User-Agent header for all API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
+- [Collaborator] Add user agent header to API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
 
 ## [0.25.1] - 2026-06-08
 

--- a/src/bearq/client.ts
+++ b/src/bearq/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info";
+import { USER_AGENT } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -76,7 +76,7 @@ export class BearQClient implements Client {
     return {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
-      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "User-Agent": USER_AGENT,
     };
   }
 

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CacheService } from "../common/cache";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info";
+import { USER_AGENT } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -187,7 +187,7 @@ export class BugsnagClient implements Client {
         );
       },
       headers: {
-        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        "User-Agent": USER_AGENT,
         "Content-Type": "application/json",
         "X-Bugsnag-API": "true",
         "X-Version": "2",

--- a/src/collaborator/client.ts
+++ b/src/collaborator/client.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { USER_AGENT } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import type {
@@ -74,7 +75,7 @@ export class CollaboratorClient implements Client {
     ];
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
       body: JSON.stringify(body),
     });
     if (!response.ok) {

--- a/src/common/info.ts
+++ b/src/common/info.ts
@@ -1,3 +1,6 @@
 import packageJson from "../../package.json" with { type: "json" };
 export const MCP_SERVER_NAME = packageJson.config.mcpServerName;
 export const MCP_SERVER_VERSION = packageJson.version;
+export const MCP_TRANSPORT =
+  process.env.MCP_TRANSPORT?.toLowerCase().trim() || "stdio";
+export const USER_AGENT = `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION} ${MCP_TRANSPORT}`;

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -2,7 +2,7 @@ import { enableCompileCache } from "node:module";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 import { clientRegistry } from "./client-registry";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
+import { USER_AGENT } from "./info";
 import { SmartBearMcpServer } from "./server";
 import { registerShutdownHandler } from "./shutdown";
 import { getTypeDescription, isOptionalType } from "./zod-utils";
@@ -32,7 +32,7 @@ function getNoConfigMessage(): string[] {
  */
 export async function runStdioMode() {
   if (process.argv.includes("--version")) {
-    console.log(`${MCP_SERVER_NAME}: v${MCP_SERVER_VERSION}`);
+    console.log(`User-Agent: ${USER_AGENT}`);
     process.exit(0);
   } else if (process.argv.includes("--help")) {
     console.log(

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info";
+import { USER_AGENT } from "../common/info";
 import {
   isSamplingPolyfillResult,
   type SamplingPolyfillResult,
@@ -297,7 +297,7 @@ export class PactflowClient implements Client {
       return {
         Authorization: authHeader,
         "Content-Type": "application/json",
-        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        "User-Agent": USER_AGENT,
       };
     }
 
@@ -313,14 +313,14 @@ export class PactflowClient implements Client {
       return {
         Authorization: authHeader,
         "Content-Type": "application/json",
-        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        "User-Agent": USER_AGENT,
       };
     } else if (this.username && this.password) {
       const authString = `${this.username}:${this.password}`;
       return {
         Authorization: `Basic ${Buffer.from(authString).toString("base64")}`,
         "Content-Type": "application/json",
-        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        "User-Agent": USER_AGENT,
       };
     }
     return undefined;

--- a/src/qmetry/client/api/client-api.ts
+++ b/src/qmetry/client/api/client-api.ts
@@ -1,4 +1,4 @@
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../../common/info";
+import { USER_AGENT } from "../../../common/info";
 import { QMETRY_DEFAULTS } from "../../config/constants";
 import type { RequestOptions } from "../../types/common";
 import { handleQMetryApiError, handleQMetryFetchError } from "./error-handler";
@@ -25,7 +25,7 @@ export async function qmetryRequest<T>({
   const headers: Record<string, string> = {
     apikey: token,
     project: project || QMETRY_DEFAULTS.PROJECT_KEY,
-    "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+    "User-Agent": USER_AGENT,
     "qmetry-source": "smartbear-mcp",
   };
   if (body) {

--- a/src/qmetry/client/automation.ts
+++ b/src/qmetry/client/automation.ts
@@ -1,4 +1,4 @@
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../common/info";
+import { USER_AGENT } from "../../common/info";
 import { QMETRY_DEFAULTS } from "../config/constants";
 import { QMETRY_PATHS } from "../config/rest-endpoints";
 import type { ImportAutomationResultsPayload } from "../types/automation";
@@ -138,7 +138,7 @@ export async function importAutomationResults(
   const headers: Record<string, string> = {
     apikey: token,
     project: finalPayload.projectID || project || QMETRY_DEFAULTS.PROJECT_KEY,
-    "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+    "User-Agent": USER_AGENT,
     "qmetry-source": "smartbear-mcp",
     // Note: Content-Type will be set automatically by fetch for FormData
   };

--- a/src/qtm4j/http/auth-service.ts
+++ b/src/qtm4j/http/auth-service.ts
@@ -1,4 +1,4 @@
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../common/info";
+import { USER_AGENT } from "../../common/info";
 import { CONTENT_TYPES, HTTP_HEADERS } from "../config/constants";
 
 /**
@@ -20,7 +20,7 @@ export class AuthService {
     return {
       [HTTP_HEADERS.API_KEY]: this.apiKey,
       [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
-      [HTTP_HEADERS.USER_AGENT]: `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      [HTTP_HEADERS.USER_AGENT]: USER_AGENT,
       [HTTP_HEADERS.ACCEPT]: CONTENT_TYPES.JSON,
     };
   }

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info";
+import { USER_AGENT } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -118,7 +118,7 @@ export class ReflectClient implements Client {
     return {
       ...this.getAuthHeader(),
       "Content-Type": "application/json",
-      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "User-Agent": USER_AGENT,
     };
   }
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../common/info";
+import { USER_AGENT } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -105,7 +105,7 @@ export class SwaggerClient implements Client {
           registryBasePath: config.registry_base_path,
           uiBasePath: config.ui_base_path,
         }),
-        `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        USER_AGENT,
       );
     }
 
@@ -113,7 +113,7 @@ export class SwaggerClient implements Client {
       this._ftApiToken = config.functional_testing_api_token;
       this.ftApi = new FunctionalTestingAPI(
         () => this.getFtAuthToken(),
-        `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        USER_AGENT,
       );
     }
   }

--- a/src/tests/unit/bugsnag/client.test.ts
+++ b/src/tests/unit/bugsnag/client.test.ts
@@ -15,7 +15,7 @@ import type {
 } from "../../../bugsnag/client/api/index.js";
 import type { ProjectAPI } from "../../../bugsnag/client/api/Project.js";
 import { BugsnagClient } from "../../../bugsnag/client.js";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../../common/info.js";
+import { USER_AGENT } from "../../../common/info.js";
 import { ToolError } from "../../../common/tools.js";
 import {
   getMockError,
@@ -202,7 +202,7 @@ describe("BugsnagClient", () => {
           basePath: "https://api.bugsnag.smartbear.com",
           apiKey: expect.any(Function),
           headers: expect.objectContaining({
-            "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+            "User-Agent": USER_AGENT,
             "Content-Type": "application/json",
             "X-Bugsnag-API": "true",
             "X-Version": "2",
@@ -687,7 +687,7 @@ describe("BugsnagClient", () => {
 
       const configCall = MockedConfiguration.mock.calls[0][0];
       expect(configCall?.headers).toEqual({
-        "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+        "User-Agent": USER_AGENT,
         "Content-Type": "application/json",
         "X-Bugsnag-API": "true",
         "X-Version": "2",

--- a/src/tests/unit/qtm4j/common/auth-service.test.ts
+++ b/src/tests/unit/qtm4j/common/auth-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../../../common/info";
+import { USER_AGENT } from "../../../../common/info";
 import {
   CONTENT_TYPES,
   HTTP_HEADERS,
@@ -24,9 +24,7 @@ describe("AuthService", () => {
 
     expect(headers[HTTP_HEADERS.API_KEY]).toBe("test-api-key-123");
     expect(headers[HTTP_HEADERS.CONTENT_TYPE]).toBe(CONTENT_TYPES.JSON);
-    expect(headers[HTTP_HEADERS.USER_AGENT]).toBe(
-      `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
-    );
+    expect(headers[HTTP_HEADERS.USER_AGENT]).toBe(USER_AGENT);
     expect(headers[HTTP_HEADERS.ACCEPT]).toBe(CONTENT_TYPES.JSON);
   });
 

--- a/src/tests/unit/zephyr/common/auth-service.test.ts
+++ b/src/tests/unit/zephyr/common/auth-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../../../common/info";
+import { USER_AGENT } from "../../../../common/info";
 import { AuthService } from "../../../../zephyr/common/auth-service";
 
 describe("AuthService", () => {
@@ -16,7 +16,7 @@ describe("AuthService", () => {
     expect(headers).toEqual({
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
-      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "User-Agent": USER_AGENT,
       "zscale-source": "smartbear-mcp",
     });
   });

--- a/src/zephyr/common/auth-service.ts
+++ b/src/zephyr/common/auth-service.ts
@@ -1,4 +1,4 @@
-import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "../../common/info";
+import { USER_AGENT } from "../../common/info";
 
 export class AuthService {
   private readonly bearerToken: string;
@@ -11,7 +11,7 @@ export class AuthService {
     return {
       Authorization: `Bearer ${this.bearerToken}`,
       "Content-Type": "application/json",
-      "User-Agent": `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION}`,
+      "User-Agent": USER_AGENT,
       "zscale-source": "smartbear-mcp",
     };
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         "@bugsnag/js",
         "node-cache",
         "swagger-client",
+        "ws",
         "zod",
         "zod-to-json-schema",
       ],


### PR DESCRIPTION
Fixes [AIA-306](https://smartbear.atlassian.net/browse/AIA-306)

Updated the MCP Server User-Agent format to include the transport type (stdio or http) for improved observability and debugging.

Also added the User-Agent header to Collaborator client requests, ensuring transport information is consistently available in logs and monitoring systems.

**Tested**
- Verified User-Agent includes transport in stdio mode
- Verified User-Agent includes transport in http mode
- Confirmed Collaborator requests send the updated User-Agent header


[AIA-306]: https://smartbear.atlassian.net/browse/AIA-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ