### PR TITLE
feat(functional-testing): Run and query test execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Add Swagger Functional Testing integration with `list_tests` tool for discovering available API tests. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+- [Swagger] Add Swagger Functional Testing integration with `list_tests`, `run_test`, and `get_test_status` tools for discovering and executing available API tests. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
 ## [0.25.1] - 2026-06-08
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -1,6 +1,6 @@
 ![swagger-functional-testing.svg](./images/embedded/swagger-functional-testing.svg)
 
-The Swagger Functional Testing client provides tools for discovering API tests. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
+The Swagger Functional Testing client provides tools for discovering and executing API tests. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
 ## Available Tools
 
@@ -11,6 +11,22 @@ The Swagger Functional Testing client provides tools for discovering API tests. 
 - Purpose: Lists all API tests available in your Swagger Functional Testing account. Use this tool when you need to discover available tests. Do not use this tool to retrieve test execution results or history.
 - Returns: Complete list of tests with their identifiers and names.
 - Use case: Discover available tests.
+
+---
+
+### Test Execution
+
+#### `run_test`
+
+- Purpose: Runs a specific API test in your Swagger Functional Testing workspace. Use this tool when you need to verify expected API functionality by executing a single test. Requires a `testId`, which can be obtained from `list_tests`.
+- Returns: Execution details including an `executionId` that can be used to poll for the result.
+- Use case: Trigger a test run against your API.
+
+#### `get_test_status`
+
+- Purpose: Retrieves the status and result of a previously triggered test execution. Use this tool to check whether a test run has completed and whether it passed or failed. Requires an `executionId` returned by `run_test`.
+- Returns: Execution status and result details for the given execution.
+- Use case: Poll for the outcome of a test run after calling `run_test`.
 
 ---
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -14,6 +14,10 @@ import {
   FUNCTIONAL_TESTING_API_KEY_HEADER,
   FunctionalTestingAPI,
 } from "./client/functional-testing-api";
+import type {
+  GetFunctionalTestingExecutionParams,
+  RunFunctionalTestingTestParams,
+} from "./client/functional-testing-types";
 import {
   type ApiDefinitionParams,
   type ApiSearchParams,
@@ -51,7 +55,6 @@ import {
   type UpdatePortalArgs,
   type UpdateProductArgs,
 } from "./client/index";
-
 import type {
   OrganizationsListResponse,
   OrganizationsQueryParams,
@@ -303,11 +306,36 @@ export class SwaggerClient implements Client {
     return this.getApi().standardizeApi(args);
   }
 
+  // Functional Testing methods
+
   async listFunctionalTestingTests(): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.listTests());
+  }
+
+  async runFunctionalTestingTest(
+    args: RunFunctionalTestingTestParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.runTest(args));
+  }
+
+  async getFunctionalTestingExecution(
+    args: GetFunctionalTestingExecutionParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.getExecution(args));
+  }
+
+  /**
+   * Perform an operation with the Functional Testing API.
+   * Throws a ToolError if Functional Testing is not configured
+   */
+  private async withFunctionalTesting<T>(
+    fn: (ftApi: FunctionalTestingAPI) => Promise<T>,
+  ): Promise<T> {
     if (!this.ftApi) {
       throw new ToolError("Functional Testing API not configured");
     }
-    return this.ftApi.listTests();
+
+    return fn(this.ftApi);
   }
 
   async registerTools(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,9 +1,17 @@
 import { ToolError } from "../../common/tools";
+import type {
+  GetFunctionalTestingExecutionParams,
+  RunFunctionalTestingTestParams,
+} from "./functional-testing-types";
 
+const API_HOSTNAME_DEV = "localhost:8900";
 const API_HOSTNAME = "api.reflect.run";
+
 export const FUNCTIONAL_TESTING_API_KEY_HEADER = "X-API-KEY";
 
 export class FunctionalTestingAPI {
+  private urlBase: string | undefined;
+
   constructor(
     private readonly getToken: () => string | null,
     private readonly userAgent: string,
@@ -22,7 +30,7 @@ export class FunctionalTestingAPI {
   }
 
   async listTests(): Promise<unknown> {
-    const response = await fetch(`https://${API_HOSTNAME}/v1/tests`, {
+    const response = await fetch(`${this.getUrlBase()}/tests`, {
       method: "GET",
       headers: this.getFtHeaders(),
     });
@@ -34,5 +42,67 @@ export class FunctionalTestingAPI {
     }
 
     return response.json();
+  }
+
+  async runTest(args: RunFunctionalTestingTestParams): Promise<unknown> {
+    if (!args.testId) throw new ToolError("testId argument is required");
+
+    const response = await fetch(
+      `${this.getUrlBase()}/tests/${args.testId}/executions`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to run test: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getExecution(
+    args: GetFunctionalTestingExecutionParams,
+  ): Promise<unknown> {
+    if (!args.executionId) {
+      throw new ToolError("executionId argument is required");
+    }
+
+    const response = await fetch(
+      `${this.getUrlBase()}/executions/${args.executionId}`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to get test status: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Get the URL base for API calls. When running against a local environment (NODE_ENV: development),
+   * the endpoints are exposed at the `/api` path. When running against production, the endpoints
+   * are exposed at `/v1`.
+   *
+   * If NODE_ENV is anything other than `development`, defaults to the production URL
+   */
+  private getUrlBase(): string {
+    if (!this.urlBase) {
+      this.urlBase =
+        process.env.NODE_ENV === "development"
+          ? `http://${API_HOSTNAME_DEV}/api`
+          : `https://${API_HOSTNAME}/v1`;
+    }
+
+    return this.urlBase;
   }
 }

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,3 +1,7 @@
+import {
+  GetFunctionalTestingExecutionSchema,
+  RunFunctionalTestingTestParamsSchema,
+} from "./functional-testing-types";
 import type { SwaggerToolParams } from "./tools";
 
 export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
@@ -9,5 +13,21 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use this tool when you need to discover available tests before running them or checking their status. " +
       "Do not use this tool to retrieve test execution results or history.",
     handler: "listFunctionalTestingTests",
+  },
+  {
+    title: "Run Test",
+    toolset: "Functional Testing",
+    summary:
+      "Runs a specific API test in your Swagger Functional Testing workspace and returns the result. " +
+      "Use this tool when you need to verify expected API functionality by executing a single test.",
+    inputSchema: RunFunctionalTestingTestParamsSchema,
+    handler: "runFunctionalTestingTest",
+  },
+  {
+    title: "Get Test Status",
+    toolset: "Functional Testing",
+    summary: "Get the status of a Swagger Functional Testing test execution",
+    inputSchema: GetFunctionalTestingExecutionSchema,
+    handler: "getFunctionalTestingExecution",
   },
 ];

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const RunFunctionalTestingTestParamsSchema = z.object({
+  testId: z.string().describe("ID of the Functional Testing test to run"),
+});
+
+export const GetFunctionalTestingExecutionSchema = z.object({
+  executionId: z.string().describe("ID of the Functional Testing execution"),
+});
+
+export type RunFunctionalTestingTestParams = z.infer<
+  typeof RunFunctionalTestingTestParamsSchema
+>;
+export type GetFunctionalTestingExecutionParams = z.infer<
+  typeof GetFunctionalTestingExecutionSchema
+>;

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -67,6 +67,102 @@ describe("FunctionalTestingAPI", () => {
     });
   });
 
+  describe("runTest", () => {
+    const executionMock = { executionId: "42", status: "running" };
+
+    it("should call the correct endpoint with POST method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.runTest({ testId: "94" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests/94/executions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      const result = await api.runTest({ testId: "94" });
+
+      expect(result).toEqual(executionMock);
+    });
+
+    it("should throw ToolError when testId is missing", async () => {
+      await expect(api.runTest({ testId: "" })).rejects.toThrow(
+        "testId argument is required",
+      );
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(api.runTest({ testId: "94" })).rejects.toThrow(
+        "Failed to run test",
+      );
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.runTest({ testId: "94" })).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
+  describe("getExecution", () => {
+    const executionMock = { executionId: "42", status: "passed" };
+
+    it("should call the correct endpoint with GET method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.getExecution({ executionId: "42" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/executions/42",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      const result = await api.getExecution({ executionId: "42" });
+
+      expect(result).toEqual(executionMock);
+    });
+
+    it("should throw ToolError when executionId is missing", async () => {
+      await expect(api.getExecution({ executionId: "" })).rejects.toThrow(
+        "executionId argument is required",
+      );
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
+
+      await expect(api.getExecution({ executionId: "42" })).rejects.toThrow(
+        "Failed to get test status",
+      );
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.getExecution({ executionId: "42" })).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
   describe("getFtHeaders", () => {
     it("should return headers with X-API-KEY and Content-Type", () => {
       const headers = api.getFtHeaders();


### PR DESCRIPTION
## Goal

Fixes [RF-4892](https://smartbear.atlassian.net/browse/RF-4892) and [RF-4925](https://smartbear.atlassian.net/browse/RF-4925)

Extend the Functional Testing toolset by adding support to running tests as well as querying the status and result of the execution.

Minor refactors, and support local development environment

## Design

Following the approach of `list_tests` as well as Reflect tool implementation

## Changeset

* Added methods in the Functional Testing API to run a test, and to get the execution status and results
* Added type definition for the input parameters
* Minor refactors:
  * Utility function to assert Functional Testing is configured
  * Support to use local development environment if `NODE_ENV` environment variable is set to `development`

## Testing

* Unit tests covering both features
* Ran locally and verified the functionality with Claude Desktop. See example:
  <img width="1045" height="860" alt="image" src="https://github.com/user-attachments/assets/94ef41af-1a2f-4d0d-9b8c-cf56109392da" />


[RF-4892]: https://smartbear.atlassian.net/browse/RF-4892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-4925]: https://smartbear.atlassian.net/browse/RF-4925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ