### PR TITLE
fix: extract tool constants to resolve circular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
 
+### Fixed
+
+- [Swagger] Extracted `READ_ONLY`, `MUTATING`, and `DELETING` constants into `tool-constants.ts` to resolve a circular dependency between `tools.ts` and `functional-testing-tools.ts` that caused a `ReferenceError` at runtime.
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -397,10 +397,14 @@ export class SwaggerClient implements Client {
 
           const result = await handlerFn.call(this, args);
 
-          // Use custom formatter if available, otherwise return JSON
           const formattedResult = formatResponse
             ? formatResponse(result)
             : result;
+
+          if (toolParams.outputSchema) {
+            return { structuredContent: formattedResult, content: [] };
+          }
+
           const responseText =
             typeof formattedResult === "string"
               ? formattedResult
@@ -411,6 +415,7 @@ export class SwaggerClient implements Client {
           };
         } catch (error) {
           return {
+            isError: true,
             content: [
               {
                 type: "text",

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -4,7 +4,7 @@ import {
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";
 import type { SwaggerToolParams } from "./tools";
-import { READ_ONLY } from "./tools";
+import { READ_ONLY } from "./tool-constants";
 
 const ListTestsOutputSchema = z.array(
   z.looseObject({

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -3,8 +3,8 @@ import {
   GetFunctionalTestingExecutionTestSchema,
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";
-import type { SwaggerToolParams } from "./tools";
 import { READ_ONLY } from "./tool-constants";
+import type { SwaggerToolParams } from "./tools";
 
 const ListTestsOutputSchema = z.array(
   z.looseObject({

--- a/src/swagger/client/tool-constants.ts
+++ b/src/swagger/client/tool-constants.ts
@@ -1,0 +1,17 @@
+export const READ_ONLY = {
+  readOnly: true,
+  destructive: false,
+  openWorld: false,
+} as const;
+
+export const MUTATING = {
+  readOnly: false,
+  destructive: false,
+  openWorld: true,
+} as const;
+
+export const DELETING = {
+  readOnly: false,
+  destructive: true,
+  openWorld: true,
+} as const;

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -8,7 +8,6 @@
 
 import type { ToolParams } from "../../common/types";
 import { FUNCTIONAL_TESTING_TOOLS } from "./functional-testing-tools";
-import { DELETING, MUTATING, READ_ONLY } from "./tool-constants";
 import {
   CreatePortalArgsSchema,
   CreateProductArgsSchema,
@@ -47,6 +46,7 @@ import {
   StandardizeApiOutputSchema,
   StandardizeApiParamsSchema,
 } from "./registry-types";
+import { DELETING, MUTATING, READ_ONLY } from "./tool-constants";
 import {
   OrganizationsListOutputSchema,
   OrganizationsQuerySchema,

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -8,6 +8,7 @@
 
 import type { ToolParams } from "../../common/types";
 import { FUNCTIONAL_TESTING_TOOLS } from "./functional-testing-tools";
+import { DELETING, MUTATING, READ_ONLY } from "./tool-constants";
 import {
   CreatePortalArgsSchema,
   CreateProductArgsSchema,
@@ -55,25 +56,6 @@ export interface SwaggerToolParams extends ToolParams {
   handler: string;
   formatResponse?: (result: any) => any;
 }
-
-export const READ_ONLY = {
-  readOnly: true,
-  destructive: false,
-  openWorld: false,
-} as const;
-
-const MUTATING = {
-  readOnly: false,
-  destructive: false,
-  openWorld: true,
-} as const;
-
-const DELETING = {
-  readOnly: false,
-  destructive: true,
-  openWorld: true,
-} as const;
-
 export const TOOLS: SwaggerToolParams[] = [
   {
     title: "List Portals",

--- a/src/tests/unit/swagger/client.test.ts
+++ b/src/tests/unit/swagger/client.test.ts
@@ -239,7 +239,8 @@ describe("SwaggerClient", () => {
       const result = await handler({}, {});
 
       expect(result).toEqual({
-        content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+        structuredContent: mockResponse,
+        content: [],
       });
     });
 
@@ -263,7 +264,8 @@ describe("SwaggerClient", () => {
       const result = await handler(args, {});
 
       expect(result).toEqual({
-        content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+        structuredContent: mockResponse,
+        content: [],
       });
     });
 
@@ -293,6 +295,7 @@ describe("SwaggerClient", () => {
       const result = await handler({}, {});
 
       expect(result).toEqual({
+        isError: true,
         content: [{ type: "text", text: "Error: Network error" }],
       });
     });
@@ -331,7 +334,8 @@ describe("SwaggerClient", () => {
       );
 
       expect(result).toEqual({
-        content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+        structuredContent: mockResponse,
+        content: [],
       });
     });
 
@@ -359,6 +363,7 @@ describe("SwaggerClient", () => {
       const result = await handler({}, {});
 
       expect(result).toEqual({
+        isError: true,
         content: [
           {
             type: "text",


### PR DESCRIPTION
## Goal

`functional-testing-tools.ts` imported `READ_ONLY` from `tools.ts`, which in turn imports from `functional-testing-tools.ts `creating a circular dependency that caused a ReferenceError at runtime.

## Design

Extracted `READ_ONLY, MUTATING, and DELETING `into a new `tool-constants.ts` file with no dependencies on other tool files. Both` tools.ts and functional-testing-tools.ts` now import from this shared file, breaking the cycle.

## Changeset

Added `src/swagger/client/tool-constants.ts` with `READ_ONLY, MUTATING, DELETING` constants
Updated `tools.ts` to import constants from `tool-constants.ts` (removed inline definitions)
Updated `functional-testing-tools.ts` to import `READ_ONLY` from `tool-constants.ts`
Updated `client.ts`: tools with `outputSchema` now return `structuredContent`, errors include `isError: true`
Updated unit tests to reflect new response shapes

## Testing

Existing unit tests in src/tests/unit/swagger/client.test.ts updated and passing (21/21). Verified build completes without the ReferenceError.
