### PR TITLE
fix: zephyr_get_test_case_steps schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Common] Added transport mode (stdio/http) to User-Agent header for all API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
 - [Collaborator] Add user agent header to API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
 
+### Fixed
+- [Zephyr] Fix output validation for `zephyr_get_test_case_steps` when Zephyr returns `null` for optional fields and includes additional step keys (e.g. `id`).
+
 ## [0.25.1] - 2026-06-08
 
 ### Fixed

--- a/src/tests/unit/zephyr/tool/test-case/get-test-steps.test.ts
+++ b/src/tests/unit/zephyr/tool/test-case/get-test-steps.test.ts
@@ -109,4 +109,33 @@ describe("GetTestCaseSteps", () => {
     );
     expect(result.structuredContent).toBeUndefined();
   });
+
+  it("should allow null values for optional inline/testCase fields", () => {
+    const responseMock = {
+      next: null,
+      startAt: 0,
+      maxResults: 1,
+      total: 1,
+      isLast: true,
+      values: [
+        {
+          id: 123,
+          index: 0,
+          customFields: {},
+          inline: {
+            description: "Navigate to Sites page",
+            testData: null,
+            expectedResult: "Sites page is displayed",
+            reflectRef: null,
+          },
+          testCase: null,
+        },
+      ],
+    };
+
+    const parsed = getTestCaseStepsResponse.parse(responseMock);
+    expect(parsed.values?.[0].inline?.testData).toBeNull();
+    expect(parsed.values?.[0].inline?.reflectRef).toBeNull();
+    expect(parsed.values?.[0].testCase).toBeNull();
+  });
 });

--- a/src/zephyr/common/rest-api-schemas.ts
+++ b/src/zephyr/common/rest-api-schemas.ts
@@ -1857,7 +1857,8 @@ export const GetTestCaseTestSteps200Response = zod
                   .describe("The instruction to be followed"),
                 testData: zod
                   .string()
-                  .nullish()
+                  .nullable()
+                  .optional()
                   .describe(
                     "Any test data required to perform the instruction (optional). The fields values provided can be interpolated into the description.",
                   ),
@@ -1875,10 +1876,11 @@ export const GetTestCaseTestSteps200Response = zod
                   ),
                 reflectRef: zod
                   .string()
-                  .nullish()
+                  .nullable()
+                  .optional()
                   .describe("The AI reference. Zephyr only feature"),
               })
-              .strict()
+              .passthrough()
               .nullish(),
             testCase: zod
               .object({
@@ -1922,10 +1924,11 @@ export const GetTestCaseTestSteps200Response = zod
                   .nullish()
                   .describe("The list of parameters of the call to test step"),
               })
-              .strict()
-              .nullish(),
+              .passthrough()
+              .nullable()
+              .optional(),
           })
-          .strict()
+          .passthrough()
           .describe(
             "An instruction to be followed as part of a step-by-step test script. The test step can have either an inline definition, or delegate execution to another test case. One of these options must be specified.",
           ),


### PR DESCRIPTION
## Goal
Fix output schema validation for `zephyr_get_test_case_steps` so MCP clients can retrieve Zephyr STEP_BY_STEP test steps even when Zephyr returns `null` for optional fields and includes additional metadata keys (e.g. `id`).

## Design
- Updated the Zod output schema (`GetTestCaseTestSteps200Response`) to:
  - allow explicit `null` for optional step fields (`inline.testData`, `inline.reflectRef`, and `testCase`)
  - relax strict object validation (`passthrough`) so Zephyr step objects with extra keys (like `id`) do not fail MCP structured-content validation
- Added a unit test that exercises parsing of a Zephyr-like response containing `null` and extra keys.

## Changeset
- `src/zephyr/common/rest-api-schemas.ts`: relax output schema for `zephyr_get_test_case_steps`
- `src/tests/unit/zephyr/tool/test-case/get-test-steps.test.ts`: add test for `null`/extra-key parsing
- `CHANGELOG.md`: add entry under Unreleased -> Fixed

## Testing
- `npm test`
- `npm run lint`

Made with [Cursor](https://cursor.com)