### PR TITLE
fix(swagger): register tools when authenticated via OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Swagger] Register Portal/Studio tools when authenticated via OAuth. Previously only an explicit API key (`SWAGGER_API_KEY` / `Swagger-Api-Key` header) enabled the tools, so OAuth-only sessions listed no Swagger tools. [#537](https://github.com/SmartBear/smartbear-mcp/pull/537)
+
 ## [0.26.0] - 2026-06-19
 
 ### Added

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -96,7 +96,19 @@ export class SwaggerClient implements Client {
     config: z.infer<typeof ConfigurationSchema>,
     _cache?: any,
   ): Promise<void> {
-    if (config.api_key) {
+    // The Swagger API key can be supplied directly as config (env var /
+    // Swagger-Api-Key header) or via an OAuth bearer token on the request's
+    // Authorization header. The bearer token is only available per-request and
+    // is resolved lazily in getAuthToken(), so check the request context here to
+    // decide whether to enable the Portal/Studio API. Without this, an
+    // OAuth-only request would leave this.api undefined and no Swagger tools
+    // would be registered.
+    const hasSwaggerAuth =
+      !!config.api_key ||
+      !!getRequestHeader("Swagger-Api-Key") ||
+      !!getRequestHeader("Authorization");
+
+    if (hasSwaggerAuth) {
       this._apiKey = config.api_key;
       this.api = new SwaggerAPI(
         new SwaggerConfiguration({

--- a/src/tests/unit/swagger/client.test.ts
+++ b/src/tests/unit/swagger/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
+import { withRequestContext } from "../../../common/request-context";
 import { SwaggerClient } from "../../../swagger/client";
 import { TOOLS } from "../../../swagger/client/tools";
 
@@ -32,6 +33,61 @@ describe("SwaggerClient", () => {
     it("should create configuration and API instances", () => {
       // Test that the client was constructed successfully
       expect(client).toBeDefined();
+    });
+  });
+
+  describe("configure (authentication)", () => {
+    const registeredTitles = (client: SwaggerClient) => {
+      const mockRegister = vi.fn();
+      client.registerTools(mockRegister, vi.fn());
+      return mockRegister.mock.calls.map((call) => call[0].title);
+    };
+
+    it("registers Portal/Studio tools when configured with an api_key", async () => {
+      const freshClient = new SwaggerClient();
+      await freshClient.configure({} as any, { api_key: "test-token" });
+
+      expect(freshClient.isConfigured()).toBe(true);
+      expect(registeredTitles(freshClient)).toContain("List Portals");
+    });
+
+    it("registers Portal/Studio tools when an OAuth bearer token is present", async () => {
+      const freshClient = new SwaggerClient();
+      await withRequestContext(
+        { headers: { authorization: "Bearer oauth-token" } } as any,
+        () => freshClient.configure({} as any, {}),
+      );
+
+      expect(freshClient.isConfigured()).toBe(true);
+      expect(registeredTitles(freshClient)).toContain("List Portals");
+    });
+
+    it("registers Portal/Studio tools when a Swagger-Api-Key header is present", async () => {
+      const freshClient = new SwaggerClient();
+      await withRequestContext(
+        { headers: { "swagger-api-key": "header-key" } } as any,
+        () => freshClient.configure({} as any, {}),
+      );
+
+      expect(freshClient.isConfigured()).toBe(true);
+      expect(registeredTitles(freshClient)).toContain("List Portals");
+    });
+
+    it("does not register Portal/Studio tools when only an FT token is configured", async () => {
+      const freshClient = new SwaggerClient();
+      await freshClient.configure({} as any, {
+        functional_testing_api_token: "ft-token",
+      });
+
+      expect(freshClient.isConfigured()).toBe(true);
+      expect(registeredTitles(freshClient)).not.toContain("List Portals");
+    });
+
+    it("is not configured when no auth is supplied", async () => {
+      const freshClient = new SwaggerClient();
+      await freshClient.configure({} as any, {});
+
+      expect(freshClient.isConfigured()).toBe(false);
     });
   });
 


### PR DESCRIPTION
This pull request is to ensure that the Portal/Studio tools are registered when any valid Swagger authentication is present, whether via API key, OAuth bearer token, or the `Swagger-Api-Key` header.