### PR TITLE
remove swagger-mcp from remotes in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -127,10 +127,6 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://swagger.mcp.smartbear.com/mcp"
-    },
-    {
-      "type": "streamable-http",
       "url": "https://bugsnag.mcp.smartbear.com/mcp"
     },
     {


### PR DESCRIPTION
  ## Goal                                                                                                                                                                                  
                                                                                                                                                                                           
  Publishing the new `com.smartbear/swagger-mcp` registry entry fails with:                                                                                                                
                                                                                                                                                                                           
  > 400 Bad Request — remote URL https://swagger.mcp.smartbear.com/mcp is already                                                                                                          
  > used by server com.smartbear/smartbear-mcp                                                                                                                                             
                                                                                                                                                                                           
  The MCP registry enforces that each remote URL is owned by exactly one server                                                                                                            
  entry. The Swagger remote is currently claimed by the umbrella                                                                                                                           
  `com.smartbear/smartbear-mcp` server, which blocks the dedicated Swagger entry                                                                                                           
  from publishing.                                                                                                                                                                         
                                                                                                                                                                                           
  ## Design                                                                                                                                                                                
                                                                                                                                                                                           
  Rather than keep the Swagger remote on the combined entry, it should live on the                                                                                                         
  new dedicated `com.smartbear/swagger-mcp` server (added in the                                                                                                                           
  SWG-20002 change). Removing it from `server.json` clears the ownership conflict                                                                                                          
  so the standalone entry can claim the URL. The BugSnag and Zephyr remotes stay                                                                                                           
  on the umbrella entry, as they have no dedicated server of their own.                                                                                                                    
                                                                                                                                                                                           
  ## Changeset                                                                                                                                                                             
                                                                                                                                                                                           
  - Removed the `https://swagger.mcp.smartbear.com/mcp` streamable-http remote                                                                                                             
    from the `remotes` array in `server.json`.                                                                                                                                             
                                                                                                                                                                                           
  ## Testing                                                                                                                                                                               
                                                                                                                                                                                           
  - `jq empty server.json` — valid JSON.                                                                                                                                                   
  - The `Validate server.json Schema` workflow runs on the PR and passes.                                                                                                                  
  - Verified the remote is no longer present so the follow-up                                                                                                                              
    `com.smartbear/swagger-mcp` publish no longer hits the 400 conflict.