### PR TITLE
feat(functional-testing): List suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Register Portal/Studio tools when authenticated via OAuth. Previously only an explicit API key (`SWAGGER_API_KEY` / `Swagger-Api-Key` header) enabled the tools, so OAuth-only sessions listed no Swagger tools. [#537](https://github.com/SmartBear/smartbear-mcp/pull/537)
 
+### Added
+
+- [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+
 ## [0.26.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Pactflow]: Send the MCP client's name and version to Pactflow via a `SOURCE_APPLICATION` header on requests, captured from the client info supplied in the MCP `initialize` request. [#556](https://github.com/SmartBear/smartbear-mcp/pull/556)
 
+### Added
+
+- [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+
 ### Fixed
 
 - [Zephyr] Fixed `get_test_case_steps` returning a schema validation error [#543](https://github.com/SmartBear/smartbear-mcp/pull/543)
@@ -26,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] Add `create_documentation_page` tool to create a documentation page in a portal product in a single call. Supports `markdown` and `html` content types with `internal` or `external` source. Returns page details and a `draftUrl` to edit the page in the portal admin.
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
-
-- [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
 ## [0.26.1] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
 
+- [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed
 
 - [Swagger] Register Portal/Studio tools when authenticated via OAuth. Previously only an explicit API key (`SWAGGER_API_KEY` / `Swagger-Api-Key` header) enabled the tools, so OAuth-only sessions listed no Swagger tools. [#537](https://github.com/SmartBear/smartbear-mcp/pull/537)
-
-### Added
-
-- [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
 ## [0.26.0] - 2026-06-19
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -15,7 +15,7 @@ The Swagger Functional Testing client provides tools for discovering and executi
 #### `list_suites`
 
 - Purpose: Lists all test Suites available in your Swagger Functional Testing workspace. Use this tool when you need to discover available Suites before running them or checking their execution history. Do not use this tool to retrieve individual tests or test Suite execution results.
-- Returns: Complete list of test Suites in the workspace. An empty list (`[]`) is returned when no Suites exist.
+- Returns: An object with a `suites` array of the test Suites in the workspace, alongside aggregate `stats`. When no Suites exist, the `suites` array is empty (`{ "suites": [] }`).
 - Use case: Discover available test Suites.
 
 ---

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -12,6 +12,12 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Returns: Complete list of tests with their identifiers and names.
 - Use case: Discover available tests.
 
+#### `list_suites`
+
+- Purpose: Lists all test suites available in your Swagger Functional Testing workspace. Use this tool when you need to discover available suites before running them or checking their execution history. Do not use this tool to retrieve individual tests or test suite execution results.
+- Returns: Complete list of test suites in the workspace. An empty list (`[]`) is returned when no suites exist.
+- Use case: Discover available test suites.
+
 ---
 
 ### Test Execution

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -14,9 +14,9 @@ The Swagger Functional Testing client provides tools for discovering and executi
 
 #### `list_suites`
 
-- Purpose: Lists all test suites available in your Swagger Functional Testing workspace. Use this tool when you need to discover available suites before running them or checking their execution history. Do not use this tool to retrieve individual tests or test suite execution results.
-- Returns: Complete list of test suites in the workspace. An empty list (`[]`) is returned when no suites exist.
-- Use case: Discover available test suites.
+- Purpose: Lists all test Suites available in your Swagger Functional Testing workspace. Use this tool when you need to discover available Suites before running them or checking their execution history. Do not use this tool to retrieve individual tests or test Suite execution results.
+- Returns: Complete list of test Suites in the workspace. An empty list (`[]`) is returned when no Suites exist.
+- Use case: Discover available test Suites.
 
 ---
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -386,6 +386,13 @@ export class SwaggerClient implements Client {
     return fn(this.ftApi);
   }
 
+  async listFunctionalTestingSuites(): Promise<unknown> {
+    if (!this.ftApi) {
+      throw new ToolError("Functional Testing API not configured");
+    }
+    return this.ftApi.listSuites();
+  }
+
   async registerTools(
     register: RegisterToolsFunction,
     _getInput: GetInputFunction,

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -387,10 +387,7 @@ export class SwaggerClient implements Client {
   }
 
   async listFunctionalTestingSuites(): Promise<unknown> {
-    if (!this.ftApi) {
-      throw new ToolError("Functional Testing API not configured");
-    }
-    return this.ftApi.listSuites();
+    return this.withFunctionalTesting((ftApi) => ftApi.listSuites());
   }
 
   async registerTools(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -92,11 +92,12 @@ export class FunctionalTestingAPI {
   }
 
   async listSuites(): Promise<ListSuitesResponse> {
+    const headers = this.getFtHeaders();
     let response: Response;
     try {
       response = await fetch(`${this.baseUrl}/suites`, {
         method: "GET",
-        headers: this.getFtHeaders(),
+        headers,
       });
     } catch {
       throw new ToolError(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -112,7 +112,7 @@ export class FunctionalTestingAPI {
 
     if (!response.ok) {
       throw new ToolError(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+        `Failed to list Functional Testing suites: ${response.status} ${response.statusText}`,
       );
     }
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,6 +1,7 @@
 import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  ListSuitesResponse,
   RunFunctionalTestingTestParams,
 } from "./functional-testing-types";
 
@@ -84,6 +85,34 @@ export class FunctionalTestingAPI {
     if (!response.ok) {
       throw new ToolError(
         `Failed to get test status: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async listSuites(): Promise<ListSuitesResponse> {
+    let response: Response;
+    try {
+      response = await fetch(`https://${API_HOSTNAME}/v1/suites`, {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      });
+    } catch {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ToolError(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    }
+
+    if (!response.ok) {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
       );
     }
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -10,7 +10,7 @@ const API_HOSTNAME = "api.reflect.run";
 export const FUNCTIONAL_TESTING_API_KEY_HEADER = "X-API-KEY";
 
 export class FunctionalTestingAPI {
-  private baseUrl: string;
+  private readonly baseUrl: string;
 
   constructor(
     private readonly getToken: () => string | null,
@@ -94,7 +94,7 @@ export class FunctionalTestingAPI {
   async listSuites(): Promise<ListSuitesResponse> {
     let response: Response;
     try {
-      response = await fetch(`https://${API_HOSTNAME}/v1/suites`, {
+      response = await fetch(`${this.baseUrl}/suites`, {
         method: "GET",
         headers: this.getFtHeaders(),
       });

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -37,4 +37,13 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     handler: "getFunctionalTestingExecution",
     idempotent: false,
   },
+  {
+    title: "List Suites",
+    toolset: "Functional Testing",
+    summary:
+      "Lists all test suites available in your Swagger Functional Testing workspace. " +
+      "Use this tool when you need to discover available suites before running them or checking their execution history. " +
+      "Do not use this tool to retrieve individual tests or test suite execution results.",
+    handler: "listFunctionalTestingSuites",
+  },
 ];

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -45,5 +45,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use this tool when you need to discover available suites before running them or checking their execution history. " +
       "Do not use this tool to retrieve individual tests or test suite execution results.",
     handler: "listFunctionalTestingSuites",
+    idempotent: true,
+    readOnly: true,
   },
 ];

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -22,3 +22,22 @@ export type RunFunctionalTestingTestParams = z.infer<
 export type GetFunctionalTestingExecutionTestParams = z.infer<
   typeof GetFunctionalTestingExecutionTestSchema
 >;
+
+export interface Suite {
+  id: number;
+  accountId: number;
+  name: string;
+  slug: string;
+  created: number;
+  numTestInstances: number;
+}
+
+export interface ListSuitesResponse {
+  suites: Suite[];
+  stats: {
+    executions: number;
+    passRate: number;
+    avgRuntimeSecs: number;
+    cumExecTimeSecs: number;
+  };
+}

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -24,7 +24,7 @@ export type GetFunctionalTestingExecutionTestParams = z.infer<
 >;
 
 export interface Suite {
-  id: number;
+  id: string;
   accountId: number;
   name: string;
   slug: string;
@@ -34,7 +34,7 @@ export interface Suite {
 
 export interface ListSuitesResponse {
   suites: Suite[];
-  stats: {
+  stats?: {
     executions: number;
     passRate: number;
     avgRuntimeSecs: number;

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -10,6 +10,11 @@ const testsMock = [
   { id: "test-2", name: "Checkout Test" },
 ];
 
+const suitesMock = [
+  { id: "suite-1", name: "Smoke Suite" },
+  { id: "suite-2", name: "Regression Suite" },
+];
+
 describe("FunctionalTestingAPI", () => {
   let api: FunctionalTestingAPI;
 
@@ -159,6 +164,70 @@ describe("FunctionalTestingAPI", () => {
 
       await expect(api.getTestExecution({ executionId: "42" })).rejects.toThrow(
         "Network error",
+      );
+    });
+  });
+
+  describe("listSuites", () => {
+    it("should call the correct endpoint with X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
+
+      await api.listSuites();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return parsed JSON response", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
+
+      const result = await api.listSuites();
+
+      expect(result).toEqual(suitesMock);
+    });
+
+    it("should return empty array when no suites exist", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([]));
+
+      const result = await api.listSuites();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should throw an authentication error on 401", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(api.listSuites()).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
+    it("should throw an authentication error on 403", async () => {
+      fetchMock.mockResponseOnce("Forbidden", { status: 403 });
+
+      await expect(api.listSuites()).rejects.toThrow(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    });
+
+    it("should throw a service-unavailable error on other HTTP errors", async () => {
+      fetchMock.mockResponseOnce("Server Error", { status: 503 });
+
+      await expect(api.listSuites()).rejects.toThrow(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    });
+
+    it("should throw a service-unavailable error on network failure", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.listSuites()).rejects.toThrow(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
       );
     });
   });

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -215,11 +215,11 @@ describe("FunctionalTestingAPI", () => {
       );
     });
 
-    it("should throw a service-unavailable error on other HTTP errors", async () => {
+    it("should throw an error with the response status on other HTTP errors", async () => {
       fetchMock.mockResponseOnce("Server Error", { status: 503 });
 
       await expect(api.listSuites()).rejects.toThrow(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+        "Failed to list Functional Testing suites",
       );
     });
 

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -10,10 +10,32 @@ const testsMock = [
   { id: "test-2", name: "Checkout Test" },
 ];
 
-const suitesMock = [
-  { id: "suite-1", name: "Smoke Suite" },
-  { id: "suite-2", name: "Regression Suite" },
-];
+const suitesResponseMock = {
+  suites: [
+    {
+      id: "suite-1",
+      accountId: 42,
+      name: "Smoke Suite",
+      slug: "smoke-suite",
+      created: 1719400000000,
+      numTestInstances: 3,
+    },
+    {
+      id: "suite-2",
+      accountId: 42,
+      name: "Regression Suite",
+      slug: "regression-suite",
+      created: 1719500000000,
+      numTestInstances: 12,
+    },
+  ],
+  stats: {
+    executions: 15,
+    passRate: 0.93,
+    avgRuntimeSecs: 42,
+    cumExecTimeSecs: 630,
+  },
+};
 
 describe("FunctionalTestingAPI", () => {
   let api: FunctionalTestingAPI;
@@ -170,7 +192,7 @@ describe("FunctionalTestingAPI", () => {
 
   describe("listSuites", () => {
     it("should call the correct endpoint with X-API-KEY header", async () => {
-      fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
+      fetchMock.mockResponseOnce(JSON.stringify(suitesResponseMock));
 
       await api.listSuites();
 
@@ -184,19 +206,19 @@ describe("FunctionalTestingAPI", () => {
     });
 
     it("should return parsed JSON response", async () => {
-      fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
+      fetchMock.mockResponseOnce(JSON.stringify(suitesResponseMock));
 
       const result = await api.listSuites();
 
-      expect(result).toEqual(suitesMock);
+      expect(result).toEqual(suitesResponseMock);
     });
 
-    it("should return empty array when no suites exist", async () => {
-      fetchMock.mockResponseOnce(JSON.stringify([]));
+    it("should return an empty suites list when no suites exist", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ suites: [] }));
 
       const result = await api.listSuites();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ suites: [] });
     });
 
     it("should throw an authentication error on 401", async () => {

--- a/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
@@ -122,6 +122,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
         (call) => call[0].title,
       );
       expect(registeredTitles).not.toContain("List Tests");
+      expect(registeredTitles).not.toContain("List Suites");
     });
 
     it("should register FT tools when FT token is configured", async () => {
@@ -137,6 +138,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
         (call) => call[0].title,
       );
       expect(registeredTitles).toContain("List Tests");
+      expect(registeredTitles).toContain("List Suites");
     });
 
     it("should not affect existing Swagger tools when FT token is absent", async () => {
@@ -164,6 +166,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
         (call) => call[0].title,
       );
       expect(registeredTitles).toContain("List Tests");
+      expect(registeredTitles).toContain("List Suites");
       expect(registeredTitles).not.toContain("List Portals");
       expect(registeredTitles).not.toContain("Search APIs and Domains");
     });
@@ -208,6 +211,39 @@ describe("SwaggerClient — Functional Testing integration", () => {
         }),
       );
       expect(result).toEqual(testsMock);
+    });
+  });
+
+  describe("listFunctionalTestingSuites", () => {
+    it("should call api.reflect.run and return results", async () => {
+      const suitesMock = [{ id: "suite-1", name: "Smoke Suite" }];
+      fetchMock.mockResponseOnce(JSON.stringify(suitesMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.listFunctionalTestingSuites(),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(suitesMock);
+    });
+
+    it("should throw when FT API is not configured", async () => {
+      await client.configure({} as any, { api_key: "swagger-key" });
+
+      await expect(client.listFunctionalTestingSuites()).rejects.toThrow(
+        "Functional Testing API not configured",
+      );
     });
   });
 });


### PR DESCRIPTION
## Goal

Implements [RF-4890](https://smartbear.atlassian.net/browse/RF-4890).  As a Developer or QA Engineer, I want to list all test suites in my Swagger Functional Testing workspace via MCP, so that I can discover available suites before running or managing them.

## Design

Followed the existing `list_tests` pattern in the Swagger Functional Testing client. Added a `listSuites()` method on `FunctionalTestingAPI` that calls `GET https://api.reflect.run/v1/suites` with the `X-API-KEY` header, a `listFunctionalTestingSuites()` delegate on `SwaggerClient`, and a new `List Suites` tool entry gated behind `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` (same conditional registration as `list_tests`).

Per the ticket's negative-path requirements, failures map to actionable messages instead of the generic error used by `list_tests`:
- `401`/`403` → "Authentication failed. Verify your API token is valid and has not expired."
- Other non-OK responses and network failures → "Swagger Functional Testing service is currently unreachable. Retry after a moment."

An empty workspace returns `[]` and is treated as a successful result, not an error.

## Changeset

- `src/swagger/client/functional-testing-api.ts` — added `listSuites()` with scoped error handling.
- `src/swagger/client.ts` — added `listFunctionalTestingSuites()` delegate.
- `src/swagger/client/functional-testing-tools.ts` — registered the `List Suites` tool.
- `docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md` — documented `list_suites`.
- `CHANGELOG.md` — added entry under `Unreleased`.
- `src/tests/unit/swagger/functional-testing/*` — added API- and client-level tests.

## Testing

- [X] Existing unit tests pass
- [X] Extended unit tests: `functional-testing-api.test.ts` and `swagger-client-ft.test.ts`


[RF-4890]: https://smartbear.atlassian.net/browse/RF-4890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ