### PR TITLE
release: v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.26.1] - 2026-06-24
+
 ### Fixed
 
 - [Swagger] Register Portal/Studio tools when authenticated via OAuth. Previously only an explicit API key (`SWAGGER_API_KEY` / `Swagger-Api-Key` header) enabled the tools, so OAuth-only sessions listed no Swagger tools. [#537](https://github.com/SmartBear/smartbear-mcp/pull/537)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",


### PR DESCRIPTION
- [Swagger] Register Portal/Studio tools when authenticated via OAuth. [#537](https://github.com/SmartBear/smartbear-mcp/pull/537)