### PR TITLE
fix: make swagger_search_apis_and_domains work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extracted `READ_ONLY`, `MUTATING`, and `DELETING` constants into `tool-constants.ts` to resolve a circular dependency between `tools.ts` and `functional-testing-tools.ts` that caused a `ReferenceError` at runtime.
 
-- [Swagger] Fix `swagger_search_apis_and_domains` tool returning MCP error `-32602` by wrapping the result array in an object `{ apis: [...] }` to satisfy the MCP protocol requirement that `structuredContent` be a record, not an array.
+- [Swagger] Fixed `swagger_search_apis_and_domains` tool returning MCP error by wrapping the result array in an object `{ apis: [...] }` to satisfy the MCP protocol requirement that `structuredContent` needs to be a record, not an array.
 
 ## [0.26.1] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extracted `READ_ONLY`, `MUTATING`, and `DELETING` constants into `tool-constants.ts` to resolve a circular dependency between `tools.ts` and `functional-testing-tools.ts` that caused a `ReferenceError` at runtime.
 
+- [Swagger] Fix `swagger_search_apis_and_domains` tool returning MCP error `-32602` by wrapping the result array in an object `{ apis: [...] }` to satisfy the MCP protocol requirement that `structuredContent` be a record, not an array.
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -38,6 +38,7 @@ import {
 } from "./portal-utils";
 import type {
   ApiDefinitionParams,
+  ApiMetadata,
   ApiProperty,
   ApiSearchParams,
   ApiSearchResponse,
@@ -1127,7 +1128,7 @@ export class SwaggerAPI {
     const apisJsonResponse = (await response.json()) as ApisJsonResponse;
 
     // Transform APIs.json response to our ApiMetadata format
-    return this.transformApisJsonToMetadata(apisJsonResponse.apis);
+    return { apis: this.transformApisJsonToMetadata(apisJsonResponse.apis) };
   }
 
   /**
@@ -1137,7 +1138,7 @@ export class SwaggerAPI {
    */
   private transformApisJsonToMetadata(
     specs: ApiSpecification[],
-  ): ApiSearchResponse {
+  ): ApiMetadata[] {
     return specs.map((spec) => {
       // Extract useful properties from the properties array
       const properties = spec.properties || [];

--- a/src/swagger/client/registry-types.ts
+++ b/src/swagger/client/registry-types.ts
@@ -189,7 +189,7 @@ export interface ApiMetadata {
   url?: string;
 }
 
-export type ApiSearchResponse = ApiMetadata[];
+export type ApiSearchResponse = { apis: ApiMetadata[] };
 
 // Response type for created or updated API
 export interface CreateApiResponse {
@@ -268,7 +268,9 @@ export const ApiMetadataOutputSchema = z.object({
   url: z.string().optional(),
 });
 
-export const ApiSearchOutputSchema = z.array(ApiMetadataOutputSchema);
+export const ApiSearchOutputSchema = z.object({
+  apis: z.array(ApiMetadataOutputSchema),
+});
 
 export const CreateApiOutputSchema = z.object({
   owner: z.string(),

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -11396,7 +11396,9 @@ None",
       "state",
       "tag",
     ],
-    "outputSchema": undefined,
+    "outputSchema": [
+      "apis",
+    ],
     "title": "Swagger: Search APIs and Domains",
   },
   "swagger_standardize_api": {

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -1404,4 +1404,89 @@ describe("SwaggerAPI", () => {
       expect(createCalls).toHaveLength(1);
     });
   });
+
+  describe("searchApis", () => {
+    const mockApisJsonResponse = {
+      name: "SmartBear APIs",
+      description: "",
+      url: "https://api.swaggerhub.com/specs",
+      offset: 0,
+      totalCount: 1,
+      blocked: false,
+      apis: [
+        {
+          name: "petstore",
+          description: "Sample pet store API",
+          summary: "Pet Store",
+          tags: [],
+          properties: [
+            {
+              type: "Swagger",
+              url: "https://app.swaggerhub.com/apis/smartbear/petstore/1.0.0",
+            },
+            { type: "X-Version", value: "1.0.0" },
+            { type: "X-Specification", value: "OpenAPI 3.0" },
+          ],
+        },
+      ],
+    };
+
+    it("should return apis wrapped in object", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockApisJsonResponse));
+
+      const result = await api.searchApis({});
+
+      expect(result).toHaveProperty("apis");
+      expect(Array.isArray(result.apis)).toBe(true);
+    });
+
+    it("should transform ApisJson response to ApiMetadata format", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockApisJsonResponse));
+
+      const result = await api.searchApis({});
+
+      expect(result.apis[0]).toMatchObject({
+        owner: "smartbear",
+        name: "petstore",
+        description: "Sample pet store API",
+        summary: "Pet Store",
+        version: "1.0.0",
+        specification: "OpenAPI 3.0",
+        url: "https://app.swaggerhub.com/apis/smartbear/petstore/1.0.0",
+      });
+    });
+
+    it("should pass query params to fetch URL", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockApisJsonResponse));
+
+      await api.searchApis({ owner: "smartbear", limit: 10 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("owner=smartbear"),
+        expect.any(Object),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("limit=10"),
+        expect.any(Object),
+      );
+    });
+
+    it("should throw on non-ok response", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(api.searchApis({})).rejects.toThrow(
+        "SwaggerHub Registry API searchApis failed",
+      );
+    });
+
+    it("should return empty apis array when no results", async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ ...mockApisJsonResponse, apis: [] }),
+      );
+
+      const result = await api.searchApis({});
+
+      expect(result).toEqual({ apis: [] });
+    });
+  });
 });


### PR DESCRIPTION
## Goal

Fixes https://smartbear.atlassian.net/browse/SWG-20871

`swagger_search_apis_and_domains` MCP tool was broken, it returned error because `structuredContent` received a top-level array, but the MCP protocol requires a record (object) at that level.

## Design

Wrapped the search result array in an object { apis: [...] } rather than returning a bare array. This is the minimal change that satisfies the MCP protocol constraint while keeping all existing data intact. Updated the response type, output schema, and the call site accordingly.

## Changeset

- registry-types.ts: Changed ApiSearchResponse from ApiMetadata[] to { apis: ApiMetadata[] }. Changed ApiSearchOutputSchema from z.array(...) to z.object({ apis: z.array(...) }).
- api.ts: Updated searchApis to return { apis: this.transformApisJsonToMetadata(...) }. Changed transformApisJsonToMetadata return type from ApiSearchResponse to ApiMetadata[] to keep it accurate. Added ApiMetadata to imports.

## Testing

- [x] Added Unit Test
- [x] Tested the tool locally
- [x] Tested other tools locally for any regression
