### PR TITLE
SWG-20002: publish com.smartbear/swagger-mcp registry entry

### DIFF
--- a/.github/workflows/check-server-json.yml
+++ b/.github/workflows/check-server-json.yml
@@ -33,30 +33,31 @@ jobs:
 
           echo "Current schema URL from registry: $CURRENT_SCHEMA_URL"
 
-          # Read the schema URL from server.json
-          SCHEMA_URL=$(jq -r '."$schema"' server.json)
-
-          echo "Schema in server.json: $SCHEMA_URL"
-
-          # Extract version date (e.g., 2025-12-11) from both URLs using regex
+          # Extract version date (e.g., 2025-12-11) from the current schema URL
           CURRENT_VERSION=$(echo "$CURRENT_SCHEMA_URL" | grep -oP '\d{4}-\d{2}-\d{2}')
-          SCHEMA_VERSION=$(echo "$SCHEMA_URL" | grep -oP '\d{4}-\d{2}-\d{2}')
-
           echo "Current schema version: $CURRENT_VERSION"
-          echo "Schema version in server.json: $SCHEMA_VERSION"
 
-          # Verify the schema versions match
-          if [ "$SCHEMA_VERSION" != "$CURRENT_VERSION" ]; then
-            echo ""
-            echo "❌ ERROR: deprecated schema detected: $SCHEMA_URL."
-            echo ""
-            echo "Migrate to the current schema format for new servers."
-            echo "📋 Migration checklist: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md#migration-checklist-for-publishers"
-            echo "📖 Full changelog with examples: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md"
-            echo ""
-            echo "Expected schema: $CURRENT_SCHEMA_URL"
-            exit 1
-          fi
+          for FILE in server.json server.swagger.json; do
+            # Read the schema URL from the server file
+            SCHEMA_URL=$(jq -r '."$schema"' "$FILE")
+            echo "Schema in $FILE: $SCHEMA_URL"
+
+            SCHEMA_VERSION=$(echo "$SCHEMA_URL" | grep -oP '\d{4}-\d{2}-\d{2}')
+            echo "Schema version in $FILE: $SCHEMA_VERSION"
+
+            # Verify the schema versions match
+            if [ "$SCHEMA_VERSION" != "$CURRENT_VERSION" ]; then
+              echo ""
+              echo "❌ ERROR: deprecated schema detected in $FILE: $SCHEMA_URL."
+              echo ""
+              echo "Migrate to the current schema format for new servers."
+              echo "📋 Migration checklist: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md#migration-checklist-for-publishers"
+              echo "📖 Full changelog with examples: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md"
+              echo ""
+              echo "Expected schema: $CURRENT_SCHEMA_URL"
+              exit 1
+            fi
+          done
 
           echo "✅ Schema validation passed - using current schema version"
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -251,6 +251,9 @@ jobs:
           jq --arg v "${{ steps.extract_version.outputs.VERSION }}" \
             '.version = $v | .packages[0].version = $v' \
             server.json > server.json.tmp && mv server.json.tmp server.json
+          jq --arg v "${{ steps.extract_version.outputs.VERSION }}" \
+            '.version = $v' \
+            server.swagger.json > server.swagger.json.tmp && mv server.swagger.json.tmp server.swagger.json
 
       - name: Install dependencies
         run: npm ci
@@ -275,6 +278,10 @@ jobs:
       - name: Publish to MCP Registry
         if: ${{ env.RUN_PUBLISH_MCP == 'true' }}
         run: ./mcp-publisher publish
+
+      - name: Publish swagger-mcp to MCP Registry
+        if: ${{ env.RUN_PUBLISH_MCP == 'true' }}
+        run: ./mcp-publisher publish server.swagger.json
 
       - name: Build and pack .mcpb
         if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}

--- a/server.swagger.json
+++ b/server.swagger.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json#/definitions/ServerDetail",
   "title": "Swagger MCP",
   "name": "com.smartbear/swagger-mcp",
-  "description": "MCP server for AI access to Swagger by SmartBear, including API design, documentation portals, and standardization.",
+  "description": "MCP server for AI access to Swagger by SmartBear.",
   "repository": {
     "url": "https://github.com/SmartBear/smartbear-mcp",
     "source": "github"

--- a/server.swagger.json
+++ b/server.swagger.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json#/definitions/ServerDetail",
+  "title": "Swagger MCP",
+  "name": "com.smartbear/swagger-mcp",
+  "description": "MCP server for AI access to Swagger by SmartBear, including API design, documentation portals, and standardization.",
+  "repository": {
+    "url": "https://github.com/SmartBear/smartbear-mcp",
+    "source": "github"
+  },
+  "version": "0.17.1",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://swagger.mcp.smartbear.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Add a remotes-only `server.swagger.json` named `com.smartbear/swagger-mcp` pointing at the Swagger remote, so the server is discoverable under the Swagger name in the MCP Registry
  alongside the existing smartbear-mcp entry.

  - New `server.swagger.json` (remotes-only; validated via smartbear.com DNS namespace ownership, so no npm mcpName conflict with `@smartbear/mcp`).
  - `publish.yaml`: bump its version and publish it after the main entry.
  - `check-server-json.yml`: validate both files' schema versions.

  ## Goal

  We already publish `com.smartbear/smartbear-mcp` to the MCP Registry, but the server isn't discoverable under the **Swagger** name. This adds a second registry entry,
  `com.smartbear/swagger-mcp`, so users searching the registry for Swagger find it directly. It's additive — the existing `smartbear-mcp` entry is untouched.

  ## Design

  The naive approach (duplicating `server.json` with a new name + the `@smartbear/mcp` package) fails registry validation: for npm-backed entries the registry fetches the package and
  requires its `mcpName` to match the server name, and a package can only declare **one** `mcpName`. The `@smartbear/mcp` package declares `com.smartbear/smartbear-mcp`, so a second
  npm-backed name would be rejected.

  Instead, the new entry is **remotes-only** (no `packages` block), pointing at the existing `https://swagger.mcp.smartbear.com/mcp` remote. Remote entries are validated purely by
  namespace ownership — which we already prove via `mcp-publisher login dns --domain smartbear.com` in the publish workflow — so there's no npm `mcpName` conflict.

  The name stays in our verified namespace as `com.smartbear/swagger-mcp`.

  ## Changeset

  - **`server.swagger.json`** (new): remotes-only `ServerDetail` named `com.smartbear/swagger-mcp`, pointing at the Swagger streamable-http remote.
  - **`.github/workflows/publish.yaml`**: bump `server.swagger.json`'s `.version` alongside the main file; add a `Publish swagger-mcp to MCP Registry` step running `./mcp-publisher
  publish server.swagger.json` after the main publish (reuses the existing login session).
  - **`.github/workflows/check-server-json.yml`**: loop schema validation over both `server.json` and `server.swagger.json` so neither drifts to a deprecated schema.

  ## Testing

  - **Two-entry coexistence (local registry):** Ran the official MCP Registry locally (`localhost:8080`), published two entries via `mcp-publisher` and queried the API — both showed
  up `status=active` and `?search=swagger`/`?search=smartbear` each returned the right one, confirming a second entry doesn't replace or break the first. (Local anonymous auth only
  allows the `io.modelcontextprotocol.anonymous/*` namespace, so test copies used that prefix — validates the mechanics, not the `com.smartbear` namespace ownership.)
  - **Schema validation:** `mcp-publisher validate` on the real `server.json` and `server.swagger.json` (with `com.smartbear/…` names) → both `valid`.
  - **CLI flag:** Confirmed `mcp-publisher publish <path>` takes a positional file argument, so the new publish step needs no file-swap workaround.
  - **Static checks:** `server.swagger.json` is valid JSON; both workflow files parse as valid YAML.

  **Not covered locally:** acceptance of the `com.smartbear/swagger-mcp` name, which is gated on `smartbear.com` DNS namespace ownership — verify by triggering the `Publish` workflow
  (`workflow_dispatch`, `publish_mcp: true`) against a tag and confirming the entry appears in registry search.

