### PR TITLE
feat: update swagger_publish_portal_product tool to get the live and preview urls for page or product (SWG-20373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Swagger] Refactored `publish_portal_product` to build live URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` in the publish response.
+[#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+### Added
 
-- [Swagger] Refactored `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix.
+- [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 
 ## [0.26.1] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Swagger] Refactored `publish_portal_product` to build live URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` in the publish response.
+- [Swagger] Refactored `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` in the publish response.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 
 ## [0.26.1] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Swagger] Refactored `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` in the publish response.
+- [Swagger] Refactored `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 
 ## [0.26.1] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix.
+- [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix. For url generation product and portal details ar required and section and toc details are optional.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 
 ## [0.26.1] - 2026-06-24

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -115,26 +115,29 @@ The Swagger Portal client provides comprehensive portal and product management c
 
 #### `publish_portal_product`
 
-- Purpose: Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
-- Returns: Publication status information with the following structure:
-  - `success` (boolean): Publication success status
-  - `preview` (boolean): Whether this is a preview or live publication
-  - `liveUrl` (string, conditional): Generated live URL (only when preview is false)
-  - `previewUrl` (string, conditional): Generated preview URL (only when preview is true)
-  - `product` (object): Product metadata with fields: `id`, `name`, `slug`
-  - `portal` (object): Portal metadata with fields: `id`, `name`, `subdomain`, `customDomain`
-  - `tableOfContentsItem` Optional (object): Table of contents metadata with fields: `id`, `slug`, `title`, `order`, `parentId` (null when tableOfContentsId is not provided or not found)
-- Use case: Make product content visible to portal visitors, either as live content or preview for testing.
-- Parameters:
+ - Purpose: Publish a product's content to make it live or as a preview. This endpoint publishes the current content of a product, making it visible to portal visitors.
+ - Use: Call with `preview` set to `true` for preview publishes, `false` for live. Optionally pass `tableOfContentsId` to resolve a page-specific URL.
+ - Returns:
+   - `success` (boolean)
+   - `preview` (boolean)
+   - `liveUrl` (string|null) — present when `preview` is false and URL build succeeds; otherwise `null`
+   - `previewUrl` (string|null) — present when `preview` is true and URL build succeeds; otherwise `null`
+   - `product` (object) — `{ id, name, slug }` when available
+   - `portal` (object) — `{ id, name, subdomain, customDomain }` when available
+   - `tableOfContentsItem` (object|null) — present when `tableOfContentsId` resolved
+   - `warning` (object) — returned when metadata/URL building failed; contains `code`, `step`, and `message`. A `warning` does NOT mean the publish failed.
 
-| Parameter   | Description                                                                                                                          | Type    | Required |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
-| `productId` | Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product                         | string  | Yes      |
-| `preview`   | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No       |
-| `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
+ - Parameters:
+
+   | Parameter | Description | Type | Required |
+   | --- | --- | --- | --- |
+   | `productId` | Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product | string | Yes |
+   | `preview` | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No |
+   | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
 **Response Details:**
 - Returns success plus product/portal metadata and a publish URL (previewUrl if preview, else liveUrl); includes tableOfContentsItem (and a direct TOC URL) only when tableOfContentsId was provided and resolved.
+- When URL building fails, response includes `liveUrl`/`previewUrl` as `null` and a `warning` explaining the failure.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -115,25 +115,25 @@ The Swagger Portal client provides comprehensive portal and product management c
 
 #### `publish_portal_product`
 
- - Purpose: Publish a product's content to make it live or as a preview. This endpoint publishes the current content of a product, making it visible to portal visitors.
- - Use: Call with `preview` set to `true` for preview publishes, `false` for live. Optionally pass `tableOfContentsId` to resolve a page-specific URL.
- - Returns:
-   - `success` (boolean)
-   - `preview` (boolean)
-   - `liveUrl` (string|null) — present when `preview` is false and URL build succeeds; otherwise `null`
-   - `previewUrl` (string|null) — present when `preview` is true and URL build succeeds; otherwise `null`
-   - `product` (object) — `{ id, name, slug }` when available
-   - `portal` (object) — `{ id, name, subdomain, customDomain }` when available
-   - `tableOfContentsItem` (object|null) — present when `tableOfContentsId` resolved
-   - `warning` (object) — returned when metadata/URL building failed; contains `code`, `step`, and `message`. A `warning` does NOT mean the publish failed.
+- Purpose: Publish a product's content to make it live or as a preview. This endpoint publishes the current content of a product, making it visible to portal visitors.
+- Use: Call with `preview` set to `true` for preview publishes, `false` for live. Optionally pass `tableOfContentsId` to resolve a page-specific URL.
+- Returns:
+  - `success` (boolean)
+  - `preview` (boolean)
+  - `liveUrl` (string|null) — present when `preview` is false and URL build succeeds; otherwise `null`
+  - `previewUrl` (string|null) — present when `preview` is true and URL build succeeds; otherwise `null`
+  - `product` (object) — `{ id, name, slug }` when available
+  - `portal` (object) — `{ id, name, subdomain, customDomain }` when available
+  - `tableOfContentsItem` (object|null) — present when `tableOfContentsId` resolved
+  - `warning` (object) — returned when metadata/URL building failed; contains `code`, `step`, and `message`. A `warning` does NOT mean the publish failed.
 
- - Parameters:
+- Parameters:
 
-   | Parameter | Description | Type | Required |
-   | --- | --- | --- | --- |
-   | `productId` | Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product | string | Yes |
-   | `preview` | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No |
-   | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| `productId` | Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product | string | Yes |
+| `preview` | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No |
+| `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
 **Response Details:**
 - Returns success plus product/portal metadata and a publish URL (previewUrl if preview, else liveUrl); includes tableOfContentsItem (and a direct TOC URL) only when tableOfContentsId was provided and resolved.

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -134,10 +134,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
 **Response Details:**
-- When `portal.customDomain` is present, it is used as the full host in the generated URL without appending the portal UI suffix
-- When `customDomain` is not present, the URL is built using `portal.subdomain` + the portal UI suffix (`.portal.swaggerhub.com`)
-- When `tableOfContentsId` resolves successfully, the returned URL includes the section and table-of-contents path in the format: `/{productSlug}/{sectionSlug}/{tocSlug}`
-- The response includes only essential fields from product, portal, and tableOfContentsItem.
+- The response contains a URL to the product. If tableOfContentsId is found, the URL links directly to that table of contents page.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -116,7 +116,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 #### `publish_portal_product`
 
 - Purpose: Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
-- Returns: Publication status information, including the generated live URL when the product can be resolved.
+- Returns: Publication status information, including the generated `liveUrl` for live publication or `previewUrl` for preview publication when the product can be resolved.
 - Use case: Make product content visible to portal visitors, either as live content or preview for testing.
 - Parameters:
 
@@ -126,7 +126,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 | `preview`   | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No       |
 | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
-The publish response now includes `liveUrl` when available. The live URL is built dynamically from the configured `portalBasePath`, so it works across dev2, int, and production environments.
+The publish response now includes `liveUrl` for live publication and `previewUrl` for preview publication. The URL is built dynamically from the configured `portalBasePath`, so it works across dev2, int, and production environments. When `tableOfContentsId` resolves, the returned URL includes the section and table-of-contents path.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -116,7 +116,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 #### `publish_portal_product`
 
 - Purpose: Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
-- Returns: Publication status information.
+- Returns: Publication status information, including the generated live URL when the product can be resolved.
 - Use case: Make product content visible to portal visitors, either as live content or preview for testing.
 - Parameters:
 
@@ -124,6 +124,9 @@ The Swagger Portal client provides comprehensive portal and product management c
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `productId` | Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product                         | string  | Yes      |
 | `preview`   | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No       |
+| `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
+
+The publish response now includes `liveUrl` when available. The live URL is built dynamically from the configured `portalBasePath`, so it works across dev2, int, and production environments.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -134,7 +134,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
 **Response Details:**
-- The response contains a URL to the product. If tableOfContentsId is found, the URL links directly to that table of contents page.
+- Returns success plus product/portal metadata and a publish URL (previewUrl if preview, else liveUrl); includes tableOfContentsItem (and a direct TOC URL) only when tableOfContentsId was provided and resolved.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -123,7 +123,7 @@ The Swagger Portal client provides comprehensive portal and product management c
   - `previewUrl` (string, conditional): Generated preview URL (only when preview is true)
   - `product` (object): Product metadata with fields: `id`, `name`, `slug`
   - `portal` (object): Portal metadata with fields: `id`, `name`, `subdomain`, `customDomain`
-  - `tableOfContentsItem` (object | null): Table of contents metadata with fields: `id`, `slug`, `title`, `order`, `parentId` (null when tableOfContentsId is not provided or not found)
+  - `tableOfContentsItem` Optional (object): Table of contents metadata with fields: `id`, `slug`, `title`, `order`, `parentId` (null when tableOfContentsId is not provided or not found)
 - Use case: Make product content visible to portal visitors, either as live content or preview for testing.
 - Parameters:
 
@@ -137,7 +137,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 - When `portal.customDomain` is present, it is used as the full host in the generated URL without appending the portal UI suffix
 - When `customDomain` is not present, the URL is built using `portal.subdomain` + the portal UI suffix (`.portal.swaggerhub.com`)
 - When `tableOfContentsId` resolves successfully, the returned URL includes the section and table-of-contents path in the format: `/{productSlug}/{sectionSlug}/{tocSlug}`
-- The response includes only essential fields from product, portal, and tableOfContentsItem following React/TypeScript best practices using Pick<> utility types
+- The response includes only essential fields from product, portal, and tableOfContentsItem.
 
 ### Product Sections Management
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -135,7 +135,7 @@ The Swagger Portal client provides comprehensive portal and product management c
 
 **Response Details:**
 - When `portal.customDomain` is present, it is used as the full host in the generated URL without appending the portal UI suffix
-- When `customDomain` is not present, the URL is built using `portal.subdomain` + the portal UI suffix (`.portal.swaggerhub.com`)  
+- When `customDomain` is not present, the URL is built using `portal.subdomain` + the portal UI suffix (`.portal.swaggerhub.com`)
 - When `tableOfContentsId` resolves successfully, the returned URL includes the section and table-of-contents path in the format: `/{productSlug}/{sectionSlug}/{tocSlug}`
 - The response includes only essential fields from product, portal, and tableOfContentsItem following React/TypeScript best practices using Pick<> utility types
 

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -116,7 +116,14 @@ The Swagger Portal client provides comprehensive portal and product management c
 #### `publish_portal_product`
 
 - Purpose: Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
-- Returns: Publication status information, including the generated `liveUrl` for live publication or `previewUrl` for preview publication when the product can be resolved.
+- Returns: Publication status information with the following structure:
+  - `success` (boolean): Publication success status
+  - `preview` (boolean): Whether this is a preview or live publication
+  - `liveUrl` (string, conditional): Generated live URL (only when preview is false)
+  - `previewUrl` (string, conditional): Generated preview URL (only when preview is true)
+  - `product` (object): Product metadata with fields: `id`, `name`, `slug`
+  - `portal` (object): Portal metadata with fields: `id`, `name`, `subdomain`, `customDomain`
+  - `tableOfContentsItem` (object | null): Table of contents metadata with fields: `id`, `slug`, `title`, `order`, `parentId` (null when tableOfContentsId is not provided or not found)
 - Use case: Make product content visible to portal visitors, either as live content or preview for testing.
 - Parameters:
 
@@ -126,7 +133,11 @@ The Swagger Portal client provides comprehensive portal and product management c
 | `preview`   | Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) | boolean | No       |
 | `tableOfContentsId` | Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug' used to resolve a specific live URL path | string | No |
 
-The publish response now includes `liveUrl` for live publication and `previewUrl` for preview publication. The URL is built dynamically from the configured `portalBasePath`, so it works across dev2, int, and production environments. When `tableOfContentsId` resolves, the returned URL includes the section and table-of-contents path.
+**Response Details:**
+- When `portal.customDomain` is present, it is used as the full host in the generated URL without appending the portal UI suffix
+- When `customDomain` is not present, the URL is built using `portal.subdomain` + the portal UI suffix (`.portal.swaggerhub.com`)  
+- When `tableOfContentsId` resolves successfully, the returned URL includes the section and table-of-contents path in the format: `/{productSlug}/{sectionSlug}/{tocSlug}`
+- The response includes only essential fields from product, portal, and tableOfContentsItem following React/TypeScript best practices using Pick<> utility types
 
 ### Product Sections Management
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -232,7 +232,11 @@ export class SwaggerClient implements Client {
     args: PublishProductArgs,
   ): Promise<PublishPortalProductResponse | FallbackResponse> {
     const { productId, preview, tableOfContentsId } = args;
-    return this.getApi().publishPortalProduct(productId, preview, tableOfContentsId ?? null);
+    return this.getApi().publishPortalProduct(
+      productId,
+      preview,
+      tableOfContentsId ?? null,
+    );
   }
 
   async getPortalProductSections(

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -35,6 +35,7 @@ import {
   type PortalsListResponse,
   type Product,
   type ProductsListResponse,
+  type PublishPortalProductResponse,
   type PublishProductArgs,
   type ScanApiStandardizationFromRegistryParams,
   type ScanApiStandardizationFromRegistryResult,
@@ -229,9 +230,9 @@ export class SwaggerClient implements Client {
 
   async publishPortalProduct(
     args: PublishProductArgs,
-  ): Promise<SuccessResponse | FallbackResponse> {
-    const { productId, preview } = args;
-    return this.getApi().publishPortalProduct(productId, preview);
+  ): Promise<PublishPortalProductResponse | FallbackResponse> {
+    const { productId, preview, tableOfContentsId } = args;
+    return this.getApi().publishPortalProduct(productId, preview, tableOfContentsId ?? null);
   }
 
   async getPortalProductSections(

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -398,15 +398,12 @@ export class SwaggerAPI {
       }),
     ]);
 
-    // Fetch portal details after portalId ID is available
     const portalDetails = await this.getPortal(
       String(productDetails.portalId ?? ""),
     );
 
-    // Get the first section (primary section)
     const targetSection = sections.items[0] ?? null;
 
-    // Resolve the target table of contents item if tableOfContentsId is provided
     const targetTocItem =
       tableOfContentsId && targetSection
         ? findTableOfContentsItem(
@@ -415,18 +412,15 @@ export class SwaggerAPI {
           )
         : null;
 
-    // Build live URL using environment-specific domain
-    const host = portalDetails.customDomain ?? portalDetails.subdomain;
     const publicationUrl = buildPortalLiveUrl(
       this.config,
-      host,
+      portalDetails,
       productDetails.slug,
       targetSection,
       targetTocItem,
       preview,
     );
 
-    // Publish the product to the portal
     const response = await fetch(
       `${this.config.portalBasePath}/products/${productId}/published-content?preview=${preview}`,
       {
@@ -441,9 +435,28 @@ export class SwaggerAPI {
 
     return {
       ...result,
+      preview,
       ...(preview
         ? { previewUrl: publicationUrl }
         : { liveUrl: publicationUrl }),
+      product: {
+        id: productDetails.id,
+        name: productDetails.name,
+        slug: productDetails.slug,
+      },
+      portal: {
+        id: portalDetails.id,
+        name: portalDetails.name,
+        subdomain: portalDetails.subdomain,
+        customDomain: portalDetails.customDomain,
+      },
+      tableOfContentsItem: targetTocItem ? {
+        id: targetTocItem.id,
+        slug: targetTocItem.slug,
+        title: targetTocItem.title,
+        order: targetTocItem.order,
+        parentId: targetTocItem.parentId,
+      } : null,
     } as PublishPortalProductResponse;
   }
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -482,7 +482,7 @@ export class SwaggerAPI {
       success: true,
     } as SuccessResponse);
 
-    return {
+    const baseResponse: any = {
       ...result,
       preview,
       ...(preview
@@ -490,8 +490,13 @@ export class SwaggerAPI {
         : { liveUrl: metadata.publicationUrl }),
       product: metadata.product,
       portal: metadata.portal,
-      tableOfContentsItem: metadata.tableOfContentsItem,
-    } as PublishPortalProductResponse;
+    };
+
+    if (tableOfContentsId && metadata.tableOfContentsItem) {
+      baseResponse.tableOfContentsItem = metadata.tableOfContentsItem;
+    }
+
+    return baseResponse as PublishPortalProductResponse;
   }
 
   async getPortalProductSections(

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1,6 +1,5 @@
 import { ToolError } from "../../common/tools";
 import type { SwaggerConfiguration } from "./configuration";
-import { buildPortalLiveUrl, findTableOfContentsItem } from "./utils";
 import type {
   CreatePortalArgs,
   CreateProductBody,
@@ -48,6 +47,7 @@ import type {
   OrganizationsListResponse,
   OrganizationsQueryParams,
 } from "./user-management-types";
+import { buildPortalLiveUrl, findTableOfContentsItem } from "./utils";
 
 // Regex to extract owner, name, and version from SwaggerHub URLs.
 // Matches /apis/owner/name/version, /domains/owner/name/version, or /templates/owner/name/version

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1,9 +1,6 @@
 import { ToolError } from "../../common/tools";
 import type { SwaggerConfiguration } from "./configuration";
-import {
-  buildPortalLiveUrl,
-  findTableOfContentsItem,
-} from "./utils";
+import { buildPortalLiveUrl, findTableOfContentsItem } from "./utils";
 import type {
   CreatePortalArgs,
   CreateProductBody,
@@ -394,7 +391,10 @@ export class SwaggerAPI {
     publicationUrl: string;
     product: Pick<Product, "id" | "name" | "slug">;
     portal: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
-    tableOfContentsItem: Pick<TableOfContentsItem, "id" | "slug" | "title" | "order" | "parentId"> | null;
+    tableOfContentsItem: Pick<
+      TableOfContentsItem,
+      "id" | "slug" | "title" | "order" | "parentId"
+    > | null;
   }> {
     const [productDetails, sections] = await Promise.all([
       this.getPortalProduct(productId),
@@ -439,13 +439,15 @@ export class SwaggerAPI {
         subdomain: portalDetails.subdomain,
         customDomain: portalDetails.customDomain,
       },
-      tableOfContentsItem: targetTocItem ? {
-        id: targetTocItem.id,
-        slug: targetTocItem.slug,
-        title: targetTocItem.title,
-        order: targetTocItem.order,
-        parentId: targetTocItem.parentId,
-      } : null,
+      tableOfContentsItem: targetTocItem
+        ? {
+            id: targetTocItem.id,
+            slug: targetTocItem.slug,
+            title: targetTocItem.title,
+            order: targetTocItem.order,
+            parentId: targetTocItem.parentId,
+          }
+        : null,
     };
   }
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -378,11 +378,12 @@ export class SwaggerAPI {
   }
 
   /**
-   * Publish a portal product and generate live URL with environment-specific domain
+   * Publish a portal product and generate a published URL with environment-specific domain.
+   * Returns `liveUrl` for live publishes and `previewUrl` for preview publishes.
    * @param productId - ID of the product to publish
    * @param preview - Whether to publish in preview mode (default: false)
-   * @param tableOfContentsId - Optional tableOfContentsId The table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
-   * @returns Complete publish response with product details and live URL
+   * @param tableOfContentsId - Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
+   * @returns Complete publish response with product details and the resolved published URL
    */
   async publishPortalProduct(
     productId: string,
@@ -416,12 +417,13 @@ export class SwaggerAPI {
 
     // Build live URL using environment-specific domain
     const host = portalDetails.customDomain ?? portalDetails.subdomain;
-    const liveUrl = buildPortalLiveUrl(
+    const publicationUrl = buildPortalLiveUrl(
       this.config,
       host,
       productDetails.slug,
       targetSection,
       targetTocItem,
+      preview,
     );
 
     // Publish the product to the portal
@@ -439,7 +441,9 @@ export class SwaggerAPI {
 
     return {
       ...result,
-      liveUrl,
+      ...(preview
+        ? { previewUrl: publicationUrl }
+        : { liveUrl: publicationUrl }),
     } as PublishPortalProductResponse;
   }
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -376,38 +376,84 @@ export class SwaggerAPI {
 
   /**
    * Prepare publication metadata and URL for a portal product and page.
-   * Fetches product, portal, and section details, resolves TOC item if provided,
-   * and builds the live and preview URL.
+   * Fetches product, portal, and section details step-by-step, gracefully handling failures.
+   * Product and portal details are essential for URL generation; sections are optional.
    * @param productId - ID of the product to publish
    * @param preview - Whether this is a preview publish
    * @param tableOfContentsId - Optional table of contents UUID or identifier
-   * @returns Publication metadata including URL and narrowed entity details
+   * @returns Publication metadata with optional fields based on what could be fetched
    */
   private async preparePublicationMetadata(
     productId: string,
     preview: boolean,
     tableOfContentsId: string | null,
   ): Promise<{
-    publicationUrl: string;
-    product: Pick<Product, "id" | "name" | "slug">;
-    portal: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
-    tableOfContentsItem: Pick<
+    publicationUrl: string | null;
+    product?: Pick<Product, "id" | "name" | "slug">;
+    portal?: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
+    tableOfContentsItem?: Pick<
       TableOfContentsItem,
       "id" | "slug" | "title" | "order" | "parentId"
-    > | null;
+    >;
+    warning?: {
+      step: string;
+      message: string;
+    };
   }> {
-    const [productDetails, sections] = await Promise.all([
-      this.getPortalProduct(productId),
-      this.getPortalProductSections(productId, {
+    // Step 1: Fetch product details (required for URL generation)
+    let productDetails: Product | null = null;
+    try {
+      productDetails = await this.getPortalProduct(productId);
+    } catch (error) {
+      console.warn("Failed to fetch product details:", error);
+      return {
+        publicationUrl: null,
+        warning: {
+          step: "product",
+          message: `Product published ${preview ? "in preview mode" : "in live mode"} successfully, but failed to fetch product details for URL generation`,
+        },
+      };
+    }
+
+    // Step 2: Fetch portal details (required for URL generation)
+    let portalDetails: Portal | null = null;
+    if (productDetails?.portalId) {
+      try {
+        portalDetails = await this.getPortal(String(productDetails.portalId));
+      } catch (error) {
+        console.warn("Failed to fetch portal details:", error);
+      }
+    }
+
+    // If we don't have both product and portal, return empty URL only
+    if (!portalDetails) {
+      return {
+        publicationUrl: null,
+        product: productDetails
+          ? {
+              id: productDetails.id,
+              name: productDetails.name,
+              slug: productDetails.slug,
+            }
+          : undefined,
+        warning: {
+          step: "portal",
+          message: `Product published ${preview ? "in preview mode" : "in live mode"} successfully, but failed to fetch portal details for URL generation`,
+        },
+      };
+    }
+
+    // Step 3: Fetch sections (optional, for page-specific URLs)
+    let sections: SectionsListResponse | null = null;
+    try {
+      sections = await this.getPortalProductSections(productId, {
         embed: ["tableOfContents", "tableOfContents.swaggerhubApi"],
-      }),
-    ]);
+      });
+    } catch (error) {
+      console.warn("Failed to fetch sections:", error);
+    }
 
-    const portalDetails = await this.getPortal(
-      String(productDetails.portalId ?? ""),
-    );
-
-    const targetSection = sections.items[0] ?? null;
+    const targetSection = sections?.items[0] ?? null;
 
     const targetTocItem =
       tableOfContentsId && targetSection
@@ -417,6 +463,7 @@ export class SwaggerAPI {
           )
         : null;
 
+    // Build URL with available data (product + portal required, section + toc optional)
     const publicationUrl = buildPortalLiveUrl(
       this.config,
       portalDetails,
@@ -439,37 +486,37 @@ export class SwaggerAPI {
         subdomain: portalDetails.subdomain,
         customDomain: portalDetails.customDomain,
       },
-      tableOfContentsItem: targetTocItem
+      ...(targetTocItem
         ? {
-            id: targetTocItem.id,
-            slug: targetTocItem.slug,
-            title: targetTocItem.title,
-            order: targetTocItem.order,
-            parentId: targetTocItem.parentId,
+            tableOfContentsItem: {
+              id: targetTocItem.id,
+              slug: targetTocItem.slug,
+              title: targetTocItem.title,
+              order: targetTocItem.order,
+              parentId: targetTocItem.parentId,
+            },
           }
-        : null,
+        : {}),
     };
   }
 
   /**
    * Publish a portal product and generate a published URL with environment-specific domain.
-   * Returns `liveUrl` for live publishes and `previewUrl` for preview publishes.
+   * The publish operation always succeeds if the API call succeeds. URL generation is done separately and may fail gracefully.
+   * Returns `liveUrl` for live publishes and `previewUrl` for preview publishes (null if URL building fails).
+   * When metadata/URL building fails, response includes `success: true` (publish succeeded), `liveUrl/previewUrl: null`,
+   * and a `warning` object explaining which step failed (product/portal fetch or URL building).
    * @param productId - ID of the product to publish
    * @param preview - Whether to publish in preview mode (default: false)
    * @param tableOfContentsId - Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
-   * @returns Complete publish response with product details and the resolved published URL
+   * @returns Complete publish response with `success: true`, optional URL/metadata, and optional warning details
    */
   async publishPortalProduct(
     productId: string,
     preview: boolean = false,
     tableOfContentsId: string | null = null,
   ): Promise<PublishPortalProductResponse | FallbackResponse> {
-    const metadata = await this.preparePublicationMetadata(
-      productId,
-      preview,
-      tableOfContentsId,
-    );
-
+    // Execute the publish operation first (primary action)
     const response = await fetch(
       `${this.config.portalBasePath}/products/${productId}/published-content?preview=${preview}`,
       {
@@ -482,21 +529,52 @@ export class SwaggerAPI {
       success: true,
     } as SuccessResponse);
 
-    const baseResponse: any = {
-      ...result,
-      preview,
-      ...(preview
-        ? { previewUrl: metadata.publicationUrl }
-        : { liveUrl: metadata.publicationUrl }),
-      product: metadata.product,
-      portal: metadata.portal,
-    };
+    // Attempt to build metadata and URLs
+    try {
+      const metadata = await this.preparePublicationMetadata(
+        productId,
+        preview,
+        tableOfContentsId,
+      );
 
-    if (tableOfContentsId && metadata.tableOfContentsItem) {
-      baseResponse.tableOfContentsItem = metadata.tableOfContentsItem;
+      // Build complete response with metadata
+      return {
+        ...result,
+        preview,
+        [preview ? "previewUrl" : "liveUrl"]: metadata.publicationUrl,
+        ...(metadata.product ? { product: metadata.product } : {}),
+        ...(metadata.portal ? { portal: metadata.portal } : {}),
+        ...(metadata.tableOfContentsItem
+          ? { tableOfContentsItem: metadata.tableOfContentsItem }
+          : {}),
+        ...(metadata.warning
+          ? {
+              warning: {
+                code: "METADATA_FETCH_FAILED",
+                step: metadata.warning.step,
+                message: metadata.warning.message,
+              },
+            }
+          : {}),
+      } as PublishPortalProductResponse;
+    } catch (error) {
+      console.warn(
+        "Failed to build publication metadata — returning publish success with empty URL:",
+        error,
+      );
+
+      // Return publish success with null URL field and warning details
+      return {
+        ...result,
+        preview,
+        [preview ? "previewUrl" : "liveUrl"]: null,
+        warning: {
+          code: "METADATA_BUILD_FAILED",
+          step: "url_build",
+          message: `Product published ${preview ? "in preview mode" : "in live mode"} successfully, but failed to build publication URL`,
+        },
+      } as PublishPortalProductResponse;
     }
-
-    return baseResponse as PublishPortalProductResponse;
   }
 
   async getPortalProductSections(

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -377,7 +377,7 @@ export class SwaggerAPI {
   /**
    * Prepare publication metadata and URL for a portal product and page.
    * Fetches product, portal, and section details, resolves TOC item if provided,
-   * and builds the publication URL.
+   * and builds the live and preview URL.
    * @param productId - ID of the product to publish
    * @param preview - Whether this is a preview publish
    * @param tableOfContentsId - Optional table of contents UUID or identifier

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1,5 +1,9 @@
 import { ToolError } from "../../common/tools";
 import type { SwaggerConfiguration } from "./configuration";
+import {
+  buildPortalLiveUrl,
+  findTableOfContentsItem,
+} from "./utils";
 import type {
   CreatePortalArgs,
   CreateProductBody,
@@ -14,6 +18,7 @@ import type {
   PortalsListResponse,
   Product,
   ProductsListResponse,
+  PublishPortalProductResponse,
   SectionsListResponse,
   SuccessResponse,
   TableOfContentsItem,
@@ -372,10 +377,54 @@ export class SwaggerAPI {
     } as SuccessResponse);
   }
 
+  /**
+   * Publish a portal product and generate live URL with environment-specific domain
+   * @param productId - ID of the product to publish
+   * @param preview - Whether to publish in preview mode (default: false)
+   * @param tableOfContentsId - Optional tableOfContentsId The table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
+   * @returns Complete publish response with product details and live URL
+   */
   async publishPortalProduct(
     productId: string,
     preview: boolean = false,
-  ): Promise<SuccessResponse | FallbackResponse> {
+    tableOfContentsId: string | null = null,
+  ): Promise<PublishPortalProductResponse | FallbackResponse> {
+
+    const [productDetails, sections] = await Promise.all([
+      this.getPortalProduct(productId),
+      this.getPortalProductSections(productId, {
+        embed: ["tableOfContents", "tableOfContents.swaggerhubApi"],
+      }),
+    ]);
+
+    // Fetch portal details after portalId ID is available
+    const portalDetails = await this.getPortal(
+      String(productDetails.portalId ?? ""),
+    );
+
+    // Get the first section (primary section)
+    const targetSection = sections.items[0] ?? null;
+
+    // Resolve the target table of contents item if tableOfContentsId is provided
+    const targetTocItem =
+      tableOfContentsId && targetSection
+        ? findTableOfContentsItem(
+            targetSection.tableOfContents ?? [],
+            tableOfContentsId,
+          )
+        : null;
+
+    // Build live URL using environment-specific domain
+    const host = portalDetails.customDomain ?? portalDetails.subdomain;
+    const liveUrl = buildPortalLiveUrl(
+      this.config,
+      host,
+      productDetails.slug,
+      targetSection,
+      targetTocItem,
+    );
+
+    // Publish the product to the portal
     const response = await fetch(
       `${this.config.portalBasePath}/products/${productId}/published-content?preview=${preview}`,
       {
@@ -383,9 +432,15 @@ export class SwaggerAPI {
         headers: this.headers,
       },
     );
-    return this.handleResponse<SuccessResponse>(response, {
+
+    const result = await this.handleResponse<SuccessResponse>(response, {
       success: true,
     } as SuccessResponse);
+
+    return {
+      ...result,
+      liveUrl,
+    } as PublishPortalProductResponse;
   }
 
   async getPortalProductSections(
@@ -413,9 +468,19 @@ export class SwaggerAPI {
       headers: this.headers,
     });
 
+    const defaultResponse: SectionsListResponse = {
+      page: {
+        number: 0,
+        size: 0,
+        totalElements: 0,
+        totalPages: 0,
+      },
+      items: [],
+    };
+
     const result = await this.handleResponse<SectionsListResponse>(
       response,
-      [] as SectionsListResponse,
+      defaultResponse,
     );
     return result as SectionsListResponse;
   }
@@ -488,8 +553,12 @@ export class SwaggerAPI {
 
     const result = await response.json();
 
-    // The API returns a paginated response, so we extract the items array
-    return result.items as TableOfContentsListResponse;
+    // The API may return either a raw array or a paginated response with an items array.
+    if (Array.isArray(result)) {
+      return result as TableOfContentsListResponse;
+    }
+
+    return (result.items ?? []) as TableOfContentsListResponse;
   }
 
   /**
@@ -981,14 +1050,12 @@ export class SwaggerAPI {
 
     const result = await this.handleResponse<StandardizeApiResponse>(response);
 
-    // Validate that we have the expected response structure
     if (!hasMessage(result)) {
       throw new ToolError(
         "Unexpected response format from standardizeApi endpoint",
       );
     }
 
-    // If errorsFound is not present, default to 0 (no errors found)
     if (!hasErrorsFound(result)) {
       return { ...result, errorsFound: 0 } as StandardizeApiResponse;
     }

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -378,19 +378,24 @@ export class SwaggerAPI {
   }
 
   /**
-   * Publish a portal product and generate a published URL with environment-specific domain.
-   * Returns `liveUrl` for live publishes and `previewUrl` for preview publishes.
+   * Prepare publication metadata and URL for a portal product and page.
+   * Fetches product, portal, and section details, resolves TOC item if provided,
+   * and builds the publication URL.
    * @param productId - ID of the product to publish
-   * @param preview - Whether to publish in preview mode (default: false)
-   * @param tableOfContentsId - Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
-   * @returns Complete publish response with product details and the resolved published URL
+   * @param preview - Whether this is a preview publish
+   * @param tableOfContentsId - Optional table of contents UUID or identifier
+   * @returns Publication metadata including URL and narrowed entity details
    */
-  async publishPortalProduct(
+  private async preparePublicationMetadata(
     productId: string,
-    preview: boolean = false,
-    tableOfContentsId: string | null = null,
-  ): Promise<PublishPortalProductResponse | FallbackResponse> {
-
+    preview: boolean,
+    tableOfContentsId: string | null,
+  ): Promise<{
+    publicationUrl: string;
+    product: Pick<Product, "id" | "name" | "slug">;
+    portal: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
+    tableOfContentsItem: Pick<TableOfContentsItem, "id" | "slug" | "title" | "order" | "parentId"> | null;
+  }> {
     const [productDetails, sections] = await Promise.all([
       this.getPortalProduct(productId),
       this.getPortalProductSections(productId, {
@@ -421,24 +426,8 @@ export class SwaggerAPI {
       preview,
     );
 
-    const response = await fetch(
-      `${this.config.portalBasePath}/products/${productId}/published-content?preview=${preview}`,
-      {
-        method: "PUT",
-        headers: this.headers,
-      },
-    );
-
-    const result = await this.handleResponse<SuccessResponse>(response, {
-      success: true,
-    } as SuccessResponse);
-
     return {
-      ...result,
-      preview,
-      ...(preview
-        ? { previewUrl: publicationUrl }
-        : { liveUrl: publicationUrl }),
+      publicationUrl,
       product: {
         id: productDetails.id,
         name: productDetails.name,
@@ -457,6 +446,49 @@ export class SwaggerAPI {
         order: targetTocItem.order,
         parentId: targetTocItem.parentId,
       } : null,
+    };
+  }
+
+  /**
+   * Publish a portal product and generate a published URL with environment-specific domain.
+   * Returns `liveUrl` for live publishes and `previewUrl` for preview publishes.
+   * @param productId - ID of the product to publish
+   * @param preview - Whether to publish in preview mode (default: false)
+   * @param tableOfContentsId - Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'
+   * @returns Complete publish response with product details and the resolved published URL
+   */
+  async publishPortalProduct(
+    productId: string,
+    preview: boolean = false,
+    tableOfContentsId: string | null = null,
+  ): Promise<PublishPortalProductResponse | FallbackResponse> {
+    const metadata = await this.preparePublicationMetadata(
+      productId,
+      preview,
+      tableOfContentsId,
+    );
+
+    const response = await fetch(
+      `${this.config.portalBasePath}/products/${productId}/published-content?preview=${preview}`,
+      {
+        method: "PUT",
+        headers: this.headers,
+      },
+    );
+
+    const result = await this.handleResponse<SuccessResponse>(response, {
+      success: true,
+    } as SuccessResponse);
+
+    return {
+      ...result,
+      preview,
+      ...(preview
+        ? { previewUrl: metadata.publicationUrl }
+        : { liveUrl: metadata.publicationUrl }),
+      product: metadata.product,
+      portal: metadata.portal,
+      tableOfContentsItem: metadata.tableOfContentsItem,
     } as PublishPortalProductResponse;
   }
 

--- a/src/swagger/client/configuration.ts
+++ b/src/swagger/client/configuration.ts
@@ -53,17 +53,7 @@ export class SwaggerConfiguration {
     };
   }
 
-  /**
-   * Get the portal UI domain suffix from portalBasePath
-   * Extracts the portal domain for building live URLs like:
-   * - https://api.dev2.portal.swaggerhub.com/v1 → ".dev2.portal.swaggerhub.com"
-   * - https://api.int.portal.swaggerhub.com/v1 → ".int.portal.swaggerhub.com"
-   * - https://api.portal.swaggerhub.com/v1 (prod) → ".portal.swaggerhub.com"
-   * @returns Portal UI domain suffix with leading dot (e.g., ".dev2.portal.swaggerhub.com")
-   */
   getPortalUiDomainSuffix(): string {
-    // Match pattern: https://api[.{env}].portal.swaggerhub.com
-    // Extract everything from the first dot after api to the end
     const match = this.portalBasePath.match(
       /https?:\/\/api(\..*\.portal\.swaggerhub\.com)/,
     );

--- a/src/swagger/client/configuration.ts
+++ b/src/swagger/client/configuration.ts
@@ -52,4 +52,24 @@ export class SwaggerConfiguration {
       "User-Agent": userAgent,
     };
   }
+
+  /**
+   * Get the portal UI domain suffix from portalBasePath
+   * Extracts the portal domain for building live URLs like:
+   * - https://api.dev2.portal.swaggerhub.com/v1 → ".dev2.portal.swaggerhub.com"
+   * - https://api.int.portal.swaggerhub.com/v1 → ".int.portal.swaggerhub.com"
+   * - https://api.portal.swaggerhub.com/v1 (prod) → ".portal.swaggerhub.com"
+   * @returns Portal UI domain suffix with leading dot (e.g., ".dev2.portal.swaggerhub.com")
+   */
+  getPortalUiDomainSuffix(): string {
+    // Match pattern: https://api[.{env}].portal.swaggerhub.com
+    // Extract everything from the first dot after api to the end
+    const match = this.portalBasePath.match(
+      /https?:\/\/api(\..*\.portal\.swaggerhub\.com)/
+    );
+    if ( match?.[1]) {
+      return match[1];
+    }
+    return ".portal.swaggerhub.com";
+  }
 }

--- a/src/swagger/client/configuration.ts
+++ b/src/swagger/client/configuration.ts
@@ -65,9 +65,9 @@ export class SwaggerConfiguration {
     // Match pattern: https://api[.{env}].portal.swaggerhub.com
     // Extract everything from the first dot after api to the end
     const match = this.portalBasePath.match(
-      /https?:\/\/api(\..*\.portal\.swaggerhub\.com)/
+      /https?:\/\/api(\..*\.portal\.swaggerhub\.com)/,
     );
-    if ( match?.[1]) {
+    if (match?.[1]) {
       return match[1];
     }
     return ".portal.swaggerhub.com";

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -432,6 +432,7 @@ export type UpdateDocumentBody = Omit<UpdateDocumentArgs, "documentId">;
 
 export type PublishPortalProductResponse = SuccessResponse & {
   liveUrl?: string;
+  previewUrl?: string;
 };
 
 // Response types for better type safety

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -436,7 +436,10 @@ export type PublishPortalProductResponse = SuccessResponse & {
   previewUrl?: string;
   product?: Pick<Product, "id" | "name" | "slug">;
   portal?: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
-  tableOfContentsItem?: Pick<TableOfContentsItem, "id" | "slug" | "title" | "order" | "parentId"> | null;
+  tableOfContentsItem?: Pick<
+    TableOfContentsItem,
+    "id" | "slug" | "title" | "order" | "parentId"
+  > | null;
 };
 
 // Response types for better type safety

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -335,6 +335,12 @@ export const UpdateProductArgsSchema = ProductArgsSchema.extend({
 });
 
 export const PublishProductArgsSchema = ProductArgsSchema.extend({
+  tableOfContentsId: z
+    .string()
+    .optional()
+    .describe(
+      "The table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'",
+    ),
   preview: z
     .boolean()
     .optional()
@@ -424,6 +430,10 @@ export type CreateTableOfContentsBody = Omit<
 >;
 export type UpdateDocumentBody = Omit<UpdateDocumentArgs, "documentId">;
 
+export type PublishPortalProductResponse = SuccessResponse & {
+  liveUrl?: string;
+};
+
 // Response types for better type safety
 export type FallbackResponse =
   | {
@@ -440,12 +450,15 @@ export interface Portal {
   id: string;
   name: string;
   subdomain?: string;
+  customDomain?: string;
   [key: string]: unknown;
 }
 
 export interface Product {
   id: string;
   name: string;
+  slug: string;
+  portalId?: string;
   [key: string]: unknown;
 }
 
@@ -508,5 +521,16 @@ export interface TableOfContentsItemSwaggerhubApi {
 // Response collection types
 export type PortalsListResponse = Portal[];
 export type ProductsListResponse = Product[];
-export type SectionsListResponse = Section[];
+
+export interface PaginatedResponse<T> {
+  page: {
+    number: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+  };
+  items: T[];
+}
+
+export type SectionsListResponse = PaginatedResponse<Section>;
 export type TableOfContentsListResponse = TableOfContentsItem[];

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -432,14 +432,19 @@ export type UpdateDocumentBody = Omit<UpdateDocumentArgs, "documentId">;
 
 export type PublishPortalProductResponse = SuccessResponse & {
   preview: boolean;
-  liveUrl?: string;
-  previewUrl?: string;
+  liveUrl?: string | null;
+  previewUrl?: string | null;
   product?: Pick<Product, "id" | "name" | "slug">;
   portal?: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
   tableOfContentsItem?: Pick<
     TableOfContentsItem,
     "id" | "slug" | "title" | "order" | "parentId"
   > | null;
+  warning?: {
+    code: string;
+    step: string;
+    message: string;
+  };
 };
 
 // Response types for better type safety

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -39,7 +39,7 @@ export const GetProductSectionsArgsSchema = z.object({
     .number()
     .optional()
     .describe(
-      "Number of items per page for pagination - controls how many results are returned per page (default is 20)",
+      "Number of items per page for pagination - controls how many results are returned per page (default is 10)",
     ),
 });
 
@@ -339,7 +339,7 @@ export const PublishProductArgsSchema = ProductArgsSchema.extend({
     .string()
     .optional()
     .describe(
-      "The table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'",
+      "Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'. When provided, publishPortalProduct uses it to resolve the published URL path for the returned preview/live link.",
     ),
   preview: z
     .boolean()
@@ -431,8 +431,12 @@ export type CreateTableOfContentsBody = Omit<
 export type UpdateDocumentBody = Omit<UpdateDocumentArgs, "documentId">;
 
 export type PublishPortalProductResponse = SuccessResponse & {
+  preview: boolean;
   liveUrl?: string;
   previewUrl?: string;
+  product?: Pick<Product, "id" | "name" | "slug">;
+  portal?: Pick<Portal, "id" | "name" | "subdomain" | "customDomain">;
+  tableOfContentsItem?: Pick<TableOfContentsItem, "id" | "slug" | "title" | "order" | "parentId"> | null;
 };
 
 // Response types for better type safety

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -108,7 +108,7 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "Publish Portal Product",
     toolset: "Products",
     summary:
-      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.",
+      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to form liveUrl or previewUrl for specific table-of-contents item or specific page url. Returns a PublishPortalProductResponse containing: success status, preview boolean, liveUrl or previewUrl (depending on preview mode), and narrowed metadata objects for product (id, name, slug), portal (id, name, subdomain, customDomain), and tableOfContentsItem (id, slug, title, order, parentId) when resolved.",
     inputSchema: PublishProductArgsSchema,
     handler: "publishPortalProduct",
   },

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -108,7 +108,7 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "Publish Portal Product",
     toolset: "Products",
     summary:
-      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to get a live or preview URL pointing to a specific page. Returns publication status, a live or preview URL, and metadata for the product and portal.",
+      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide `tableOfContentsId` to get a page-specific URL. Returns publication status, a live or preview URL (null if URL building fails), product and portal metadata, and an optional `warning` when metadata/URL building failed — a warning does NOT mean the publish failed.",
     inputSchema: PublishProductArgsSchema,
     handler: "publishPortalProduct",
   },

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -108,7 +108,7 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "Publish Portal Product",
     toolset: "Products",
     summary:
-      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to form liveUrl or previewUrl for specific table-of-contents item or specific page url. Returns a PublishPortalProductResponse containing: success status, preview boolean, liveUrl or previewUrl (depending on preview mode), and narrowed metadata objects for product (id, name, slug), portal (id, name, subdomain, customDomain), and tableOfContentsItem (id, slug, title, order, parentId) when resolved.",
+      "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to get a live or preview URL pointing to a specific page. Returns publication status, a live or preview URL, and metadata for the product and portal.",
     inputSchema: PublishProductArgsSchema,
     handler: "publishPortalProduct",
   },

--- a/src/swagger/client/utils.ts
+++ b/src/swagger/client/utils.ts
@@ -26,7 +26,7 @@ export function findTableOfContentsItem(
 }
 
 /**
- * Build the live URL for a published portal product.
+ * Build the live URL or previewUrl for a published portal product.
  */
 export function buildPortalLiveUrl(
   config: SwaggerConfiguration,
@@ -34,6 +34,7 @@ export function buildPortalLiveUrl(
   productSlug: string | undefined,
   section: UrlSegmentSource,
   tocItem: UrlSegmentSource,
+  preview: boolean = false,
 ): string {
   if (!host || !productSlug) {
     return "";
@@ -41,10 +42,11 @@ export function buildPortalLiveUrl(
 
   const portalUiDomain = config.getPortalUiDomainSuffix();
   const baseUrl = `https://${host}${portalUiDomain}/${productSlug}`;
+  const previewSuffix = preview ? "?preview=product" : "";
 
   if (section?.slug && tocItem?.slug) {
-    return `${baseUrl}/${section.slug}/${tocItem.slug}`;
+    return `${baseUrl}/${section.slug}/${tocItem.slug}${previewSuffix}`;
   }
 
-  return baseUrl;
+  return `${baseUrl}${previewSuffix}`;
 }

--- a/src/swagger/client/utils.ts
+++ b/src/swagger/client/utils.ts
@@ -1,4 +1,3 @@
-
 import type { SwaggerConfiguration } from "./configuration";
 import type { TableOfContentsItem } from "./portal-types";
 
@@ -41,7 +40,9 @@ export function buildPortalLiveUrl(
   preview: boolean = false,
 ): string {
   const host = portal?.customDomain ?? portal?.subdomain;
-  const portalUiDomain = portal?.customDomain ? "" : config.getPortalUiDomainSuffix();
+  const portalUiDomain = portal?.customDomain
+    ? ""
+    : config.getPortalUiDomainSuffix();
 
   if (!host || !productSlug) {
     return "";

--- a/src/swagger/client/utils.ts
+++ b/src/swagger/client/utils.ts
@@ -1,0 +1,50 @@
+
+import type { SwaggerConfiguration } from "./configuration";
+import type { TableOfContentsItem } from "./portal-types";
+
+type UrlSegmentSource = { slug?: string } | null;
+
+/**
+ * Recursively search for a table of contents item by ID.
+ */
+export function findTableOfContentsItem(
+  items: TableOfContentsItem[],
+  targetId: string,
+): TableOfContentsItem | null {
+  for (const item of items) {
+    if (item.id === targetId) {
+      return item;
+    }
+
+    const nestedMatch = findTableOfContentsItem(item.children ?? [], targetId);
+    if (nestedMatch) {
+      return nestedMatch;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build the live URL for a published portal product.
+ */
+export function buildPortalLiveUrl(
+  config: SwaggerConfiguration,
+  host: string | undefined,
+  productSlug: string | undefined,
+  section: UrlSegmentSource,
+  tocItem: UrlSegmentSource,
+): string {
+  if (!host || !productSlug) {
+    return "";
+  }
+
+  const portalUiDomain = config.getPortalUiDomainSuffix();
+  const baseUrl = `https://${host}${portalUiDomain}/${productSlug}`;
+
+  if (section?.slug && tocItem?.slug) {
+    return `${baseUrl}/${section.slug}/${tocItem.slug}`;
+  }
+
+  return baseUrl;
+}

--- a/src/swagger/client/utils.ts
+++ b/src/swagger/client/utils.ts
@@ -3,6 +3,10 @@ import type { SwaggerConfiguration } from "./configuration";
 import type { TableOfContentsItem } from "./portal-types";
 
 type UrlSegmentSource = { slug?: string } | null;
+type PortalHostSource = {
+  customDomain?: string | null;
+  subdomain?: string | null;
+} | null;
 
 /**
  * Recursively search for a table of contents item by ID.
@@ -30,17 +34,19 @@ export function findTableOfContentsItem(
  */
 export function buildPortalLiveUrl(
   config: SwaggerConfiguration,
-  host: string | undefined,
+  portal: PortalHostSource,
   productSlug: string | undefined,
   section: UrlSegmentSource,
   tocItem: UrlSegmentSource,
   preview: boolean = false,
 ): string {
+  const host = portal?.customDomain ?? portal?.subdomain;
+  const portalUiDomain = portal?.customDomain ? "" : config.getPortalUiDomainSuffix();
+
   if (!host || !productSlug) {
     return "";
   }
 
-  const portalUiDomain = config.getPortalUiDomainSuffix();
   const baseUrl = `https://${host}${portalUiDomain}/${productSlug}`;
   const previewSuffix = preview ? "?preview=product" : "";
 

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -10460,7 +10460,7 @@ None",
 - productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product
 - embed (array): List of related entities to embed in the response - e.g., ['tableOfContents', 'tableOfContents.swaggerhubApi'] to include table of contents and SwaggerHub API details
 - page (number): Page number for paginated results - specifies which page of results to retrieve (default is 1)
-- size (number): Number of items per page for pagination - controls how many results are returned per page (default is 20)",
+- size (number): Number of items per page for pagination - controls how many results are returned per page (default is 10)",
     "inputSchema": [
       "embed",
       "page",
@@ -10539,16 +10539,18 @@ None",
       "readOnlyHint": true,
       "title": "Swagger: Publish Portal Product",
     },
-    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live.
+    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to form liveUrl or previewUrl for specific table-of-contents item or specific page url. Returns a PublishPortalProductResponse containing: success status, preview boolean, liveUrl or previewUrl (depending on preview mode), and narrowed metadata objects for product (id, name, slug), portal (id, name, subdomain, customDomain), and tableOfContentsItem (id, slug, title, order, parentId) when resolved.
 
 **Toolset:** Products
 
 **Parameters:**
 - productId (string) *required*: Product UUID or identifier in the format 'portal-subdomain:product-slug' - unique identifier for the product
+- tableOfContentsId (string): Optional table of contents UUID, or identifier in the format 'portal-subdomain:product-slug:section-slug:table-of-contents-slug'. When provided, publishPortalProduct uses it to resolve the published URL path for the returned preview/live link.
 - preview (boolean): Whether to publish as preview (true) or live (false). Preview allows testing before going live. Defaults to false (live publication) (default: false)",
     "inputSchema": [
       "preview",
       "productId",
+      "tableOfContentsId",
     ],
     "outputSchema": undefined,
     "title": "Swagger: Publish Portal Product",

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -10539,7 +10539,7 @@ None",
       "readOnlyHint": true,
       "title": "Swagger: Publish Portal Product",
     },
-    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to get a live or preview URL pointing to a specific page. Returns publication status, a live or preview URL, and metadata for the product and portal.
+    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide \`tableOfContentsId\` to get a page-specific URL. Returns publication status, a live or preview URL (null if URL building fails), product and portal metadata, and an optional \`warning\` when metadata/URL building failed — a warning does NOT mean the publish failed.
 
 **Toolset:** Products
 

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -10539,7 +10539,7 @@ None",
       "readOnlyHint": true,
       "title": "Swagger: Publish Portal Product",
     },
-    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to form liveUrl or previewUrl for specific table-of-contents item or specific page url. Returns a PublishPortalProductResponse containing: success status, preview boolean, liveUrl or previewUrl (depending on preview mode), and narrowed metadata objects for product (id, name, slug), portal (id, name, subdomain, customDomain), and tableOfContentsItem (id, slug, title, order, parentId) when resolved.
+    "description": "Publish a product's content to make it live or as preview. This endpoint publishes the current content of a product, making it visible to portal visitors. Use preview mode to test before going live. Optionally provide tableOfContentsId to get a live or preview URL pointing to a specific page. Returns publication status, a live or preview URL, and metadata for the product and portal.
 
 **Toolset:** Products
 

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -536,7 +536,6 @@ describe("SwaggerAPI", () => {
           subdomain: portalResponse.subdomain,
           customDomain: undefined,
         },
-        tableOfContentsItem: null,
       });
     });
 

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -481,8 +481,7 @@ describe("SwaggerAPI", () => {
       expect(result).toEqual({
         success: true,
         preview: false,
-        liveUrl:
-          `https://testportal.portal.swaggerhub.com/${productSlug}/docs/getting-started`,
+        liveUrl: `https://testportal.portal.swaggerhub.com/${productSlug}/docs/getting-started`,
         product: {
           id: productResponse.id,
           name: productResponse.name,
@@ -525,8 +524,7 @@ describe("SwaggerAPI", () => {
       expect(result).toEqual({
         success: true,
         preview: true,
-        previewUrl:
-          `https://testportal.portal.swaggerhub.com/${productSlug}?preview=product`,
+        previewUrl: `https://testportal.portal.swaggerhub.com/${productSlug}?preview=product`,
         product: {
           id: productResponse.id,
           name: productResponse.name,

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -424,56 +424,44 @@ describe("SwaggerAPI", () => {
       ],
     };
 
-    const previewSectionsResponse = {
+    const emptySectionsResponse = {
       page: {
         number: 0,
         size: 20,
-        totalElements: 1,
-        totalPages: 1,
+        totalElements: 0,
+        totalPages: 0,
       },
       items: [],
     };
 
     const publishResponse = { success: true };
 
-    it("should publish product and return resolved liveUrl", async () => {
+    it("should publish live product and return full metadata with liveUrl", async () => {
+      // Publish happens first, then metadata fetching
       fetchMock
-        .mockResponseOnce(JSON.stringify(productResponse))
-        .mockResponseOnce(JSON.stringify(sectionsResponse))
-        .mockResponseOnce(JSON.stringify(portalResponse))
-        .mockResponseOnce(JSON.stringify(publishResponse));
+        .mockResponseOnce(JSON.stringify(publishResponse)) // 1. PUT publish
+        .mockResponseOnce(JSON.stringify(productResponse)) // 2. GET product
+        .mockResponseOnce(JSON.stringify(portalResponse)) // 3. GET portal
+        .mockResponseOnce(JSON.stringify(sectionsResponse)); // 4. GET sections
 
       const result = await api.publishPortalProduct(productId, false, tocId);
 
+      // Verify publish was called first
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        `https://api.portal.swaggerhub.com/v1/products/${productId}`,
-        {
-          method: "GET",
-          headers,
-        },
-      );
-      expect(fetchMock).toHaveBeenNthCalledWith(
-        2,
-        `https://api.portal.swaggerhub.com/v1/products/${productId}/sections?embed=tableOfContents&embed=tableOfContents.swaggerhubApi`,
-        {
-          method: "GET",
-          headers,
-        },
-      );
-      expect(fetchMock).toHaveBeenNthCalledWith(
-        3,
-        `https://api.portal.swaggerhub.com/v1/portals/${portalId}`,
-        {
-          method: "GET",
-          headers,
-        },
-      );
-      expect(fetchMock).toHaveBeenNthCalledWith(
-        4,
         `https://api.portal.swaggerhub.com/v1/products/${productId}/published-content?preview=false`,
         {
           method: "PUT",
+          headers,
+        },
+      );
+
+      // Verify metadata was fetched after publish
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        `https://api.portal.swaggerhub.com/v1/products/${productId}`,
+        {
+          method: "GET",
           headers,
         },
       );
@@ -503,17 +491,17 @@ describe("SwaggerAPI", () => {
       });
     });
 
-    it("should publish preview product and return previewUrl", async () => {
+    it("should publish preview product and return previewUrl without tableOfContents", async () => {
       fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
         .mockResponseOnce(JSON.stringify(productResponse))
-        .mockResponseOnce(JSON.stringify(previewSectionsResponse))
         .mockResponseOnce(JSON.stringify(portalResponse))
-        .mockResponseOnce(JSON.stringify(publishResponse));
+        .mockResponseOnce(JSON.stringify(emptySectionsResponse));
 
       const result = await api.publishPortalProduct(productId, true);
 
       expect(fetchMock).toHaveBeenNthCalledWith(
-        4,
+        1,
         `https://api.portal.swaggerhub.com/v1/products/${productId}/published-content?preview=true`,
         {
           method: "PUT",
@@ -539,12 +527,12 @@ describe("SwaggerAPI", () => {
       });
     });
 
-    it("should use customDomain as the full host when present", async () => {
+    it("should use customDomain when present in portal", async () => {
       fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
         .mockResponseOnce(JSON.stringify(productResponse))
-        .mockResponseOnce(JSON.stringify(sectionsResponse))
         .mockResponseOnce(JSON.stringify(customDomainPortalResponse))
-        .mockResponseOnce(JSON.stringify(publishResponse));
+        .mockResponseOnce(JSON.stringify(sectionsResponse));
 
       const result = await api.publishPortalProduct(productId, true, tocId);
 
@@ -570,6 +558,140 @@ describe("SwaggerAPI", () => {
           title: sectionsResponse.items[0].tableOfContents[0].title,
           order: sectionsResponse.items[0].tableOfContents[0].order,
           parentId: sectionsResponse.items[0].tableOfContents[0].parentId,
+        },
+      });
+    });
+
+    it("should succeed with warning when product fetch fails (live mode)", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
+        .mockResponseOnce(JSON.stringify({ error: "Not found" }), {
+          status: 404,
+        });
+
+      const result = await api.publishPortalProduct(productId, false);
+
+      expect(result).toEqual({
+        success: true,
+        preview: false,
+        liveUrl: null,
+        warning: {
+          code: "METADATA_FETCH_FAILED",
+          step: "product",
+          message:
+            "Product published in live mode successfully, but failed to fetch product details for URL generation",
+        },
+      });
+    });
+
+    it("should succeed with warning when product fetch fails (preview mode)", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
+        .mockResponseOnce(JSON.stringify({ error: "Not found" }), {
+          status: 404,
+        });
+
+      const result = await api.publishPortalProduct(productId, true);
+
+      expect(result).toEqual({
+        success: true,
+        preview: true,
+        previewUrl: null,
+        warning: {
+          code: "METADATA_FETCH_FAILED",
+          step: "product",
+          message:
+            "Product published in preview mode successfully, but failed to fetch product details for URL generation",
+        },
+      });
+    });
+
+    it("should succeed with warning when portal fetch fails", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
+        .mockResponseOnce(JSON.stringify(productResponse))
+        .mockResponseOnce(JSON.stringify({ error: "Not found" }), {
+          status: 404,
+        });
+
+      const result = await api.publishPortalProduct(productId, false);
+
+      expect(result).toEqual({
+        success: true,
+        preview: false,
+        liveUrl: null,
+        product: {
+          id: productResponse.id,
+          name: productResponse.name,
+          slug: productResponse.slug,
+        },
+        warning: {
+          code: "METADATA_FETCH_FAILED",
+          step: "portal",
+          message:
+            "Product published in live mode successfully, but failed to fetch portal details for URL generation",
+        },
+      });
+    });
+
+    it("should succeed even when sections fetch fails (sections are optional)", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
+        .mockResponseOnce(JSON.stringify(productResponse))
+        .mockResponseOnce(JSON.stringify(portalResponse))
+        .mockResponseOnce(JSON.stringify({ error: "Server error" }), {
+          status: 500,
+        });
+
+      const result = await api.publishPortalProduct(productId, false);
+
+      // Should still build URL without section/toc
+      expect(result).toEqual({
+        success: true,
+        preview: false,
+        liveUrl: `https://testportal.portal.swaggerhub.com/${productSlug}`,
+        product: {
+          id: productResponse.id,
+          name: productResponse.name,
+          slug: productResponse.slug,
+        },
+        portal: {
+          id: portalResponse.id,
+          name: portalResponse.name,
+          subdomain: portalResponse.subdomain,
+          customDomain: undefined,
+        },
+      });
+    });
+
+    it("should handle product without portalId", async () => {
+      const productWithoutPortal = {
+        id: productId,
+        name: "Orphan Product",
+        slug: productSlug,
+        portalId: null,
+      };
+
+      fetchMock
+        .mockResponseOnce(JSON.stringify(publishResponse))
+        .mockResponseOnce(JSON.stringify(productWithoutPortal));
+
+      const result = await api.publishPortalProduct(productId, false);
+
+      expect(result).toEqual({
+        success: true,
+        preview: false,
+        liveUrl: null,
+        product: {
+          id: productWithoutPortal.id,
+          name: productWithoutPortal.name,
+          slug: productWithoutPortal.slug,
+        },
+        warning: {
+          code: "METADATA_FETCH_FAILED",
+          step: "portal",
+          message:
+            "Product published in live mode successfully, but failed to fetch portal details for URL generation",
         },
       });
     });

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -364,59 +364,73 @@ describe("SwaggerAPI", () => {
   });
 
   describe("publishPortalProduct", () => {
-    it("should publish product and return resolved liveUrl", async () => {
-      const headers = {
-        Authorization: "Bearer test-token",
-        "Content-Type": "application/json",
-        "User-Agent": "SmartBear-MCP/1.0.0",
-      };
-      const productId = "prod-123";
-      const portalId = "portal-123";
-      const productSlug = "test-product";
-      const tocId = "toc-1";
+    const headers = {
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+      "User-Agent": "SmartBear-MCP/1.0.0",
+    };
 
-      const productResponse = {
-        id: productId,
-        name: "Test Product",
-        slug: productSlug,
-        portalId,
-      };
-      const portalResponse = {
-        id: portalId,
-        name: "Test Portal",
-        subdomain: "testportal",
-      };
-      const sectionsResponse = {
-        page: {
-          number: 0,
-          size: 20,
-          totalElements: 1,
-          totalPages: 1,
+    const productId = "prod-123";
+    const portalId = "portal-123";
+    const productSlug = "test-product";
+    const tocId = "toc-1";
+
+    const productResponse = {
+      id: productId,
+      name: "Test Product",
+      slug: productSlug,
+      portalId,
+    };
+
+    const portalResponse = {
+      id: portalId,
+      name: "Test Portal",
+      subdomain: "testportal",
+    };
+
+    const sectionsResponse = {
+      page: {
+        number: 0,
+        size: 20,
+        totalElements: 1,
+        totalPages: 1,
+      },
+      items: [
+        {
+          id: "section-1",
+          productId,
+          title: "Docs",
+          slug: "docs",
+          tableOfContents: [
+            {
+              id: tocId,
+              slug: "getting-started",
+              title: "Getting Started",
+              order: 0,
+              parentId: null,
+              children: [],
+              swaggerhubApi: null,
+              content: null,
+            },
+          ],
+          order: 0,
         },
-        items: [
-          {
-            id: "section-1",
-            productId,
-            title: "Docs",
-            slug: "docs",
-            tableOfContents: [
-              {
-                id: tocId,
-                slug: "getting-started",
-                title: "Getting Started",
-                order: 0,
-                parentId: null,
-                children: [],
-                swaggerhubApi: null,
-                content: null,
-              },
-            ],
-            order: 0,
-          },
-        ],
-      };
-      const publishResponse = { success: true };
+      ],
+    };
 
+    const previewSectionsResponse = {
+      page: {
+        number: 0,
+        size: 20,
+        totalElements: 1,
+        totalPages: 1,
+      },
+      items: [],
+    };
+
+    const publishResponse = { success: true };
+
+    it("should publish product and return resolved liveUrl", async () => {
       fetchMock
         .mockResponseOnce(JSON.stringify(productResponse))
         .mockResponseOnce(JSON.stringify(sectionsResponse))
@@ -462,6 +476,31 @@ describe("SwaggerAPI", () => {
         success: true,
         liveUrl:
           `https://testportal.portal.swaggerhub.com/${productSlug}/docs/getting-started`,
+      });
+    });
+
+    it("should publish preview product and return previewUrl", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(productResponse))
+        .mockResponseOnce(JSON.stringify(previewSectionsResponse))
+        .mockResponseOnce(JSON.stringify(portalResponse))
+        .mockResponseOnce(JSON.stringify(publishResponse));
+
+      const result = await api.publishPortalProduct(productId, true);
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        4,
+        `https://api.portal.swaggerhub.com/v1/products/${productId}/published-content?preview=true`,
+        {
+          method: "PUT",
+          headers,
+        },
+      );
+
+      expect(result).toEqual({
+        success: true,
+        previewUrl:
+          `https://testportal.portal.swaggerhub.com/${productSlug}?preview=product`,
       });
     });
   });

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -363,6 +363,109 @@ describe("SwaggerAPI", () => {
     });
   });
 
+  describe("publishPortalProduct", () => {
+    it("should publish product and return resolved liveUrl", async () => {
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+        "User-Agent": "SmartBear-MCP/1.0.0",
+      };
+      const productId = "prod-123";
+      const portalId = "portal-123";
+      const productSlug = "test-product";
+      const tocId = "toc-1";
+
+      const productResponse = {
+        id: productId,
+        name: "Test Product",
+        slug: productSlug,
+        portalId,
+      };
+      const portalResponse = {
+        id: portalId,
+        name: "Test Portal",
+        subdomain: "testportal",
+      };
+      const sectionsResponse = {
+        page: {
+          number: 0,
+          size: 20,
+          totalElements: 1,
+          totalPages: 1,
+        },
+        items: [
+          {
+            id: "section-1",
+            productId,
+            title: "Docs",
+            slug: "docs",
+            tableOfContents: [
+              {
+                id: tocId,
+                slug: "getting-started",
+                title: "Getting Started",
+                order: 0,
+                parentId: null,
+                children: [],
+                swaggerhubApi: null,
+                content: null,
+              },
+            ],
+            order: 0,
+          },
+        ],
+      };
+      const publishResponse = { success: true };
+
+      fetchMock
+        .mockResponseOnce(JSON.stringify(productResponse))
+        .mockResponseOnce(JSON.stringify(sectionsResponse))
+        .mockResponseOnce(JSON.stringify(portalResponse))
+        .mockResponseOnce(JSON.stringify(publishResponse));
+
+      const result = await api.publishPortalProduct(productId, false, tocId);
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        `https://api.portal.swaggerhub.com/v1/products/${productId}`,
+        {
+          method: "GET",
+          headers,
+        },
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        `https://api.portal.swaggerhub.com/v1/products/${productId}/sections?embed=tableOfContents&embed=tableOfContents.swaggerhubApi`,
+        {
+          method: "GET",
+          headers,
+        },
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        `https://api.portal.swaggerhub.com/v1/portals/${portalId}`,
+        {
+          method: "GET",
+          headers,
+        },
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        4,
+        `https://api.portal.swaggerhub.com/v1/products/${productId}/published-content?preview=false`,
+        {
+          method: "PUT",
+          headers,
+        },
+      );
+
+      expect(result).toEqual({
+        success: true,
+        liveUrl:
+          `https://testportal.portal.swaggerhub.com/${productSlug}/docs/getting-started`,
+      });
+    });
+  });
+
   describe("error handling", () => {
     it("should handle fetch errors gracefully", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -388,6 +388,12 @@ describe("SwaggerAPI", () => {
       subdomain: "testportal",
     };
 
+    const customDomainPortalResponse = {
+      id: portalId,
+      name: "Test Portal",
+      customDomain: "testCustomDomain.portal-testing.com",
+    };
+
     const sectionsResponse = {
       page: {
         number: 0,
@@ -474,8 +480,27 @@ describe("SwaggerAPI", () => {
 
       expect(result).toEqual({
         success: true,
+        preview: false,
         liveUrl:
           `https://testportal.portal.swaggerhub.com/${productSlug}/docs/getting-started`,
+        product: {
+          id: productResponse.id,
+          name: productResponse.name,
+          slug: productResponse.slug,
+        },
+        portal: {
+          id: portalResponse.id,
+          name: portalResponse.name,
+          subdomain: portalResponse.subdomain,
+          customDomain: undefined,
+        },
+        tableOfContentsItem: {
+          id: sectionsResponse.items[0].tableOfContents[0].id,
+          slug: sectionsResponse.items[0].tableOfContents[0].slug,
+          title: sectionsResponse.items[0].tableOfContents[0].title,
+          order: sectionsResponse.items[0].tableOfContents[0].order,
+          parentId: sectionsResponse.items[0].tableOfContents[0].parentId,
+        },
       });
     });
 
@@ -499,8 +524,56 @@ describe("SwaggerAPI", () => {
 
       expect(result).toEqual({
         success: true,
+        preview: true,
         previewUrl:
           `https://testportal.portal.swaggerhub.com/${productSlug}?preview=product`,
+        product: {
+          id: productResponse.id,
+          name: productResponse.name,
+          slug: productResponse.slug,
+        },
+        portal: {
+          id: portalResponse.id,
+          name: portalResponse.name,
+          subdomain: portalResponse.subdomain,
+          customDomain: undefined,
+        },
+        tableOfContentsItem: null,
+      });
+    });
+
+    it("should use customDomain as the full host when present", async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(productResponse))
+        .mockResponseOnce(JSON.stringify(sectionsResponse))
+        .mockResponseOnce(JSON.stringify(customDomainPortalResponse))
+        .mockResponseOnce(JSON.stringify(publishResponse));
+
+      const result = await api.publishPortalProduct(productId, true, tocId);
+
+      expect(result).toEqual({
+        success: true,
+        preview: true,
+        previewUrl:
+          "https://testCustomDomain.portal-testing.com/test-product/docs/getting-started?preview=product",
+        product: {
+          id: productResponse.id,
+          name: productResponse.name,
+          slug: productResponse.slug,
+        },
+        portal: {
+          id: customDomainPortalResponse.id,
+          name: customDomainPortalResponse.name,
+          subdomain: undefined,
+          customDomain: customDomainPortalResponse.customDomain,
+        },
+        tableOfContentsItem: {
+          id: sectionsResponse.items[0].tableOfContents[0].id,
+          slug: sectionsResponse.items[0].tableOfContents[0].slug,
+          title: sectionsResponse.items[0].tableOfContents[0].title,
+          order: sectionsResponse.items[0].tableOfContents[0].order,
+          parentId: sectionsResponse.items[0].tableOfContents[0].parentId,
+        },
       });
     });
   });


### PR DESCRIPTION
## Goal
Ticket: SWG-20373
Fix swagger_publish_portal_product so the tool itself returns the live or preview page URL. This removes the need for the agent skill or LLM to construct URLs, which was causing incorrect links.

## Design

Generate the publish URL inside the MCP tool using the actual product, portal, section, and optional [tableOfContentsId] data returned from the API. Keep URL logic in the tool response so the agent can display the exact link directly without inference.

## Changeset

Updated swagger_publish_portal_product to accept [tableOfContentsId], resolve the matching TOC item when provided, and return the computed live or preview page URL in the tool response. Also narrowed the returned metadata to only the fields needed for the publish result.

## Testing

The unit tests for [publishPortalProduct] were updated to cover:

live publish with [tableOfContentsId]
preview publish without [tableOfContentsId]
custom domain URL generation
