### PR TITLE
Capture and propagate MCP client identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Common] Capture MCP client identity (`clientInfo.name`/`version`) from the `initialize` handshake and store it in the session context. The normalized client name and version are forwarded on the outbound User-Agent for all downstream API requests and attached to BugSnag event metadata, enabling usage attribution by originating MCP client (Claude, Cursor, Copilot Studio, etc.) without client-side changes [#532](https://github.com/SmartBear/smartbear-mcp/pull/532)
+
 ### Added
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.

--- a/src/bearq/client.ts
+++ b/src/bearq/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { USER_AGENT } from "../common/info";
+import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -77,7 +77,7 @@ export class BearQClient implements Client {
     return {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
-      "User-Agent": USER_AGENT,
+      "User-Agent": getUserAgent(),
     };
   }
 

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CacheService } from "../common/cache";
-import { USER_AGENT } from "../common/info";
+import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -187,7 +187,7 @@ export class BugsnagClient implements Client {
         );
       },
       headers: {
-        "User-Agent": USER_AGENT,
+        "User-Agent": getUserAgent(),
         "Content-Type": "application/json",
         "X-Bugsnag-API": "true",
         "X-Version": "2",

--- a/src/collaborator/client.ts
+++ b/src/collaborator/client.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { USER_AGENT } from "../common/info";
+import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import type {
@@ -75,7 +75,10 @@ export class CollaboratorClient implements Client {
     ];
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": getUserAgent(),
+      },
       body: JSON.stringify(body),
     });
     if (!response.ok) {

--- a/src/common/client-identity.ts
+++ b/src/common/client-identity.ts
@@ -1,0 +1,55 @@
+import { getRequestContext } from "./request-context";
+
+/**
+ * Client identity captured from the MCP `initialize` handshake.
+ *
+ * `clientInfo` is protocol-guaranteed for conforming clients but self-reported:
+ * a client may omit it or report an arbitrary value.
+ */
+export interface McpClientIdentity {
+  /** Raw `clientInfo.name` as reported by the client (may be absent). */
+  name?: string;
+  /** Raw `clientInfo.version` as reported by the client (may be absent). */
+  version?: string;
+  /** Negotiated protocol version from the initialize request, when known. */
+  protocolVersion?: string;
+}
+
+/**
+ * Build an {@link McpClientIdentity} from a raw `clientInfo` object (as found
+ * on the MCP `initialize` request, or returned by `Server.getClientVersion()`).
+ */
+export function toClientIdentity(
+  info?: { name?: string; version?: string },
+  protocolVersion?: string,
+): McpClientIdentity {
+  return {
+    name: info?.name,
+    version: info?.version,
+    protocolVersion,
+  };
+}
+
+/**
+ * Process-wide fallback identity, used by stdio transport where there is a
+ * single connection for the process lifetime and no per-request AsyncLocalStorage
+ * context. Safe because stdio handles exactly one client.
+ */
+let processClientIdentity: McpClientIdentity | undefined;
+
+/** Set (or clear) the process-wide client identity (stdio transport). */
+export function setProcessClientIdentity(
+  identity: McpClientIdentity | undefined,
+): void {
+  processClientIdentity = identity;
+}
+
+/**
+ * Resolve the client identity for the current outbound request, preferring the
+ * per-request context (HTTP, supports concurrent sessions) and falling back to
+ * the process-wide identity (stdio). Returns `undefined` when nothing has been
+ * captured yet (e.g. before `initialize`).
+ */
+export function getCurrentClientIdentity(): McpClientIdentity | undefined {
+  return getRequestContext()?.mcpClient ?? processClientIdentity;
+}

--- a/src/common/info.ts
+++ b/src/common/info.ts
@@ -1,6 +1,55 @@
 import packageJson from "../../package.json" with { type: "json" };
+import {
+  getCurrentClientIdentity,
+  type McpClientIdentity,
+} from "./client-identity";
+
 export const MCP_SERVER_NAME = packageJson.config.mcpServerName;
 export const MCP_SERVER_VERSION = packageJson.version;
 export const MCP_TRANSPORT =
   process.env.MCP_TRANSPORT?.toLowerCase().trim() || "stdio";
 export const USER_AGENT = `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION} ${MCP_TRANSPORT}`;
+
+/**
+ * Sanitize a value for safe inclusion in a User-Agent comment segment by
+ * stripping characters that would break the `( ... )` syntax or span lines.
+ */
+function sanitizeUserAgentToken(value: string): string {
+  return value.replace(/[()\r\n;]/g, "").trim();
+}
+
+/**
+ * Build the ` (client: ...; clientVersion: ...)` User-Agent comment segment for
+ * a given identity, or an empty string when the client is unidentified.
+ */
+function clientIdentitySuffix(identity?: McpClientIdentity): string {
+  if (!identity?.name) {
+    return "";
+  }
+  const clientName = sanitizeUserAgentToken(identity.name) || "unknown";
+  const version = identity.version
+    ? sanitizeUserAgentToken(identity.version) || "unknown"
+    : "unknown";
+  return ` (client: ${clientName}; clientVersion: ${version})`;
+}
+
+/**
+ * Append the identified MCP client (from the `initialize` handshake) to a base
+ * User-Agent as a comment segment, so downstream services can attribute traffic
+ * by source — e.g.
+ * `Smartbear-MCP/1.2.3 http (client: cursor; clientVersion: 0.40.0)`.
+ *
+ * Returns `baseUserAgent` unchanged when no client has been identified (e.g.
+ * before `initialize`, or an unknown client with no reported name).
+ */
+export function appendClientIdentity(baseUserAgent: string): string {
+  return baseUserAgent + clientIdentitySuffix(getCurrentClientIdentity());
+}
+
+/**
+ * Build the outbound User-Agent for downstream API calls, including the
+ * identified MCP client when known. See {@link appendClientIdentity}.
+ */
+export function getUserAgent(): string {
+  return appendClientIdentity(USER_AGENT);
+}

--- a/src/common/initialize.ts
+++ b/src/common/initialize.ts
@@ -1,3 +1,4 @@
+import { setProcessClientIdentity, toClientIdentity } from "./client-identity";
 import type { SmartBearMcpServer } from "./server";
 import type { ClientInfo } from "./types";
 
@@ -24,6 +25,15 @@ export function handleInitializeMessage(
   }
 
   const params = (message as { params?: Record<string, unknown> }).params;
+
+  const identity = toClientIdentity(
+    params?.clientInfo as { name?: string; version?: string } | undefined,
+    params?.protocolVersion as string | undefined,
+  );
+
+  server.setMcpClientIdentity(identity);
+  setProcessClientIdentity(identity);
+
   const clientInfo = params?.clientInfo as ClientInfo | undefined;
   if (clientInfo) {
     server.setClientInfo(clientInfo);

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -1,10 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { IncomingMessage } from "node:http";
+import type { McpClientIdentity } from "./client-identity";
 
 // Storage for pre-request data that can be retrieved from a tool to prevent caching as part of the server instance in a session.
 // For example, the auth token.
 export interface RequestContext {
   headers: Record<string, string | string[] | undefined>;
+  // Identity of the MCP client for this session, captured at `initialize`.
+  // Used to forward client attribution to downstream APIs (User-Agent).
+  mcpClient?: McpClientIdentity;
 }
 
 // Create the storage instance
@@ -21,6 +25,18 @@ export function withRequestContext<T>(req: IncomingMessage, fn: () => T): T {
 // Helper to get the current context
 export function getRequestContext(): RequestContext | undefined {
   return requestContextStorage.getStore();
+}
+
+/**
+ * Attach the captured MCP client identity to the current request context so
+ * downstream code (e.g. User-Agent construction) can forward it. No-op when
+ * called outside a request context.
+ */
+export function setRequestMcpClient(identity: McpClientIdentity): void {
+  const context = getRequestContext();
+  if (context) {
+    context.mcpClient = identity;
+  }
 }
 
 /**

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -14,6 +14,7 @@ import {
 } from "zod";
 import Bugsnag, { type BugsnagEvent } from "../common/bugsnag";
 import { CacheService } from "./cache";
+import { type McpClientIdentity, toClientIdentity } from "./client-identity";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
 import {
   executeElicitationOrPolyfill,
@@ -35,6 +36,7 @@ export class SmartBearMcpServer extends McpServer {
   private clientInfo?: ClientInfo;
   private clients: Client[] = [];
   private enabledToolsets?: string[];
+  private mcpClientIdentity?: McpClientIdentity;
 
   constructor(enabledToolsets?: string) {
     super(
@@ -88,6 +90,38 @@ export class SmartBearMcpServer extends McpServer {
 
   getClients(): Client[] {
     return this.clients;
+  }
+
+  /**
+   * Record the MCP client identity reported in the `initialize` handshake.
+   * Captured once per session by the transport layer.
+   */
+  setMcpClientIdentity(identity: McpClientIdentity): void {
+    this.mcpClientIdentity = identity;
+  }
+
+  /**
+   * Return the MCP client identity for this session. Prefers the value captured
+   * at `initialize`; falls back to the SDK's `getClientVersion()` so callers
+   * still get an answer if the explicit capture was skipped.
+   */
+  getMcpClientIdentity(): McpClientIdentity {
+    return (
+      this.mcpClientIdentity ?? toClientIdentity(this.server.getClientVersion())
+    );
+  }
+
+  /**
+   * Attach MCP client attribution to a Bugsnag event so errors can be segmented
+   * by originating client/marketplace.
+   */
+  private addClientMetadata(event: BugsnagEvent): void {
+    const identity = this.getMcpClientIdentity();
+    event.addMetadata("mcpClient", {
+      mcp_client_name: identity.name ?? null,
+      mcp_client_version: identity.version ?? null,
+      mcp_protocol_version: identity.protocolVersion ?? null,
+    });
   }
 
   async cleanupSession(mcpSessionId: string): Promise<void> {
@@ -149,6 +183,7 @@ export class SmartBearMcpServer extends McpServer {
               } else {
                 Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
                   event.addMetadata("app", { tool: toolName });
+                  this.addClientMetadata(event);
                   event.unhandled = true;
                 });
               }
@@ -201,6 +236,7 @@ export class SmartBearMcpServer extends McpServer {
                   resource: resourceName,
                   url: url,
                 });
+                this.addClientMetadata(event);
                 event.unhandled = true;
               });
               throw e;
@@ -227,6 +263,7 @@ export class SmartBearMcpServer extends McpServer {
                 event.addMetadata("app", {
                   prompt: this.getCapabilityName(client, params.title),
                 });
+                this.addClientMetadata(event);
                 event.unhandled = true;
               });
               throw e;

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -6,10 +6,9 @@ import querystring from "node:querystring";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-
 import { clientRegistry } from "./client-registry";
 import { handleInitializeMessage } from "./initialize";
-import { withRequestContext } from "./request-context";
+import { setRequestMcpClient, withRequestContext } from "./request-context";
 import { SmartBearMcpServer } from "./server";
 import { isDraining, registerShutdownHandler } from "./shutdown";
 import { getEnvVarName } from "./transport-stdio";
@@ -462,11 +461,19 @@ export async function handleStreamableHttpRequest(
       return;
     }
 
-    // Delegate to transport to handle the MCP protocol message
-    await withRequestContext(
-      req,
-      async () => await transport.handleRequest(req, res, parsedBody),
-    );
+    // Delegate to transport to handle the MCP protocol message. For requests on
+    // an established session, surface the client identity captured at
+    // `initialize` so downstream API calls (User-Agent) can forward it. New
+    // (initialize) requests have no identity yet and make no downstream calls.
+    const sessionServer = sessionId
+      ? transports.get(sessionId)?.server
+      : undefined;
+    await withRequestContext(req, async () => {
+      if (sessionServer) {
+        setRequestMcpClient(sessionServer.getMcpClientIdentity());
+      }
+      return await transport.handleRequest(req, res, parsedBody);
+    });
   } catch (error) {
     console.error("Error handling StreamableHTTP request:", error);
     res.writeHead(500, { "Content-Type": "text/plain" });
@@ -502,6 +509,11 @@ async function handleLegacySseRequest(
 
   // SSE transport keeps the connection open and sends events to the client
   const transport = new SSEServerTransport("/message", res);
+
+  // Capture the client identity from the initialize handshake (see the
+  // streamable HTTP transport for rationale). Set before connect() so the SDK
+  // chains this handler ahead of its own message processing.
+  transport.onmessage = (message) => handleInitializeMessage(server, message);
 
   // Store the session so POST /message requests can find it
   transports.set(transport.sessionId, { server, transport });
@@ -571,16 +583,14 @@ async function handleLegacyMessageRequest(
   req.on("end", async () => {
     try {
       const parsedBody = JSON.parse(body);
-      // Route message to the SSE transport for processing
-      await withRequestContext(
-        req,
-        async () =>
-          await (session.transport as SSEServerTransport).handlePostMessage(
-            req,
-            res,
-            parsedBody,
-          ),
-      );
+      // Route message to the SSE transport for processing, surfacing the client
+      // identity captured at `initialize` for downstream forwarding.
+      await withRequestContext(req, async () => {
+        setRequestMcpClient(session.server.getMcpClientIdentity());
+        return await (
+          session.transport as SSEServerTransport
+        ).handlePostMessage(req, res, parsedBody);
+      });
     } catch (error) {
       console.error("Error handling POST message:", error);
       res.writeHead(500, { "Content-Type": "text/plain" });

--- a/src/qmetry/client/api/client-api.ts
+++ b/src/qmetry/client/api/client-api.ts
@@ -1,4 +1,4 @@
-import { USER_AGENT } from "../../../common/info";
+import { getUserAgent } from "../../../common/info";
 import { QMETRY_DEFAULTS } from "../../config/constants";
 import type { RequestOptions } from "../../types/common";
 import { handleQMetryApiError, handleQMetryFetchError } from "./error-handler";
@@ -28,7 +28,7 @@ export async function qmetryRequest<T>({
   const headers: Record<string, string> = {
     apikey: token,
     project: project || QMETRY_DEFAULTS.PROJECT_KEY,
-    "User-Agent": USER_AGENT,
+    "User-Agent": getUserAgent(),
     "qmetry-source": "smartbear-mcp",
   };
   if (scopeId !== undefined) {

--- a/src/qmetry/client/automation.ts
+++ b/src/qmetry/client/automation.ts
@@ -1,4 +1,4 @@
-import { USER_AGENT } from "../../common/info";
+import { getUserAgent } from "../../common/info";
 import { QMETRY_DEFAULTS } from "../config/constants";
 import { QMETRY_PATHS } from "../config/rest-endpoints";
 import type { ImportAutomationResultsPayload } from "../types/automation";
@@ -138,7 +138,7 @@ export async function importAutomationResults(
   const headers: Record<string, string> = {
     apikey: token,
     project: finalPayload.projectID || project || QMETRY_DEFAULTS.PROJECT_KEY,
-    "User-Agent": USER_AGENT,
+    "User-Agent": getUserAgent(),
     "qmetry-source": "smartbear-mcp",
     // Note: Content-Type will be set automatically by fetch for FormData
   };

--- a/src/qtm4j/http/auth-service.ts
+++ b/src/qtm4j/http/auth-service.ts
@@ -1,4 +1,4 @@
-import { USER_AGENT } from "../../common/info";
+import { getUserAgent } from "../../common/info";
 import { CONTENT_TYPES, HTTP_HEADERS } from "../config/constants";
 
 /**
@@ -20,7 +20,7 @@ export class AuthService {
     return {
       [HTTP_HEADERS.API_KEY]: this.apiKey,
       [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
-      [HTTP_HEADERS.USER_AGENT]: USER_AGENT,
+      [HTTP_HEADERS.USER_AGENT]: getUserAgent(),
       [HTTP_HEADERS.ACCEPT]: CONTENT_TYPES.JSON,
     };
   }

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { USER_AGENT } from "../common/info";
+import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
 import { ToolError } from "../common/tools";
@@ -119,7 +119,7 @@ export class ReflectClient implements Client {
     return {
       ...this.getAuthHeader(),
       "Content-Type": "application/json",
-      "User-Agent": USER_AGENT,
+      "User-Agent": getUserAgent(),
     };
   }
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1,3 +1,4 @@
+import { appendClientIdentity } from "../../common/info";
 import { ToolError } from "../../common/tools";
 import type { SwaggerConfiguration } from "./configuration";
 import type {
@@ -127,7 +128,7 @@ export class SwaggerAPI {
   }
 
   private get headers(): Record<string, string> {
-    return this.config.getHeaders(this.userAgent);
+    return this.config.getHeaders(appendClientIdentity(this.userAgent));
   }
 
   /**

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,3 +1,4 @@
+import { appendClientIdentity } from "../../common/info";
 import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
@@ -32,7 +33,7 @@ export class FunctionalTestingAPI {
     return {
       [FUNCTIONAL_TESTING_API_KEY_HEADER]: token,
       "Content-Type": "application/json",
-      "User-Agent": this.userAgent,
+      "User-Agent": appendClientIdentity(this.userAgent),
     };
   }
 

--- a/src/tests/unit/common/client-identity.test.ts
+++ b/src/tests/unit/common/client-identity.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getCurrentClientIdentity,
+  setProcessClientIdentity,
+  toClientIdentity,
+} from "../../../common/client-identity";
+import { appendClientIdentity, getUserAgent } from "../../../common/info";
+import { requestContextStorage } from "../../../common/request-context";
+
+describe("client-identity", () => {
+  afterEach(() => {
+    // Reset the process-wide fallback between tests.
+    setProcessClientIdentity(undefined);
+  });
+
+  describe("toClientIdentity", () => {
+    it("preserves raw name/version and protocol version", () => {
+      expect(
+        toClientIdentity({ name: "claude-ai", version: "1.2.3" }, "2025-06-18"),
+      ).toEqual({
+        name: "claude-ai",
+        version: "1.2.3",
+        protocolVersion: "2025-06-18",
+      });
+    });
+
+    it("handles a missing clientInfo object", () => {
+      expect(toClientIdentity(undefined)).toEqual({
+        name: undefined,
+        version: undefined,
+        protocolVersion: undefined,
+      });
+    });
+  });
+
+  describe("getCurrentClientIdentity", () => {
+    it("returns the request-context identity when present", () => {
+      const identity = toClientIdentity({ name: "cursor", version: "0.40.0" });
+      requestContextStorage.run({ headers: {}, mcpClient: identity }, () => {
+        expect(getCurrentClientIdentity()).toBe(identity);
+      });
+    });
+
+    it("falls back to the process identity (stdio) outside a request", () => {
+      const identity = toClientIdentity({ name: "claude-ai", version: "9" });
+      setProcessClientIdentity(identity);
+      expect(getCurrentClientIdentity()).toBe(identity);
+    });
+
+    it("prefers the request-context identity over the process fallback", () => {
+      const processId = toClientIdentity({ name: "claude-ai" });
+      const requestId = toClientIdentity({ name: "cursor" });
+      setProcessClientIdentity(processId);
+      requestContextStorage.run({ headers: {}, mcpClient: requestId }, () => {
+        expect(getCurrentClientIdentity()).toBe(requestId);
+      });
+    });
+  });
+
+  describe("appendClientIdentity / getUserAgent", () => {
+    it("returns the base unchanged when no client is identified", () => {
+      expect(appendClientIdentity("Base/1.0")).toBe("Base/1.0");
+    });
+
+    it("returns the base unchanged for a client with no name", () => {
+      requestContextStorage.run(
+        { headers: {}, mcpClient: toClientIdentity(undefined) },
+        () => {
+          expect(appendClientIdentity("Base/1.0")).toBe("Base/1.0");
+        },
+      );
+    });
+
+    it("appends raw client name and version as a comment segment", () => {
+      const identity = toClientIdentity({ name: "cursor", version: "0.40.0" });
+      requestContextStorage.run({ headers: {}, mcpClient: identity }, () => {
+        expect(appendClientIdentity("Base/1.0")).toBe(
+          "Base/1.0 (client: cursor; clientVersion: 0.40.0)",
+        );
+        expect(getUserAgent()).toContain(
+          "(client: cursor; clientVersion: 0.40.0)",
+        );
+      });
+    });
+
+    it("forwards unrecognized client names as-is", () => {
+      const identity = toClientIdentity({ name: "weird-wrapper" });
+      requestContextStorage.run({ headers: {}, mcpClient: identity }, () => {
+        expect(appendClientIdentity("Base/1.0")).toBe(
+          "Base/1.0 (client: weird-wrapper; clientVersion: unknown)",
+        );
+      });
+    });
+
+    it("sanitizes characters that would break the UA comment syntax", () => {
+      const identity = toClientIdentity({
+        name: "cursor",
+        version: "1.0 (beta);\n",
+      });
+      requestContextStorage.run({ headers: {}, mcpClient: identity }, () => {
+        expect(appendClientIdentity("Base/1.0")).toBe(
+          "Base/1.0 (client: cursor; clientVersion: 1.0 beta)",
+        );
+      });
+    });
+  });
+});

--- a/src/tests/unit/common/initialize.test.ts
+++ b/src/tests/unit/common/initialize.test.ts
@@ -5,6 +5,7 @@ import type { SmartBearMcpServer } from "../../../common/server";
 function fakeServer() {
   return {
     setClientInfo: vi.fn(),
+    setMcpClientIdentity: vi.fn(),
     setSamplingSupported: vi.fn(),
     setElicitationSupported: vi.fn(),
   } as unknown as SmartBearMcpServer;

--- a/src/tests/unit/common/transport-http.test.ts
+++ b/src/tests/unit/common/transport-http.test.ts
@@ -733,7 +733,9 @@ describe("handleStreamableHttpRequest (session routing)", () => {
     );
     fakeTransport.handleRequest = handleRequest;
     transports.set("known-session", {
-      server: {} as any,
+      server: {
+        getMcpClientIdentity: () => ({ name: undefined }),
+      } as any,
       transport: fakeTransport,
     });
 

--- a/src/tests/unit/qmetry/tools.test.ts
+++ b/src/tests/unit/qmetry/tools.test.ts
@@ -1160,13 +1160,13 @@ describe("QmetryClient tools", () => {
       expect(parsed.data[0].udfjson).toBeUndefined();
       expect(parsed.data[0].testRunUdfs).toBeDefined();
       expect(parsed.data[0].testRunUdfs["8260LUP"]).toBe("l1");
-      expect(parsed.data[0].testRunUdfs["NB_Multilppup_TR"]).toEqual(["ahd"]);
-      expect(parsed.data[0].testRunUdfs["cascade_vK"]).toEqual({
+      expect(parsed.data[0].testRunUdfs.NB_Multilppup_TR).toEqual(["ahd"]);
+      expect(parsed.data[0].testRunUdfs.cascade_vK).toEqual({
         child: "aa",
         parent: "abc",
       });
       // HTML stripped from rich text field
-      expect(parsed.data[0].testRunUdfs["Jal_Largetext"]).toBe("hello world");
+      expect(parsed.data[0].testRunUdfs.Jal_Largetext).toBe("hello world");
 
       // Row without udfjson: no testRunUdfs added, original fields preserved
       expect(parsed.data[1].udfjson).toBeUndefined();

--- a/src/zephyr/common/auth-service.ts
+++ b/src/zephyr/common/auth-service.ts
@@ -1,4 +1,4 @@
-import { USER_AGENT } from "../../common/info";
+import { getUserAgent } from "../../common/info";
 
 export class AuthService {
   private readonly bearerToken: string;
@@ -11,7 +11,7 @@ export class AuthService {
     return {
       Authorization: `Bearer ${this.bearerToken}`,
       "Content-Type": "application/json",
-      "User-Agent": USER_AGENT,
+      "User-Agent": getUserAgent(),
       "zscale-source": "smartbear-mcp",
     };
   }


### PR DESCRIPTION
Fixes [AIA-359](https://smartbear.atlassian.net/browse/AIA-359)

Capture MCP client name and version from the initialize handshake and propagate a normalized client identity through the session.

The client identity is appended to outbound User-Agent headers and included in Bugsnag metadata for improved source attribution and observability.

**Tested**
- Verified client identity is captured and normalized in stdio mode
- Confirmed User-Agent includes client identity on downstream requests
- Verified client identity is available in Swagger metadata

[AIA-359]: https://smartbear.atlassian.net/browse/AIA-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ