### PR TITLE
feat(functional-testing): new tools: run suite, get suite execution status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.
+
 ## [0.28.0] - 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.27.0] - 2026-06-29
 - [Qmetry]: add Test Run UDF workflow support and customer fixes [#538](https://github.com/SmartBear/smartbear-mcp/pull/538)
 
-## [0.26.1] - 2026-06-25
-
 ### Added
 
 - [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix. For url generation product and portal details ar required and section and toc details are optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.27.0] - 2026-06-29
 - [Qmetry]: add Test Run UDF workflow support and customer fixes [#538](https://github.com/SmartBear/smartbear-mcp/pull/538)
 
+## [0.26.1] - 2026-06-25
+
+### Added
+
+- [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.
+
 ### Added
 
 - [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix. For url generation product and portal details ar required and section and toc details are optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.
-
-### Added
-
 - [Swagger] Extended `publish_portal_product` to build published URLs dynamically from `SWAGGER_PORTAL_BASE_PATH`, support preview and section/table-of-contents paths, and return the resolved `liveUrl` or `previewUrl` plus product, portal, and table-of-contents metadata in the publish response. If `portal.customDomain` is present, the client now uses it as the full host without appending the portal UI suffix. For url generation product and portal details ar required and section and toc details are optional.
 [#525](https://github.com/SmartBear/smartbear-mcp/pull/525)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 - [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.
 
 ## [0.28.0] - 2026-07-07

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -1,6 +1,6 @@
 ![swagger-functional-testing.svg](./images/embedded/swagger-functional-testing.svg)
 
-The Swagger Functional Testing client provides tools for discovering and executing API tests and test suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
+The Swagger Functional Testing client provides tools for discovering and executing API tests and test Suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
 ## Available Tools
 
@@ -40,15 +40,15 @@ The Swagger Functional Testing client provides tools for discovering and executi
 
 #### `run_suite`
 
-- Purpose: Runs a specific test suite in your Swagger Functional Testing workspace. Use this tool when you need to verify expected API functionality by executing all tests in a suite. Requires a `suiteId`. Optionally accepts a `tunnelAgentName` to override the suite's saved tunnel for this run; when omitted, the suite's saved overrides are used (falling back to each test's saved tunnel).
-- Returns: Execution details including an `executionId` that can be used to poll the run result.
-- Use case: Trigger a suite run that exercises every test it contains.
+- Purpose: Runs a specific test Suite in your Swagger Functional Testing workspace. Use this tool when you need to verify expected API functionality by executing all tests within your Suite. Requires a `suiteId`. Optionally accepts a `tunnelAgentName` that will override any tunnels saved on each API tests within that Suite; when omitted, each test's saved tunnel is used instead.
+- Returns: Run details including `suiteId`, `executionId` and current status. First two (`suiteId` and `executionId`) can be used in `get_suite_status` tool to poll the Suite run result.
+- Use case: Trigger a Suite run that exercises every test it contains.
 
 #### `get_suite_status`
 
-- Purpose: Retrieves the status and per-test result of triggered suite execution. Requires both the `suiteId` and the `executionId` returned by `run_suite`.
-- Returns: Overall suite execution status (pending, canceled, passed, or failed), whether the run is finished, and a per-test breakdown with pass/fail.
-- Use case: Poll for the outcome of a suite run after calling `run_suite`.
+- Purpose: Retrieves the status and per-test result of triggered Suite execution. Requires the `suiteId` of your test Suite and the `executionId` returned by `run_suite`.
+- Returns: Execution details including `suiteId`, `executionId`, overall status (pending, canceled, passed, or failed), whether run finished, and a per-test breakdown. The per-test results include status (pending, canceled, passed, or failed), runtime and number of steps.
+- Use case: Poll for the outcome of a Suite run after calling `run_suite`.
 
 ---
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -1,6 +1,6 @@
 ![swagger-functional-testing.svg](./images/embedded/swagger-functional-testing.svg)
 
-The Swagger Functional Testing client provides tools for discovering and executing API tests. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
+The Swagger Functional Testing client provides tools for discovering and executing API tests and test suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
 ## Available Tools
 
@@ -33,6 +33,22 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Purpose: Retrieves the status and result of a previously triggered test execution. Use this tool to check whether a test run has completed and whether it passed or failed. Requires an `executionId` returned by `run_test`.
 - Returns: Execution status and result details for the given execution.
 - Use case: Poll for the outcome of a test run after calling `run_test`.
+
+---
+
+### Suite Execution
+
+#### `run_suite`
+
+- Purpose: Runs a specific test suite in your Swagger Functional Testing workspace. Use this tool when you need to verify expected API functionality by executing all tests in a suite. Requires a `suiteId`. Optionally accepts a `tunnelAgentName` to override the suite's saved tunnel for this run; when omitted, the suite's saved overrides are used (falling back to each test's saved tunnel).
+- Returns: Execution details including an `executionId` that can be used to poll the run result.
+- Use case: Trigger a suite run that exercises every test it contains.
+
+#### `get_suite_status`
+
+- Purpose: Retrieves the status and per-test result of triggered suite execution. Requires both the `suiteId` and the `executionId` returned by `run_suite`.
+- Returns: Overall suite execution status (pending, canceled, passed, or failed), whether the run is finished, and a per-test breakdown with pass/fail.
+- Use case: Poll for the outcome of a suite run after calling `run_suite`.
 
 ---
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,6 +16,8 @@ import {
 } from "./client/functional-testing-api";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  GetFunctionalTestingSuiteExecutionParams,
+  RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
 } from "./client/functional-testing-types";
 import {
@@ -370,6 +372,18 @@ export class SwaggerClient implements Client {
     args: GetFunctionalTestingExecutionTestParams,
   ): Promise<unknown> {
     return this.withFunctionalTesting((ftApi) => ftApi.getTestExecution(args));
+  }
+
+  async runFunctionalTestingSuite(
+    args: RunFunctionalTestingSuiteParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.runSuite(args));
+  }
+
+  async getFunctionalTestingSuiteExecution(
+    args: GetFunctionalTestingSuiteExecutionParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.getSuiteExecution(args));
   }
 
   /**

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -90,8 +90,17 @@ export class FunctionalTestingAPI {
       );
     }
 
-    // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
-    return this.withoutField("videoUrl", response);
+    const data = (await response.json()) as Record<string, unknown>;
+    // Reflect API returns video recording URL for each test run, which SFT does not need so we remove it.
+    if (Array.isArray(data.tests)) {
+      for (const test of data.tests as Record<string, unknown>[]) {
+        const run = test.run as Record<string, unknown> | undefined;
+        if (run) {
+          delete run.videoUrl;
+        }
+      }
+    }
+    return data;
   }
 
   async listSuites(): Promise<ListSuitesResponse> {
@@ -177,12 +186,12 @@ export class FunctionalTestingAPI {
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
     const data = await this.withoutField("url", response);
+    // Reflect API returns video recording URL for each test run within suite, which SFT does not need so we remove it.
     const testsData = (data.tests as Record<string, unknown> | undefined)?.data;
     if (Array.isArray(testsData)) {
       for (const test of testsData as Record<string, unknown>[]) {
         if (Array.isArray(test.runs)) {
           for (const run of test.runs as Record<string, unknown>[]) {
-            // Reflect API returns video recording URL for each run, which SFT does not need so we remove it.
             delete run.videoUrl;
           }
         }

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -149,7 +149,7 @@ export class FunctionalTestingAPI {
     const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    delete data["url"];
+    delete data.url;
     return data;
   }
 
@@ -178,11 +178,11 @@ export class FunctionalTestingAPI {
     const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    delete data["url"];
-    if (Array.isArray(data["tests"])) {
-      for (const test of data["tests"] as Record<string, unknown>[]) {
+    delete data.url;
+    if (Array.isArray(data.tests)) {
+      for (const test of data.tests as Record<string, unknown>[]) {
         // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
-        delete test["videoUrl"];
+        delete test.videoUrl;
       }
     }
     return data;

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -90,7 +90,10 @@ export class FunctionalTestingAPI {
       );
     }
 
-    return response.json();
+    const data = (await response.json()) as Record<string, unknown>;
+    // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
+    delete data.videoUrl;
+    return data;
   }
 
   async listSuites(): Promise<ListSuitesResponse> {

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -127,9 +127,7 @@ export class FunctionalTestingAPI {
 
     const body = args.tunnelAgentName
       ? JSON.stringify({
-          overrides: {
-            reserved: { agent: { name: args.tunnelAgentName } },
-          },
+          overrides: { agent: { name: args.tunnelAgentName } },
         })
       : undefined;
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -141,14 +141,27 @@ export class FunctionalTestingAPI {
         })
       : undefined;
 
-    const response = await fetch(
-      `${this.baseUrl}/suites/${args.suiteId}/executions`,
-      {
-        method: "POST",
-        headers: this.getFtHeaders(),
-        body,
-      },
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `${this.baseUrl}/suites/${args.suiteId}/executions`,
+        {
+          method: "POST",
+          headers: this.getFtHeaders(),
+          body,
+        },
+      );
+    } catch {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ToolError(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    }
 
     if (!response.ok) {
       throw new ToolError(
@@ -169,13 +182,26 @@ export class FunctionalTestingAPI {
       throw new ToolError("executionId argument is required");
     }
 
-    const response = await fetch(
-      `${this.baseUrl}/suites/${args.suiteId}/executions/${args.executionId}`,
-      {
-        method: "GET",
-        headers: this.getFtHeaders(),
-      },
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `${this.baseUrl}/suites/${args.suiteId}/executions/${args.executionId}`,
+        {
+          method: "GET",
+          headers: this.getFtHeaders(),
+        },
+      );
+    } catch {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ToolError(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    }
 
     if (!response.ok) {
       throw new ToolError(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -146,7 +146,11 @@ export class FunctionalTestingAPI {
       );
     }
 
-    return response.json();
+    const data = (await response.json()) as Record<string, unknown>;
+    // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
+    // We strip-it for now, but will bring-back in scope of https://smartbear.atlassian.net/browse/RF-5271.
+    delete data["url"];
+    return data;
   }
 
   async getSuiteExecution(
@@ -171,6 +175,16 @@ export class FunctionalTestingAPI {
       );
     }
 
-    return response.json();
+    const data = (await response.json()) as Record<string, unknown>;
+    // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
+    // We strip-it for now, but will bring-back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
+    delete data["url"];
+    if (Array.isArray(data["tests"])) {
+      for (const test of data["tests"] as Record<string, unknown>[]) {
+        // Reflect API returns video recording URL for each test, which SFT does not need. We strip-it.
+        delete test["videoUrl"];
+      }
+    }
+    return data;
   }
 }

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -90,10 +90,8 @@ export class FunctionalTestingAPI {
       );
     }
 
-    const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
-    delete data.videoUrl;
-    return data;
+    return this.withoutField("videoUrl", response);
   }
 
   async listSuites(): Promise<ListSuitesResponse> {
@@ -149,11 +147,9 @@ export class FunctionalTestingAPI {
       );
     }
 
-    const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    delete data.url;
-    return data;
+    return this.withoutField("url", response);
   }
 
   async getSuiteExecution(
@@ -178,18 +174,29 @@ export class FunctionalTestingAPI {
       );
     }
 
-    const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    delete data.url;
-    if (Array.isArray(data.tests)) {
-      for (const test of data.tests as Record<string, unknown>[]) {
-        if (test && typeof test === "object") {
-          // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
-          delete test.videoUrl;
+    const data = await this.withoutField("url", response);
+    const testsData = (data.tests as Record<string, unknown> | undefined)?.data;
+    if (Array.isArray(testsData)) {
+      for (const test of testsData as Record<string, unknown>[]) {
+        if (Array.isArray(test.runs)) {
+          for (const run of test.runs as Record<string, unknown>[]) {
+            // Reflect API returns video recording URL for each run, which SFT does not need so we remove it.
+            delete run.videoUrl;
+          }
         }
       }
     }
+    return data;
+  }
+
+  private async withoutField(
+    field: string,
+    response: Response,
+  ): Promise<Record<string, unknown>> {
+    const data = (await response.json()) as Record<string, unknown>;
+    delete data[field];
     return data;
   }
 }

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,7 +1,9 @@
 import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  GetFunctionalTestingSuiteExecutionParams,
   ListSuitesResponse,
+  RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
 } from "./functional-testing-types";
 
@@ -114,6 +116,60 @@ export class FunctionalTestingAPI {
     if (!response.ok) {
       throw new ToolError(
         `Failed to list Functional Testing suites: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async runSuite(args: RunFunctionalTestingSuiteParams): Promise<unknown> {
+    if (!args.suiteId) throw new ToolError("suiteId argument is required");
+
+    const body = args.tunnelAgentName
+      ? JSON.stringify({
+          overrides: {
+            reserved: { agent: { name: args.tunnelAgentName } },
+          },
+        })
+      : undefined;
+
+    const response = await fetch(
+      `${this.baseUrl}/suites/${args.suiteId}/executions`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+        body,
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to run suite: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getSuiteExecution(
+    args: GetFunctionalTestingSuiteExecutionParams,
+  ): Promise<unknown> {
+    if (!args.suiteId) throw new ToolError("suiteId argument is required");
+    if (!args.executionId) {
+      throw new ToolError("executionId argument is required");
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/suites/${args.suiteId}/executions/${args.executionId}`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to get suite execution status: ${response.status} ${response.statusText}`,
       );
     }
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -184,8 +184,10 @@ export class FunctionalTestingAPI {
     delete data.url;
     if (Array.isArray(data.tests)) {
       for (const test of data.tests as Record<string, unknown>[]) {
-        // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
-        delete test.videoUrl;
+        if (test && typeof test === "object") {
+          // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
+          delete test.videoUrl;
+        }
       }
     }
     return data;

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -148,7 +148,7 @@ export class FunctionalTestingAPI {
 
     const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
-    // We strip-it for now, but will bring-back in scope of https://smartbear.atlassian.net/browse/RF-5271.
+    // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
     delete data["url"];
     return data;
   }
@@ -177,11 +177,11 @@ export class FunctionalTestingAPI {
 
     const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
-    // We strip-it for now, but will bring-back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
+    // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
     delete data["url"];
     if (Array.isArray(data["tests"])) {
       for (const test of data["tests"] as Record<string, unknown>[]) {
-        // Reflect API returns video recording URL for each test, which SFT does not need. We strip-it.
+        // Reflect API returns video recording URL for each test, which SFT does not need so we remove it.
         delete test["videoUrl"];
       }
     }

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,5 +1,7 @@
 import {
   GetFunctionalTestingExecutionTestSchema,
+  GetFunctionalTestingSuiteExecutionSchema,
+  RunFunctionalTestingSuiteParamsSchema,
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";
 import type { SwaggerToolParams } from "./tools";
@@ -47,5 +49,31 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     handler: "listFunctionalTestingSuites",
     idempotent: true,
     readOnly: true,
+  },
+  {
+    title: "Run Suite",
+    toolset: "Functional Testing",
+    summary:
+      "Runs a specific test suite in your Swagger Functional Testing workspace. " +
+      "The execution is asynchronous — it returns an executionId, not results directly. " +
+      "Use `swagger_get_suite_status` with your suiteId and executionId to track progress and retrieve the final per-test results. " +
+      "Optionally accepts a `tunnelAgentName` argument to override the suite's saved tunnel for this run. " +
+      "Do not use this tool to run a single test — use `runFunctionalTestingTest` instead.",
+    inputSchema: RunFunctionalTestingSuiteParamsSchema,
+    handler: "runFunctionalTestingSuite",
+    idempotent: false,
+    readOnly: false,
+  },
+  {
+    title: "Get Suite Status",
+    toolset: "Functional Testing",
+    summary:
+      "Get the status of a Swagger Functional Testing suite execution. " +
+      "Returns the overall status (pending, canceled, passed or failed), whether the run is finished, and a per-test breakdown with pass/fail. " +
+      "Use this to poll for the outcome of a suite run triggered by `runFunctionalTestingTest`. " +
+      "Requires both `suiteId` and the `executionId` arguments returned by `runFunctionalTestingTest`.",
+    inputSchema: GetFunctionalTestingSuiteExecutionSchema,
+    handler: "getFunctionalTestingSuiteExecution",
+    idempotent: false,
   },
 ];

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -15,6 +15,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use this tool when you need to discover available tests before running them or checking their status. " +
       "Do not use this tool to retrieve test execution results or history.",
     handler: "listFunctionalTestingTests",
+    idempotent: true,
+    readOnly: true,
   },
   {
     title: "Run Test",
@@ -37,7 +39,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "as well as the break down of the status of each test step.",
     inputSchema: GetFunctionalTestingExecutionTestSchema,
     handler: "getFunctionalTestingExecution",
-    idempotent: false,
+    idempotent: true,
+    readOnly: true,
   },
   {
     title: "List Suites",
@@ -74,6 +77,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Requires both `suiteId` and the `executionId` arguments returned by `swagger_run_suite`.",
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
-    idempotent: false,
+    idempotent: true,
+    readOnly: true,
   },
 ];

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -15,8 +15,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use this tool when you need to discover available tests before running them or checking their status. " +
       "Do not use this tool to retrieve test execution results or history.",
     handler: "listFunctionalTestingTests",
-    idempotent: true,
-    readOnly: true,
   },
   {
     title: "Run Test",
@@ -27,8 +25,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use swagger_get_test_status with that executionId to track progress and retrieve the final result.",
     inputSchema: RunFunctionalTestingTestParamsSchema,
     handler: "runFunctionalTestingTest",
-    idempotent: false,
-    readOnly: false,
   },
   {
     title: "Get Test Status",
@@ -39,8 +35,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "as well as the break down of the status of each test step.",
     inputSchema: GetFunctionalTestingExecutionTestSchema,
     handler: "getFunctionalTestingExecution",
-    idempotent: true,
-    readOnly: true,
   },
   {
     title: "List Suites",
@@ -64,8 +58,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to run a single test — use `swagger_run_test` instead.",
     inputSchema: RunFunctionalTestingSuiteParamsSchema,
     handler: "runFunctionalTestingSuite",
-    idempotent: false,
-    readOnly: false,
   },
   {
     title: "Get Suite Status",
@@ -77,7 +69,5 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Requires both `suiteId` and the `executionId` arguments returned by `swagger_run_suite`.",
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
-    idempotent: true,
-    readOnly: true,
   },
 ];

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -58,7 +58,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "The execution is asynchronous — it returns an executionId, not results directly. " +
       "Use `swagger_get_suite_status` with your suiteId and executionId to track progress and retrieve the final per-test results. " +
       "Optionally accepts a `tunnelAgentName` argument to override the suite's saved tunnel for this run. " +
-      "Do not use this tool to run a single test — use `runFunctionalTestingTest` instead.",
+      "Do not use this tool to run a single test — use `swagger_run_test` instead.",
     inputSchema: RunFunctionalTestingSuiteParamsSchema,
     handler: "runFunctionalTestingSuite",
     idempotent: false,
@@ -70,8 +70,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     summary:
       "Get the status of a Swagger Functional Testing suite execution. " +
       "Returns the overall status (pending, canceled, passed or failed), whether the run is finished, and a per-test breakdown with pass/fail. " +
-      "Use this to poll for the outcome of a suite run triggered by `runFunctionalTestingTest`. " +
-      "Requires both `suiteId` and the `executionId` arguments returned by `runFunctionalTestingTest`.",
+      "Use this to poll for the outcome of a suite run triggered by `swagger_run_suite`. " +
+      "Requires both `suiteId` and the `executionId` arguments returned by `swagger_run_suite`.",
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
     idempotent: false,

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -15,6 +15,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use this tool when you need to discover available tests before running them or checking their status. " +
       "Do not use this tool to retrieve test execution results or history.",
     handler: "listFunctionalTestingTests",
+    idempotent: true,
+    readOnly: true,
   },
   {
     title: "Run Test",
@@ -25,6 +27,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use swagger_get_test_status with that executionId to track progress and retrieve the final result.",
     inputSchema: RunFunctionalTestingTestParamsSchema,
     handler: "runFunctionalTestingTest",
+    idempotent: false,
+    readOnly: false,
   },
   {
     title: "Get Test Status",
@@ -35,6 +39,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "as well as the break down of the status of each test step.",
     inputSchema: GetFunctionalTestingExecutionTestSchema,
     handler: "getFunctionalTestingExecution",
+    idempotent: true,
+    readOnly: true,
   },
   {
     title: "List Suites",
@@ -58,6 +64,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to run a single test — use `swagger_run_test` instead.",
     inputSchema: RunFunctionalTestingSuiteParamsSchema,
     handler: "runFunctionalTestingSuite",
+    idempotent: false,
+    readOnly: false,
   },
   {
     title: "Get Suite Status",
@@ -69,5 +77,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Requires both `suiteId` and the `executionId` arguments returned by `swagger_run_suite`.",
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
+    idempotent: true,
+    readOnly: true,
   },
 ];

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -33,7 +33,7 @@ export const RunFunctionalTestingSuiteParamsSchema = z.object({
 });
 
 export const GetFunctionalTestingSuiteExecutionSchema = z.object({
-  suiteId: z.string().min(1).describe("ID of the Functional Testing suite"),
+  suiteId: z.string().trim().min(1).describe("ID of the Functional Testing suite"),
   executionId: z
     .string()
     .describe("ID of the Functional Testing suite execution")

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -16,11 +16,39 @@ export const GetFunctionalTestingExecutionTestSchema = z.object({
     .min(1),
 });
 
+export const RunFunctionalTestingSuiteParamsSchema = z.object({
+  suiteId: z
+    .string()
+    .min(1)
+    .describe("ID of the Functional Testing suite to run"),
+  tunnelAgentName: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional tunnel agent name to override the suite's saved tunnel for this run. When omitted, the suite's saved tunnel overrides are used, falling back to each test's saved tunnel.",
+    ),
+});
+
+export const GetFunctionalTestingSuiteExecutionSchema = z.object({
+  suiteId: z.string().min(1).describe("ID of the Functional Testing suite"),
+  executionId: z
+    .string()
+    .min(1)
+    .describe("ID of the Functional Testing suite execution"),
+});
+
 export type RunFunctionalTestingTestParams = z.infer<
   typeof RunFunctionalTestingTestParamsSchema
 >;
 export type GetFunctionalTestingExecutionTestParams = z.infer<
   typeof GetFunctionalTestingExecutionTestSchema
+>;
+export type RunFunctionalTestingSuiteParams = z.infer<
+  typeof RunFunctionalTestingSuiteParamsSchema
+>;
+export type GetFunctionalTestingSuiteExecutionParams = z.infer<
+  typeof GetFunctionalTestingSuiteExecutionSchema
 >;
 
 export interface Suite {

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -33,7 +33,11 @@ export const RunFunctionalTestingSuiteParamsSchema = z.object({
 });
 
 export const GetFunctionalTestingSuiteExecutionSchema = z.object({
-  suiteId: z.string().trim().min(1).describe("ID of the Functional Testing suite"),
+  suiteId: z
+    .string()
+    .describe("ID of the Functional Testing suite")
+    .trim()
+    .min(1),
   executionId: z
     .string()
     .describe("ID of the Functional Testing suite execution")

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -19,23 +19,26 @@ export const GetFunctionalTestingExecutionTestSchema = z.object({
 export const RunFunctionalTestingSuiteParamsSchema = z.object({
   suiteId: z
     .string()
-    .min(1)
-    .describe("ID of the Functional Testing suite to run"),
+    .describe("ID of the Functional Testing suite to run")
+    .trim()
+    .min(1),
   tunnelAgentName: z
     .string()
-    .min(1)
-    .optional()
     .describe(
       "Optional tunnel agent name to override the suite's saved tunnel for this run. When omitted, the suite's saved tunnel overrides are used, falling back to each test's saved tunnel.",
-    ),
+    )
+    .trim()
+    .min(1)
+    .optional(),
 });
 
 export const GetFunctionalTestingSuiteExecutionSchema = z.object({
   suiteId: z.string().min(1).describe("ID of the Functional Testing suite"),
   executionId: z
     .string()
-    .min(1)
-    .describe("ID of the Functional Testing suite execution"),
+    .describe("ID of the Functional Testing suite execution")
+    .trim()
+    .min(1),
 });
 
 export type RunFunctionalTestingTestParams = z.infer<

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -407,21 +407,23 @@ describe("FunctionalTestingAPI", () => {
       expect((result as Record<string, unknown>).url).toBeUndefined();
     });
 
-    it("should strip videoUrl from each test item in tests array", async () => {
+    it("should strip videoUrl from each run in tests.data array", async () => {
       const mockWithTests = {
         ...suiteExecutionMock,
-        tests: [
-          {
-            id: "test-1",
-            status: "passed",
-            videoUrl: "https://cdn.reflect.run/video/1.mp4",
-          },
-          {
-            id: "test-2",
-            status: "failed",
-            videoUrl: "https://cdn.reflect.run/video/2.mp4",
-          },
-        ],
+        tests: {
+          data: [
+            {
+              id: "test-1",
+              status: "passed",
+              runs: [{ runId: 1, videoUrl: "https://cdn.reflect.run/video/1.mp4" }],
+            },
+            {
+              id: "test-2",
+              status: "failed",
+              runs: [{ runId: 2, videoUrl: "https://cdn.reflect.run/video/2.mp4" }],
+            },
+          ],
+        },
       };
       fetchMock.mockResponseOnce(JSON.stringify(mockWithTests));
 
@@ -430,14 +432,15 @@ describe("FunctionalTestingAPI", () => {
         executionId: "7",
       });
 
-      const tests = (result as Record<string, unknown>).tests as Record<
-        string,
-        unknown
-      >[];
-      expect(tests[0].videoUrl).toBeUndefined();
-      expect(tests[1].videoUrl).toBeUndefined();
-      expect(tests[0].id).toBe("test-1");
-      expect(tests[1].id).toBe("test-2");
+      const testsData = (
+        (result as Record<string, unknown>).tests as Record<string, unknown>
+      ).data as Record<string, unknown>[];
+      const runs0 = testsData[0].runs as Record<string, unknown>[];
+      const runs1 = testsData[1].runs as Record<string, unknown>[];
+      expect(runs0[0].videoUrl).toBeUndefined();
+      expect(runs1[0].videoUrl).toBeUndefined();
+      expect(testsData[0].id).toBe("test-1");
+      expect(testsData[1].id).toBe("test-2");
     });
 
     it("should throw ToolError when suiteId is missing", async () => {

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
-import {
-  FunctionalTestingAPI,
-  FunctionalTestingApiEnv,
-} from "../../../../swagger/client/functional-testing-api";
+import { FunctionalTestingAPI } from "../../../../swagger/client/functional-testing-api";
 
 const fetchMock = createFetchMock(vi);
 fetchMock.enableMocks();
@@ -48,7 +45,6 @@ describe("FunctionalTestingAPI", () => {
     api = new FunctionalTestingAPI(
       () => "test-api-key",
       "SmartBear MCP Server/test",
-      FunctionalTestingApiEnv.Production,
     );
   });
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -167,6 +167,20 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(executionMock);
     });
 
+    it("should strip videoUrl from response", async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          ...executionMock,
+          videoUrl: "https://cdn.reflect.run/video/42.mp4",
+        }),
+      );
+
+      const result = await api.getTestExecution({ executionId: "42" });
+
+      expect((result as Record<string, unknown>).videoUrl).toBeUndefined();
+      expect((result as Record<string, unknown>).executionId).toBe("42");
+    });
+
     it("should throw ToolError when executionId is missing", async () => {
       await expect(api.getTestExecution({ executionId: "" })).rejects.toThrow(
         "executionId argument is required",

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
-import { FunctionalTestingAPI } from "../../../../swagger/client/functional-testing-api";
+import {
+  FunctionalTestingAPI,
+  FunctionalTestingApiEnv,
+} from "../../../../swagger/client/functional-testing-api";
 
 const fetchMock = createFetchMock(vi);
 fetchMock.enableMocks();
@@ -45,6 +48,7 @@ describe("FunctionalTestingAPI", () => {
     api = new FunctionalTestingAPI(
       () => "test-api-key",
       "SmartBear MCP Server/test",
+      FunctionalTestingApiEnv.Production,
     );
   });
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -360,7 +360,7 @@ describe("FunctionalTestingAPI", () => {
       executionId: 7,
       isFinished: true,
       status: "Passed",
-      tests: { items: [] },
+      tests: [],
     };
 
     it("should call the correct endpoint with GET method and X-API-KEY header", async () => {

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -291,7 +291,7 @@ describe("FunctionalTestingAPI", () => {
       const [, init] = fetchMock.mock.calls[0];
       expect((init as RequestInit | undefined)?.body).toBe(
         JSON.stringify({
-          overrides: { reserved: { agent: { name: "my-tunnel" } } },
+          overrides: { agent: { name: "my-tunnel" } },
         }),
       );
       expect((init as RequestInit | undefined)?.headers).toEqual(

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -254,6 +254,154 @@ describe("FunctionalTestingAPI", () => {
     });
   });
 
+  describe("runSuite", () => {
+    const executionMock = { executionId: "7", status: "pending" };
+
+    it("should call the correct endpoint with POST method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.runSuite({ suiteId: "checkout-suite" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/checkout-suite/executions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should not send a request body when no tunnelAgentName is provided", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.runSuite({ suiteId: "checkout-suite" });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect((init as RequestInit | undefined)?.body).toBeUndefined();
+    });
+
+    it("should send tunnel agent override body when tunnelAgentName is provided", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await api.runSuite({
+        suiteId: "checkout-suite",
+        tunnelAgentName: "my-tunnel",
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect((init as RequestInit | undefined)?.body).toBe(
+        JSON.stringify({
+          overrides: { reserved: { agent: { name: "my-tunnel" } } },
+        }),
+      );
+      expect((init as RequestInit | undefined)?.headers).toEqual(
+        expect.objectContaining({ "Content-Type": "application/json" }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      const result = await api.runSuite({ suiteId: "checkout-suite" });
+
+      expect(result).toEqual(executionMock);
+    });
+
+    it("should throw ToolError when suiteId is missing", async () => {
+      await expect(api.runSuite({ suiteId: "" })).rejects.toThrow(
+        "suiteId argument is required",
+      );
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(api.runSuite({ suiteId: "checkout-suite" })).rejects.toThrow(
+        "Failed to run suite",
+      );
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.runSuite({ suiteId: "checkout-suite" })).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
+  describe("getSuiteExecution", () => {
+    const suiteExecutionMock = {
+      suiteId: "checkout-suite",
+      executionId: 7,
+      isFinished: true,
+      status: "Passed",
+      tests: { items: [] },
+    };
+
+    it("should call the correct endpoint with GET method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionMock));
+
+      await api.getSuiteExecution({
+        suiteId: "checkout-suite",
+        executionId: "7",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/checkout-suite/executions/7",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionMock));
+
+      const result = await api.getSuiteExecution({
+        suiteId: "checkout-suite",
+        executionId: "7",
+      });
+
+      expect(result).toEqual(suiteExecutionMock);
+    });
+
+    it("should throw ToolError when suiteId is missing", async () => {
+      await expect(
+        api.getSuiteExecution({ suiteId: "", executionId: "7" }),
+      ).rejects.toThrow("suiteId argument is required");
+    });
+
+    it("should throw ToolError when executionId is missing", async () => {
+      await expect(
+        api.getSuiteExecution({ suiteId: "checkout-suite", executionId: "" }),
+      ).rejects.toThrow("executionId argument is required");
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
+
+      await expect(
+        api.getSuiteExecution({
+          suiteId: "checkout-suite",
+          executionId: "7",
+        }),
+      ).rejects.toThrow("Failed to get suite execution status");
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(
+        api.getSuiteExecution({
+          suiteId: "checkout-suite",
+          executionId: "7",
+        }),
+      ).rejects.toThrow("Network error");
+    });
+  });
+
   describe("getFtHeaders", () => {
     it("should return headers with X-API-KEY and Content-Type", () => {
       const headers = api.getFtHeaders();

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -352,6 +352,22 @@ describe("FunctionalTestingAPI", () => {
       );
     });
 
+    it("should throw an authentication error on 401", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(api.runSuite({ suiteId: "checkout-suite" })).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
+    it("should throw an authentication error on 403", async () => {
+      fetchMock.mockResponseOnce("Forbidden", { status: 403 });
+
+      await expect(api.runSuite({ suiteId: "checkout-suite" })).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
     it("should throw ToolError on HTTP error", async () => {
       fetchMock.mockResponseOnce("Not Found", { status: 404 });
 
@@ -360,11 +376,11 @@ describe("FunctionalTestingAPI", () => {
       );
     });
 
-    it("should propagate network errors", async () => {
+    it("should throw a service-unavailable error on network failure", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(api.runSuite({ suiteId: "checkout-suite" })).rejects.toThrow(
-        "Network error",
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
       );
     });
   });
@@ -474,6 +490,32 @@ describe("FunctionalTestingAPI", () => {
       ).rejects.toThrow("executionId argument is required");
     });
 
+    it("should throw an authentication error on 401", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(
+        api.getSuiteExecution({
+          suiteId: "checkout-suite",
+          executionId: "7",
+        }),
+      ).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
+    it("should throw an authentication error on 403", async () => {
+      fetchMock.mockResponseOnce("Forbidden", { status: 403 });
+
+      await expect(
+        api.getSuiteExecution({
+          suiteId: "checkout-suite",
+          executionId: "7",
+        }),
+      ).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
     it("should throw ToolError on HTTP error", async () => {
       fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
 
@@ -485,7 +527,7 @@ describe("FunctionalTestingAPI", () => {
       ).rejects.toThrow("Failed to get suite execution status");
     });
 
-    it("should propagate network errors", async () => {
+    it("should throw a service-unavailable error on network failure", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(
@@ -493,7 +535,9 @@ describe("FunctionalTestingAPI", () => {
           suiteId: "checkout-suite",
           executionId: "7",
         }),
-      ).rejects.toThrow("Network error");
+      ).rejects.toThrow(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
     });
   });
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -294,9 +294,6 @@ describe("FunctionalTestingAPI", () => {
           overrides: { agent: { name: "my-tunnel" } },
         }),
       );
-      expect((init as RequestInit | undefined)?.headers).toEqual(
-        expect.objectContaining({ "Content-Type": "application/json" }),
-      );
     });
 
     it("should return parsed JSON response", async () => {
@@ -309,12 +306,15 @@ describe("FunctionalTestingAPI", () => {
 
     it("should strip url field from response", async () => {
       fetchMock.mockResponseOnce(
-        JSON.stringify({ ...executionMock, url: "https://app.reflect.run/suites/checkout-suite/executions/7" }),
+        JSON.stringify({
+          ...executionMock,
+          url: "https://app.reflect.run/suites/checkout-suite/executions/7",
+        }),
       );
 
       const result = await api.runSuite({ suiteId: "checkout-suite" });
 
-      expect((result as Record<string, unknown>)["url"]).toBeUndefined();
+      expect((result as Record<string, unknown>).url).toBeUndefined();
     });
 
     it("should throw ToolError when suiteId is missing", async () => {
@@ -379,7 +379,10 @@ describe("FunctionalTestingAPI", () => {
 
     it("should strip url field from response", async () => {
       fetchMock.mockResponseOnce(
-        JSON.stringify({ ...suiteExecutionMock, url: "https://app.reflect.run/suites/checkout-suite/executions/7" }),
+        JSON.stringify({
+          ...suiteExecutionMock,
+          url: "https://app.reflect.run/suites/checkout-suite/executions/7",
+        }),
       );
 
       const result = await api.getSuiteExecution({
@@ -387,15 +390,23 @@ describe("FunctionalTestingAPI", () => {
         executionId: "7",
       });
 
-      expect((result as Record<string, unknown>)["url"]).toBeUndefined();
+      expect((result as Record<string, unknown>).url).toBeUndefined();
     });
 
     it("should strip videoUrl from each test item in tests array", async () => {
       const mockWithTests = {
         ...suiteExecutionMock,
         tests: [
-          { id: "test-1", status: "passed", videoUrl: "https://cdn.reflect.run/video/1.mp4" },
-          { id: "test-2", status: "failed", videoUrl: "https://cdn.reflect.run/video/2.mp4" },
+          {
+            id: "test-1",
+            status: "passed",
+            videoUrl: "https://cdn.reflect.run/video/1.mp4",
+          },
+          {
+            id: "test-2",
+            status: "failed",
+            videoUrl: "https://cdn.reflect.run/video/2.mp4",
+          },
         ],
       };
       fetchMock.mockResponseOnce(JSON.stringify(mockWithTests));
@@ -405,11 +416,14 @@ describe("FunctionalTestingAPI", () => {
         executionId: "7",
       });
 
-      const tests = (result as Record<string, unknown>)["tests"] as Record<string, unknown>[];
-      expect(tests[0]["videoUrl"]).toBeUndefined();
-      expect(tests[1]["videoUrl"]).toBeUndefined();
-      expect(tests[0]["id"]).toBe("test-1");
-      expect(tests[1]["id"]).toBe("test-2");
+      const tests = (result as Record<string, unknown>).tests as Record<
+        string,
+        unknown
+      >[];
+      expect(tests[0].videoUrl).toBeUndefined();
+      expect(tests[1].videoUrl).toBeUndefined();
+      expect(tests[0].id).toBe("test-1");
+      expect(tests[1].id).toBe("test-2");
     });
 
     it("should throw ToolError when suiteId is missing", async () => {

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -357,9 +357,9 @@ describe("FunctionalTestingAPI", () => {
   describe("getSuiteExecution", () => {
     const suiteExecutionMock = {
       suiteId: "checkout-suite",
-      executionId: 7,
+      executionId: "7",
       isFinished: true,
-      status: "Passed",
+      status: "passed",
       tests: [],
     };
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -167,17 +167,32 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(executionMock);
     });
 
-    it("should strip videoUrl from response", async () => {
+    it("should strip videoUrl from nested test run", async () => {
       fetchMock.mockResponseOnce(
         JSON.stringify({
           ...executionMock,
-          videoUrl: "https://cdn.reflect.run/video/42.mp4",
+          tests: [
+            {
+              testId: 1,
+              run: {
+                runId: 10,
+                status: "passed",
+                videoUrl: "https://cdn.reflect.run/video/42.mp4",
+              },
+            },
+          ],
         }),
       );
 
       const result = await api.getTestExecution({ executionId: "42" });
+      const tests = (result as Record<string, unknown>).tests as Record<
+        string,
+        unknown
+      >[];
+      const run = tests[0].run as Record<string, unknown>;
 
-      expect((result as Record<string, unknown>).videoUrl).toBeUndefined();
+      expect(run.videoUrl).toBeUndefined();
+      expect(run.runId).toBe(10);
       expect((result as Record<string, unknown>).executionId).toBe("42");
     });
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -307,6 +307,16 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(executionMock);
     });
 
+    it("should strip url field from response", async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ ...executionMock, url: "https://app.reflect.run/suites/checkout-suite/executions/7" }),
+      );
+
+      const result = await api.runSuite({ suiteId: "checkout-suite" });
+
+      expect((result as Record<string, unknown>)["url"]).toBeUndefined();
+    });
+
     it("should throw ToolError when suiteId is missing", async () => {
       await expect(api.runSuite({ suiteId: "" })).rejects.toThrow(
         "suiteId argument is required",
@@ -365,6 +375,41 @@ describe("FunctionalTestingAPI", () => {
       });
 
       expect(result).toEqual(suiteExecutionMock);
+    });
+
+    it("should strip url field from response", async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ ...suiteExecutionMock, url: "https://app.reflect.run/suites/checkout-suite/executions/7" }),
+      );
+
+      const result = await api.getSuiteExecution({
+        suiteId: "checkout-suite",
+        executionId: "7",
+      });
+
+      expect((result as Record<string, unknown>)["url"]).toBeUndefined();
+    });
+
+    it("should strip videoUrl from each test item in tests array", async () => {
+      const mockWithTests = {
+        ...suiteExecutionMock,
+        tests: [
+          { id: "test-1", status: "passed", videoUrl: "https://cdn.reflect.run/video/1.mp4" },
+          { id: "test-2", status: "failed", videoUrl: "https://cdn.reflect.run/video/2.mp4" },
+        ],
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(mockWithTests));
+
+      const result = await api.getSuiteExecution({
+        suiteId: "checkout-suite",
+        executionId: "7",
+      });
+
+      const tests = (result as Record<string, unknown>)["tests"] as Record<string, unknown>[];
+      expect(tests[0]["videoUrl"]).toBeUndefined();
+      expect(tests[1]["videoUrl"]).toBeUndefined();
+      expect(tests[0]["id"]).toBe("test-1");
+      expect(tests[1]["id"]).toBe("test-2");
     });
 
     it("should throw ToolError when suiteId is missing", async () => {

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -415,12 +415,16 @@ describe("FunctionalTestingAPI", () => {
             {
               id: "test-1",
               status: "passed",
-              runs: [{ runId: 1, videoUrl: "https://cdn.reflect.run/video/1.mp4" }],
+              runs: [
+                { runId: 1, videoUrl: "https://cdn.reflect.run/video/1.mp4" },
+              ],
             },
             {
               id: "test-2",
               status: "failed",
-              runs: [{ runId: 2, videoUrl: "https://cdn.reflect.run/video/2.mp4" }],
+              runs: [
+                { runId: 2, videoUrl: "https://cdn.reflect.run/video/2.mp4" },
+              ],
             },
           ],
         },

--- a/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
@@ -246,4 +246,63 @@ describe("SwaggerClient — Functional Testing integration", () => {
       );
     });
   });
+
+  describe("runFunctionalTestingSuite", () => {
+    it("should POST to suite executions endpoint and return result", async () => {
+      const executionMock = { executionId: "42", status: "pending" };
+      fetchMock.mockResponseOnce(JSON.stringify(executionMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.runFunctionalTestingSuite({ suiteId: "checkout-suite" }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/checkout-suite/executions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(executionMock);
+    });
+  });
+
+  describe("getFunctionalTestingSuiteExecution", () => {
+    it("should GET suite execution endpoint and return result", async () => {
+      const suiteExecutionMock = {
+        suiteId: "checkout-suite",
+        executionId: "42",
+        isFinished: true,
+        status: "passed",
+        tests: [],
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.getFunctionalTestingSuiteExecution({
+          suiteId: "checkout-suite",
+          executionId: "42",
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/checkout-suite/executions/42",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(suiteExecutionMock);
+    });
+  });
 });


### PR DESCRIPTION
## Goal
Fixes RF-4893 (https://smartbear.atlassian.net/browse/RF-4893) and RF-4926 (https://smartbear.atlassian.net/browse/RF-4926)

1. Extends the SFT toolset with `run_suite` and `get_suite_status`
- `run_suite` allows users to run an already-created suite by `suiteId`. Optionally accepts `tunnelAgentName` to override tunnel agent for this suite run.
- `get_suite_status` retrieves the triggered suite run status, overall result, and per-test results. Requires both `suiteId` and `executionId`.

2. Adjusts SFT tools responses to not contain `url` and `videoUrl` parameter returned from Reflect API.

3. Fixes incorrect/lack-off `readOnly` and `indepotetent` parameters for all current SFT tools.
(temp, will update once https://github.com/SmartBear/smartbear-mcp/pull/553 is merged)

## Design
Followed similar design for `run_test` and `get_test_status` functional testing tools when implementing new ones. New tools delegate through SwaggerClient methods, API calls live in FunctionalTestingAPI, and input schemas are defined with Zod in a dedicated types file. Everything is properly described.

Followed existing Reflect BE APIs to remove `url` and `videoUrl` from test and suite related tools.

## Changeset
  - Added `run_suite` and `get_suite_status` tools to FunctionalTestingAPI and wired them through SwaggerClient
  - Added optional `tunnelAgentName` parameter to `run_suite`, serialized as `overrides.agent.name` in the request body when provided
  - Implemented ts logic for new tools, removed `url` and `videoUrl` params from processed responses.
  - Removed `videoUrl` param from `get_test_status` processed response.
  - Adjusted `readOnly` and `indepotetent` parameters for all current and new tools
  - Added Zod input schemas for new tools
  - Updated docs (swagger-functional-testing-integration.md)

## Testing
- [x] Unit tests added
- [x] Manual local testing of new SFT tools performed
- [x] Manual local regression testing of other SFT tools performed
- [x] Manual local regression testing of other Swagger tools performed