### PR TITLE
feat(functional-testing): Run and query test execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix. For url generation product and portal details ar required and section and toc details are optional.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 
+- [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
         "QTM4J_BASE_URL": "${input:qtm4j_base_url}",
         "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}",
-        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}"
+        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}",
+        "SWAGGER_FUNCTIONAL_TESTING_BASE_PATH": "${input:swagger_functional_testing_base_path}"
       }
     }
   },
@@ -258,6 +259,12 @@ Alternatively, you can use `npx` (or globally install) the `@smartbear/mcp` pack
           "type": "promptString",
           "description": "Swagger Functional Testing API Token - leave blank to disable Functional Testing tools",
           "password": true
+    },
+    {
+          "id": "swagger_functional_testing_base_path",
+          "type": "promptString",
+          "description": "Swagger Functional Testing API Base URL - leave blank to use the default (https://api.reflect.run/v1)",
+          "password": false
     }
   ]
 }
@@ -300,7 +307,8 @@ Add the following configuration to your `claude_desktop_config.json` to launch t
         "QTM4J_API_KEY": "your_qtm4j_key",
         "QTM4J_BASE_URL": "https://qtmcloud.qmetry.com",
         "QTM4J_AUTOMATION_API_KEY": "your_qtm4j_automation_api_key",
-        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "your_swagger_functional_testing_api_token"
+        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "your_swagger_functional_testing_api_token",
+        "SWAGGER_FUNCTIONAL_TESTING_BASE_PATH": "https://api.reflect.run/v1"
       }
     }
   }

--- a/docs/products/SmartBear MCP Server/local-server.md
+++ b/docs/products/SmartBear MCP Server/local-server.md
@@ -130,6 +130,8 @@ export QTM4J_BASE_URL="https://qtmcloud.qmetry.com"
 
 # Required for Swagger Functional Testing tools
 export SWAGGER_FUNCTIONAL_TESTING_API_TOKEN=your-functional-testing-api-token
+# Optional: Override the Swagger Functional Testing API base URL (defaults to https://api.reflect.run/v1)
+export SWAGGER_FUNCTIONAL_TESTING_BASE_PATH=https://api.reflect.run/v1
 ```
 
 > ⚠️ The `MCP_SERVER_BUGSNAG_API_KEY` is used for monitoring the MCP server itself and should be different from your main application's API key.
@@ -170,7 +172,8 @@ Create or edit `.vscode/mcp.json` in your workspace:
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
         "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}",
         "QTM4J_BASE_URL": "${input:qtm4j_base_url}",
-        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}"
+        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}",
+        "SWAGGER_FUNCTIONAL_TESTING_BASE_PATH": "${input:swagger_functional_testing_base_path}"
       }
     }
   },
@@ -282,6 +285,12 @@ Create or edit `.vscode/mcp.json` in your workspace:
       "type": "promptString",
       "description": "Swagger Functional Testing API Token",
       "password": true
+    },
+    {
+      "id": "swagger_functional_testing_base_path",
+      "type": "promptString",
+      "description": "Swagger Functional Testing API Base URL (leave blank for default https://api.reflect.run/v1)",
+      "password": false
     }
   ]
 }
@@ -460,7 +469,8 @@ To run the built server locally in VS Code, add the following to `.vscode/mcp.js
         "QTM4J_API_KEY": "${input:qtm4j_api_key}",
         "QTM4J_AUTOMATION_API_KEY": "${input:qtm4j_automation_api_key}",
         "QTM4J_BASE_URL": "${input:qtm4j_base_url}",
-        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}"
+        "SWAGGER_FUNCTIONAL_TESTING_API_TOKEN": "${input:swagger_functional_testing_api_token}",
+        "SWAGGER_FUNCTIONAL_TESTING_BASE_PATH": "${input:swagger_functional_testing_base_path}"
       }
     }
   },
@@ -572,6 +582,12 @@ To run the built server locally in VS Code, add the following to `.vscode/mcp.js
       "type": "promptString",
       "description": "Swagger Functional Testing API Token",
       "password": true
+    },
+    {
+      "id": "swagger_functional_testing_base_path",
+      "type": "promptString",
+      "description": "Swagger Functional Testing API Base URL (leave blank for default https://api.reflect.run/v1)",
+      "password": false
     }
   ]
 }

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -1,6 +1,6 @@
 ![swagger-functional-testing.svg](./images/embedded/swagger-functional-testing.svg)
 
-The Swagger Functional Testing client provides tools for discovering API tests. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
+The Swagger Functional Testing client provides tools for discovering and executing API tests. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
 ## Available Tools
 
@@ -14,6 +14,23 @@ The Swagger Functional Testing client provides tools for discovering API tests. 
 
 ---
 
+### Test Execution
+
+#### `run_test`
+
+- Purpose: Runs a specific API test in your Swagger Functional Testing workspace. Use this tool when you need to verify expected API functionality by executing a single test. Requires a `testId`, which can be obtained from `list_tests`.
+- Returns: Execution details including an `executionId` that can be used to poll for the result.
+- Use case: Trigger a test run against your API.
+
+#### `get_test_status`
+
+- Purpose: Retrieves the status and result of a previously triggered test execution. Use this tool to check whether a test run has completed and whether it passed or failed. Requires an `executionId` returned by `run_test`.
+- Returns: Execution status and result details for the given execution.
+- Use case: Poll for the outcome of a test run after calling `run_test`.
+
+---
+
 ## Additional Notes
 
 - The `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` environment variable is required to authenticate with the Swagger Functional Testing API.
+- The optional `SWAGGER_FUNCTIONAL_TESTING_BASE_PATH` environment variable allows to override the Swagger Functional Testing API base URL. Defaults to `https://api.reflect.run/v1`

--- a/server.json
+++ b/server.json
@@ -62,6 +62,12 @@
           "isSecret": true
         },
         {
+          "name": "SWAGGER_FUNCTIONAL_TESTING_BASE_PATH",
+          "description": "Override the Swagger Functional Testing API base URL (optional). Defaults to https://api.reflect.run/v1",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
           "name": "PACT_BROKER_BASE_URL",
           "description": "PactFlow/Pact Broker base URL. Leave empty to disable Pact tools. Learn more: https://developer.smartbear.com/smartbear-mcp/docs/contract-testing-with-pactflow",
           "isRequired": false,

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -14,6 +14,10 @@ import {
   FUNCTIONAL_TESTING_API_KEY_HEADER,
   FunctionalTestingAPI,
 } from "./client/functional-testing-api";
+import type {
+  GetFunctionalTestingExecutionTestParams,
+  RunFunctionalTestingTestParams,
+} from "./client/functional-testing-types";
 import {
   type ApiDefinitionParams,
   type ApiSearchParams,
@@ -54,7 +58,6 @@ import {
   type UpdatePortalArgs,
   type UpdateProductArgs,
 } from "./client/index";
-
 import type {
   OrganizationsListResponse,
   OrganizationsQueryParams,
@@ -79,6 +82,12 @@ const ConfigurationSchema = z.object({
     .optional()
     .describe(
       "Swagger Functional Testing API token. Leave empty to disable Functional Testing tools.",
+    ),
+  functional_testing_base_path: z
+    .string()
+    .optional()
+    .describe(
+      "Base URL for Swagger Functional Testing API requests (optional)",
     ),
 });
 
@@ -129,6 +138,7 @@ export class SwaggerClient implements Client {
       this.ftApi = new FunctionalTestingAPI(
         () => this.getFtAuthToken(),
         USER_AGENT,
+        config.functional_testing_base_path,
       );
     }
   }
@@ -328,11 +338,36 @@ export class SwaggerClient implements Client {
     return this.getApi().standardizeApi(args);
   }
 
+  // Functional Testing methods
+
   async listFunctionalTestingTests(): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.listTests());
+  }
+
+  async runFunctionalTestingTest(
+    args: RunFunctionalTestingTestParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.runTest(args));
+  }
+
+  async getFunctionalTestingExecution(
+    args: GetFunctionalTestingExecutionTestParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.getTestExecution(args));
+  }
+
+  /**
+   * Perform an operation with the Functional Testing API.
+   * Throws a ToolError if Functional Testing is not configured
+   */
+  private async withFunctionalTesting<T>(
+    fn: (ftApi: FunctionalTestingAPI) => Promise<T>,
+  ): Promise<T> {
     if (!this.ftApi) {
       throw new ToolError("Functional Testing API not configured");
     }
-    return this.ftApi.listTests();
+
+    return fn(this.ftApi);
   }
 
   async registerTools(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,13 +1,23 @@
 import { ToolError } from "../../common/tools";
+import type {
+  GetFunctionalTestingExecutionTestParams,
+  RunFunctionalTestingTestParams,
+} from "./functional-testing-types";
 
 const API_HOSTNAME = "api.reflect.run";
+
 export const FUNCTIONAL_TESTING_API_KEY_HEADER = "X-API-KEY";
 
 export class FunctionalTestingAPI {
+  private baseUrl: string;
+
   constructor(
     private readonly getToken: () => string | null,
     private readonly userAgent: string,
-  ) {}
+    baseUrl?: string,
+  ) {
+    this.baseUrl = baseUrl || `https://${API_HOSTNAME}/v1`;
+  }
 
   getFtHeaders(): Record<string, string> {
     const token = this.getToken();
@@ -22,7 +32,7 @@ export class FunctionalTestingAPI {
   }
 
   async listTests(): Promise<unknown> {
-    const response = await fetch(`https://${API_HOSTNAME}/v1/tests`, {
+    const response = await fetch(`${this.baseUrl}/tests`, {
       method: "GET",
       headers: this.getFtHeaders(),
     });
@@ -30,6 +40,50 @@ export class FunctionalTestingAPI {
     if (!response.ok) {
       throw new ToolError(
         `Failed to list Functional Testing tests: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async runTest(args: RunFunctionalTestingTestParams): Promise<unknown> {
+    if (!args.testId) throw new ToolError("testId argument is required");
+
+    const response = await fetch(
+      `${this.baseUrl}/tests/${args.testId}/executions`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to run test: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getTestExecution(
+    args: GetFunctionalTestingExecutionTestParams,
+  ): Promise<unknown> {
+    if (!args.executionId) {
+      throw new ToolError("executionId argument is required");
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/executions/${args.executionId}`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to get test status: ${response.status} ${response.statusText}`,
       );
     }
 

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  GetFunctionalTestingExecutionTestSchema,
+  RunFunctionalTestingTestParamsSchema,
+} from "./functional-testing-types";
 import type { SwaggerToolParams } from "./tools";
 import { READ_ONLY } from "./tools";
 
@@ -20,5 +24,28 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     ...READ_ONLY,
     handler: "listFunctionalTestingTests",
     outputSchema: ListTestsOutputSchema,
+  },
+  {
+    title: "Run Test",
+    toolset: "Functional Testing",
+    summary:
+      "Runs a specific API test in your Swagger Functional Testing workspace. " +
+      "The execution is asynchronous — it returns an executionId, not the result directly. " +
+      "Use swagger_get_test_status with that executionId to track progress and retrieve the final result.",
+    inputSchema: RunFunctionalTestingTestParamsSchema,
+    handler: "runFunctionalTestingTest",
+    idempotent: false,
+    readOnly: false,
+  },
+  {
+    title: "Get Test Status",
+    toolset: "Functional Testing",
+    summary:
+      "Get the status of a Swagger Functional Testing test execution. " +
+      "It returns information about the execution such as its status (running, passed or failed), run time, " +
+      "as well as the break down of the status of each test step.",
+    inputSchema: GetFunctionalTestingExecutionTestSchema,
+    handler: "getFunctionalTestingExecution",
+    idempotent: false,
   },
 ];

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const RunFunctionalTestingTestParamsSchema = z.object({
+  testId: z
+    .string()
+    .describe("ID of the Functional Testing test to run")
+    .trim()
+    .min(1),
+});
+
+export const GetFunctionalTestingExecutionTestSchema = z.object({
+  executionId: z
+    .string()
+    .describe("ID of the Functional Testing execution")
+    .trim()
+    .min(1),
+});
+
+export type RunFunctionalTestingTestParams = z.infer<
+  typeof RunFunctionalTestingTestParamsSchema
+>;
+export type GetFunctionalTestingExecutionTestParams = z.infer<
+  typeof GetFunctionalTestingExecutionTestSchema
+>;

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -67,6 +67,102 @@ describe("FunctionalTestingAPI", () => {
     });
   });
 
+  describe("runTest", () => {
+    const executionMock = { executionId: "42", status: "running" };
+
+    it("should call the correct endpoint with POST method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.runTest({ testId: "94" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests/94/executions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      const result = await api.runTest({ testId: "94" });
+
+      expect(result).toEqual(executionMock);
+    });
+
+    it("should throw ToolError when testId is missing", async () => {
+      await expect(api.runTest({ testId: "" })).rejects.toThrow(
+        "testId argument is required",
+      );
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(api.runTest({ testId: "94" })).rejects.toThrow(
+        "Failed to run test",
+      );
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.runTest({ testId: "94" })).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
+  describe("getTestExecution", () => {
+    const executionMock = { executionId: "42", status: "passed" };
+
+    it("should call the correct endpoint with GET method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.getTestExecution({ executionId: "42" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/executions/42",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      const result = await api.getTestExecution({ executionId: "42" });
+
+      expect(result).toEqual(executionMock);
+    });
+
+    it("should throw ToolError when executionId is missing", async () => {
+      await expect(api.getTestExecution({ executionId: "" })).rejects.toThrow(
+        "executionId argument is required",
+      );
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
+
+      await expect(api.getTestExecution({ executionId: "42" })).rejects.toThrow(
+        "Failed to get test status",
+      );
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.getTestExecution({ executionId: "42" })).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
   describe("getFtHeaders", () => {
     it("should return headers with X-API-KEY and Content-Type", () => {
       const headers = api.getFtHeaders();


### PR DESCRIPTION
## Goal

Fixes [RF-4892](https://smartbear.atlassian.net/browse/RF-4892) and [RF-4925](https://smartbear.atlassian.net/browse/RF-4925)

Extend the Functional Testing toolset by adding support to running tests as well as querying the status and result of the execution.

Minor refactors, and support local development environment

## Design

Following the approach of `list_tests` as well as Reflect tool implementation

## Changeset

* Added methods in the Functional Testing API to run a test, and to get the execution status and results
* Added type definition for the input parameters
* Minor refactors:
  * Utility function to assert Functional Testing is configured
  * Support to use local development environment if `NODE_ENV` environment variable is set to `development`

## Testing

* Unit tests covering both features
* Ran locally and verified the functionality with Claude Desktop. See example:
  <img width="1045" height="860" alt="image" src="https://github.com/user-attachments/assets/94ef41af-1a2f-4d0d-9b8c-cf56109392da" />


[RF-4892]: https://smartbear.atlassian.net/browse/RF-4892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-4925]: https://smartbear.atlassian.net/browse/RF-4925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ