### PR TITLE
feat(tools): add `get_test_detail` for fetching test details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] Add Swagger Functional Testing integration with `list_tests` tool for discovering available API tests. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 - [Common] Added transport mode (stdio/http) to User-Agent header for all API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
 - [Collaborator] Add user agent header to API requests [#517](https://github.com/SmartBear/smartbear-mcp/pull/517)
+- [Reflect] Added `get_test_detail` tool for retrieving full test details including name, description, and all recorded steps [#524](https://github.com/SmartBear/smartbear-mcp/pull/524)
 
 ## [0.25.1] - 2026-06-08
 

--- a/docs/products/SmartBear MCP Server/reflect-integration.md
+++ b/docs/products/SmartBear MCP Server/reflect-integration.md
@@ -64,6 +64,13 @@ The Reflect client provides test management, execution, and test authoring capab
 - Returns: Status of a test.
 - Use case: Understand the health status of a given test.
 
+#### `reflect_get_test_detail`
+
+- Purpose: Get the full detail of a reflect test, including its name, description, and all recorded steps.
+- Parameters: Test identifier (`testId`).
+- Returns: Complete test details including all recorded steps.
+- Use case: Inspect the structure of a specific test before executing or editing it.
+
 ---
 
 ### Test Authoring & Agent Interaction

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -26,6 +26,7 @@ import { ExecuteSuite } from "./tool/suites/execute-suite";
 import { GetSuiteExecutionStatus } from "./tool/suites/get-suite-execution-status";
 import { ListSuiteExecutions } from "./tool/suites/list-suite-executions";
 import { ListSuites } from "./tool/suites/list-suites";
+import { GetTestDetail } from "./tool/tests/get-test-detail";
 import { GetTestStatus } from "./tool/tests/get-test-status";
 import { ListSegments } from "./tool/tests/list-segments";
 import { ListTests } from "./tool/tests/list-tests";
@@ -185,6 +186,7 @@ export class ReflectClient implements Client {
       new ExecuteSuite(this),
       new CancelSuiteExecution(this),
       new ListTests(this),
+      new GetTestDetail(this),
       new RunTest(this),
       new GetTestStatus(this),
     ];

--- a/src/reflect/tool/tests/get-test-detail.ts
+++ b/src/reflect/tool/tests/get-test-detail.ts
@@ -1,0 +1,46 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
+import { Tool, ToolError } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { ReflectClient } from "../../client";
+import { API_HOSTNAME } from "../../config/constants";
+
+export class GetTestDetail extends Tool<ReflectClient> {
+  specification: ToolParams = {
+    title: "Get Test Detail",
+    toolset: "Tests",
+    summary:
+      "Get the full detail of a reflect test, including its name, description, and all recorded steps",
+    inputSchema: z.object({
+      testId: z
+        .string()
+        .describe("ID of the reflect test to retrieve details for"),
+    }),
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args) => {
+    const { testId } = args as { testId: string };
+    if (!testId || !testId.trim())
+      throw new ToolError("testId argument is required");
+
+    const response = await fetch(
+      `https://${API_HOSTNAME}/v1/tests/${encodeURIComponent(testId)}`,
+      {
+        method: "GET",
+        headers: this.client.getHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to get test detail: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+    };
+  };
+}

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -9996,6 +9996,26 @@ Expected Output: Tool is NOT called yet. Inform the user that 'critical' was not
     "outputSchema": undefined,
     "title": "Reflect: Get Suite Execution Status",
   },
+  "reflect_get_test_detail": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Reflect: Get Test Detail",
+    },
+    "description": "Get the full detail of a reflect test, including its name, description, and all recorded steps
+
+**Toolset:** Tests
+
+**Parameters:**
+- testId (string) *required*: ID of the reflect test to retrieve details for",
+    "inputSchema": [
+      "testId",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Get Test Detail",
+  },
   "reflect_get_test_status": {
     "annotations": {
       "destructiveHint": false,

--- a/src/tests/unit/reflect/tool/tests/get-test-detail.test.ts
+++ b/src/tests/unit/reflect/tool/tests/get-test-detail.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+import { GetTestDetail } from "../../../../../reflect/tool/tests/get-test-detail";
+
+const fetchMock = createFetchMock(vi);
+fetchMock.enableMocks();
+
+const testDetailMock = {
+  id: 1,
+  name: "Sauce Demo",
+  description: "",
+  steps: [
+    {
+      type: "direct-navigation",
+      url: "https://www.saucedemo.com/",
+    },
+    {
+      type: "click",
+      selector: '[data-test="username"]',
+    },
+    {
+      type: "input",
+      selector: '[data-test="username"]',
+      inputText: "error_user",
+    },
+    {
+      type: "click",
+      selector: '[data-test="password"]',
+    },
+    {
+      type: "input",
+      selector: '[data-test="password"]',
+      inputText: "secret_sauce",
+    },
+    {
+      type: "click",
+      selector: '[data-test="login-button"]',
+    },
+    {
+      type: "implicit-navigation",
+      url: "https://www.saucedemo.com/inventory.html",
+    },
+  ],
+};
+
+describe("GetTestDetail", () => {
+  let mockClient: any;
+  let instance: GetTestDetail;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+
+    mockClient = {
+      getHeaders: vi.fn().mockReturnValue({
+        "X-API-KEY": "test-api-key",
+        "Content-Type": "application/json",
+      }),
+    };
+
+    instance = new GetTestDetail(mockClient as any);
+  });
+
+  describe("specification", () => {
+    it("should have the correct title", () => {
+      expect(instance.specification.title).toBe("Get Test Detail");
+    });
+
+    it("should have the correct toolset", () => {
+      expect(instance.specification.toolset).toBe("Tests");
+    });
+
+    it("should have a non-empty summary", () => {
+      expect(instance.specification.summary).toBeTruthy();
+    });
+  });
+
+  describe("handle – happy path", () => {
+    it("should call the correct URL with GET method and auth headers", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      await instance.handle({ testId: "1" }, {} as any);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests/1",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return test id and name in the response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      const result = await instance.handle({ testId: "1" }, {} as any);
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.id).toBe(1);
+      expect(parsed.name).toBe("Sauce Demo");
+    });
+
+    it("should return the full steps array in the response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      const result = await instance.handle({ testId: "1" }, {} as any);
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      expect(parsed.steps).toHaveLength(7);
+    });
+
+    it("should include direct-navigation step with correct url", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      const result = await instance.handle({ testId: "1" }, {} as any);
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      const navStep = parsed.steps.find(
+        (s: any) => s.type === "direct-navigation",
+      );
+      expect(navStep?.url).toBe("https://www.saucedemo.com/");
+    });
+
+    it("should include input step with inputText", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      const result = await instance.handle({ testId: "1" }, {} as any);
+
+      const parsed = JSON.parse((result.content[0] as any).text);
+      const inputStep = parsed.steps.find(
+        (s: any) =>
+          s.type === "input" && s.selector === '[data-test="username"]',
+      );
+      expect(inputStep?.inputText).toBe("error_user");
+    });
+
+    it("should return content as a text node", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(testDetailMock));
+
+      const result = await instance.handle({ testId: "1" }, {} as any);
+
+      expect(result.content[0].type).toBe("text");
+    });
+  });
+
+  describe("handle – error cases", () => {
+    it("should throw ToolError if testId is missing (empty string)", async () => {
+      await expect(instance.handle({ testId: "" }, {} as any)).rejects.toThrow(
+        "testId argument is required",
+      );
+    });
+
+    it("should throw ToolError if testId is not provided at all", async () => {
+      await expect(instance.handle({}, {} as any)).rejects.toThrow(
+        "testId argument is required",
+      );
+    });
+
+    it("should throw ToolError if testId is whitespace-only", async () => {
+      await expect(
+        instance.handle({ testId: "   " }, {} as any),
+      ).rejects.toThrow("testId argument is required");
+    });
+
+    it("should throw ToolError on 401 Unauthorized", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(instance.handle({ testId: "1" }, {} as any)).rejects.toThrow(
+        "Failed to get test detail",
+      );
+    });
+
+    it("should throw ToolError on 404 Not Found", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(
+        instance.handle({ testId: "999" }, {} as any),
+      ).rejects.toThrow("Failed to get test detail");
+    });
+
+    it("should throw ToolError on 500 Internal Server Error", async () => {
+      fetchMock.mockResponseOnce("Server Error", { status: 500 });
+
+      await expect(instance.handle({ testId: "1" }, {} as any)).rejects.toThrow(
+        "Failed to get test detail",
+      );
+    });
+
+    it("should include HTTP status in the error message", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(instance.handle({ testId: "1" }, {} as any)).rejects.toThrow(
+        "404",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes : [RF-4805](https://smartbear.atlassian.net/browse/RF-4805)

## Goal

  Expose full test detail (name, description, recorded steps) via MCP so agents can inspect a Reflect test without leaving the conversation.

  ## Design
  
  Follows the existing tool pattern (`RunTest`, `GetTestStatus`) — single `GET /v1/tests/:testId` call, response returned as raw JSON text content. `testId` is URL-encoded to prevent path injection;
  whitespace-only IDs are rejected before the network call.

  ## Changeset
  
  - `src/reflect/tool/tests/get-test-detail.ts` — new `GetTestDetail` tool
  - `src/reflect/client.ts` — registers `GetTestDetail` in the tool list

  ## Testing
 - [x] Correct URL and auth headers used in fetch call
  - [x] Returns full response (id, name, steps) as JSON text content
  - [x] Rejects empty `testId` with `ToolError`
  - [x] Rejects whitespace-only `testId` with `ToolError`
  - [x] Rejects missing `testId` with `ToolError`
  - [x] Throws `ToolError` on 401 Unauthorized
  - [x] Throws `ToolError` on 404 Not Found
  - [x] Throws `ToolError` on 500 Internal Server Error
  - [x] Error message includes HTTP status code


[RF-4805]: https://smartbear.atlassian.net/browse/RF-4805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ