### PR TITLE
feat(functional-testing): list suite executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_suite`, and `get_suite_status` tools for executing available suites and querying their execution.
 
+- [Swagger] Added `list_suite_executions` tool for reviewing the execution history and timings of a test suite in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+
 ## [0.28.0] - 2026-07-07
 
 ### Changed
@@ -42,8 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] Add `create_documentation_page` tool to create a documentation page in a portal product in a single call. Supports `markdown` and `html` content types with `internal` or `external` source. Returns page details and a `draftUrl` to edit the page in the portal admin.
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
-
-- [Swagger] Added `list_suite_executions` tool for reviewing the execution history and timings of a test suite in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
 ## [0.26.1] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Extended Swagger Functional Testing integration with `run_test`, and `get_test_status` tools for executing available API tests and querying their execution.
 
+- [Swagger] Added `list_suite_executions` tool for reviewing the execution history and timings of a test suite in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
+
 ## [0.26.1] - 2026-06-24
 
 ### Fixed

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -31,7 +31,7 @@ The Swagger Functional Testing client provides tools for discovering and executi
 #### `list_suite_executions`
 
 - Purpose: Lists all executions for a given test suite in your Swagger Functional Testing workspace. Use this tool when you need to review execution history and timings for a specific suite. Do not use this tool to retrieve the status of a single execution or individual test results. Requires a `suiteId`.
-- Returns: Complete list of executions for the given suite, in the order returned by the API. An empty list is returned when no executions exist.
+- Returns: Complete list of executions for the given suite. An empty list is returned when no executions exist.
 - Use case: Review the execution history and timings of a test suite.
 
 ---

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -28,6 +28,12 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Returns: Execution status and result details for the given execution.
 - Use case: Poll for the outcome of a test run after calling `run_test`.
 
+#### `list_suite_executions`
+
+- Purpose: Lists all executions for a given test suite in your Swagger Functional Testing workspace. Use this tool when you need to review execution history and timings for a specific suite. Do not use this tool to retrieve the status of a single execution or individual test results. Requires a `suiteId`.
+- Returns: Complete list of executions for the given suite, in the order returned by the API. An empty list is returned when no executions exist.
+- Use case: Review the execution history and timings of a test suite.
+
 ---
 
 ## Additional Notes

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,6 +16,7 @@ import {
 } from "./client/functional-testing-api";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  ListFunctionalTestingSuiteExecutionsParams,
   RunFunctionalTestingTestParams,
 } from "./client/functional-testing-types";
 import {
@@ -370,6 +371,14 @@ export class SwaggerClient implements Client {
     args: GetFunctionalTestingExecutionTestParams,
   ): Promise<unknown> {
     return this.withFunctionalTesting((ftApi) => ftApi.getTestExecution(args));
+  }
+
+  async listFunctionalTestingSuiteExecutions(
+    args: ListFunctionalTestingSuiteExecutionsParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) =>
+      ftApi.listSuiteExecutions(args),
+    );
   }
 
   /**

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,8 +16,8 @@ import {
 } from "./client/functional-testing-api";
 import type {
   GetFunctionalTestingExecutionTestParams,
-  ListFunctionalTestingSuiteExecutionsParams,
   GetFunctionalTestingSuiteExecutionParams,
+  ListFunctionalTestingSuiteExecutionsParams,
   RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
 } from "./client/functional-testing-types";

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -382,7 +382,7 @@ export class SwaggerClient implements Client {
       ftApi.listSuiteExecutions(args),
     );
   }
-  
+
   async runFunctionalTestingSuite(
     args: RunFunctionalTestingSuiteParams,
   ): Promise<unknown> {

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -143,24 +143,10 @@ export class FunctionalTestingAPI {
     };
   }
   async listSuites(): Promise<ListSuitesResponse> {
-    const headers = this.getFtHeaders();
-    let response: Response;
-    try {
-      response = await fetch(`${this.baseUrl}/suites`, {
-        method: "GET",
-        headers,
-      });
-    } catch {
-      throw new ToolError(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
-      );
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      throw new ToolError(
-        "Authentication failed. Verify your API token is valid and has not expired.",
-      );
-    }
+    const response = await this.ftFetch(`${this.baseUrl}/suites`, {
+      method: "GET",
+      headers: this.getFtHeaders(),
+    });
 
     if (!response.ok) {
       throw new ToolError(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -134,11 +134,13 @@ export class FunctionalTestingAPI {
     return {
       ...data,
       executions: {
-        data: data.executions.data.map(({ executionId, status, isFinished }) => ({
-          executionId,
-          status,
-          isFinished,
-        })),
+        data: data.executions.data.map(
+          ({ executionId, status, isFinished }) => ({
+            executionId,
+            status,
+            isFinished,
+          }),
+        ),
       },
     };
   }
@@ -170,4 +172,3 @@ function suiteExecutionsErrorMessage(response: Response): string {
       return `Failed to list suite executions: ${response.status} ${response.statusText}`;
   }
 }
-

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -71,7 +71,7 @@ export class FunctionalTestingAPI {
     if (!args.testId) throw new ToolError("testId argument is required");
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/tests/${args.testId}/executions`,
+      `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/executions`,
       {
         method: "POST",
         headers: this.getFtHeaders(),
@@ -95,7 +95,7 @@ export class FunctionalTestingAPI {
     }
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/executions/${args.executionId}`,
+      `${this.baseUrl}/executions/${encodeURIComponent(args.executionId)}`,
       {
         method: "GET",
         headers: this.getFtHeaders(),
@@ -117,7 +117,7 @@ export class FunctionalTestingAPI {
     if (!args.suiteId) throw new ToolError("suiteId argument is required");
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/suites/${args.suiteId}/executions`,
+      `${this.baseUrl}/suites/${encodeURIComponent(args.suiteId)}/executions`,
       {
         method: "GET",
         headers: this.getFtHeaders(),

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -33,8 +33,30 @@ export class FunctionalTestingAPI {
     };
   }
 
+  private async ftFetch(
+    input: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    let response: Response;
+    try {
+      response = await fetch(input, init);
+    } catch {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ToolError(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    }
+
+    return response;
+  }
+
   async listTests(): Promise<unknown> {
-    const response = await fetch(`${this.baseUrl}/tests`, {
+    const response = await this.ftFetch(`${this.baseUrl}/tests`, {
       method: "GET",
       headers: this.getFtHeaders(),
     });
@@ -51,7 +73,7 @@ export class FunctionalTestingAPI {
   async runTest(args: RunFunctionalTestingTestParams): Promise<unknown> {
     if (!args.testId) throw new ToolError("testId argument is required");
 
-    const response = await fetch(
+    const response = await this.ftFetch(
       `${this.baseUrl}/tests/${args.testId}/executions`,
       {
         method: "POST",
@@ -75,7 +97,7 @@ export class FunctionalTestingAPI {
       throw new ToolError("executionId argument is required");
     }
 
-    const response = await fetch(
+    const response = await this.ftFetch(
       `${this.baseUrl}/executions/${args.executionId}`,
       {
         method: "GET",
@@ -97,7 +119,7 @@ export class FunctionalTestingAPI {
   ): Promise<ListSuiteExecutionsResponse> {
     if (!args.suiteId) throw new ToolError("suiteId argument is required");
 
-    const response = await fetch(
+    const response = await this.ftFetch(
       `${this.baseUrl}/suites/${args.suiteId}/executions`,
       {
         method: "GET",

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -2,6 +2,7 @@ import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
   ListFunctionalTestingSuiteExecutionsParams,
+  ListSuiteExecutionsResponse,
   RunFunctionalTestingTestParams,
 } from "./functional-testing-types";
 
@@ -93,7 +94,7 @@ export class FunctionalTestingAPI {
 
   async listSuiteExecutions(
     args: ListFunctionalTestingSuiteExecutionsParams,
-  ): Promise<unknown> {
+  ): Promise<ListSuiteExecutionsResponse> {
     if (!args.suiteId) throw new ToolError("suiteId argument is required");
 
     const response = await fetch(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,6 +1,7 @@
 import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  ListFunctionalTestingSuiteExecutionsParams,
   RunFunctionalTestingTestParams,
 } from "./functional-testing-types";
 
@@ -88,5 +89,38 @@ export class FunctionalTestingAPI {
     }
 
     return response.json();
+  }
+
+  async listSuiteExecutions(
+    args: ListFunctionalTestingSuiteExecutionsParams,
+  ): Promise<unknown> {
+    if (!args.suiteId) throw new ToolError("suiteId argument is required");
+
+    const response = await fetch(
+      `${this.baseUrl}/suites/${args.suiteId}/executions`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      throw new ToolError(suiteExecutionsErrorMessage(response));
+    }
+
+    return response.json();
+  }
+}
+
+function suiteExecutionsErrorMessage(response: Response): string {
+  switch (response.status) {
+    // Defensive: the Reflect API currently returns 200 with an empty
+    // `executions.data` list for an unknown suiteId rather than a 404, so this
+    // branch is not expected to fire today. Kept in case the API starts
+    // returning 404 for missing suites.
+    case 404:
+      return "Test suite not found. Verify the suiteId is correct and belongs to your workspace.";
+    default:
+      return `Failed to list suite executions: ${response.status} ${response.statusText}`;
   }
 }

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -33,10 +33,7 @@ export class FunctionalTestingAPI {
     };
   }
 
-  private async ftFetch(
-    input: string,
-    init: RequestInit,
-  ): Promise<Response> {
+  private async ftFetch(input: string, init: RequestInit): Promise<Response> {
     let response: Response;
     try {
       response = await fetch(input, init);

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -1,9 +1,9 @@
 import { ToolError } from "../../common/tools";
 import type {
   GetFunctionalTestingExecutionTestParams,
+  GetFunctionalTestingSuiteExecutionParams,
   ListFunctionalTestingSuiteExecutionsParams,
   ListSuiteExecutionsResponse,
-  GetFunctionalTestingSuiteExecutionParams,
   ListSuitesResponse,
   RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -128,7 +128,18 @@ export class FunctionalTestingAPI {
       throw new ToolError(suiteExecutionsErrorMessage(response));
     }
 
-    return response.json();
+    const data: ListSuiteExecutionsResponse = await response.json();
+    // Will be adjusted after https://smartbear.atlassian.net/browse/RF-5271 is done
+    return {
+      ...data,
+      executions: {
+        data: data.executions.data.map(({ executionId, status, isFinished }) => ({
+          executionId,
+          status,
+          isFinished,
+        })),
+      },
+    };
   }
 }
 

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,5 +1,6 @@
 import {
   GetFunctionalTestingExecutionTestSchema,
+  ListFunctionalTestingSuiteExecutionsSchema,
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";
 import type { SwaggerToolParams } from "./tools";
@@ -36,5 +37,16 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: GetFunctionalTestingExecutionTestSchema,
     handler: "getFunctionalTestingExecution",
     idempotent: false,
+  },
+  {
+    title: "List Suite Executions",
+    toolset: "Functional Testing",
+    summary:
+      "Lists all executions for a given test suite in your Swagger Functional Testing workspace. " +
+      "Use this tool when you need to review execution history and timings for a specific suite. " +
+      "Do not use this tool to retrieve the status of a single execution or individual test results.",
+    inputSchema: ListFunctionalTestingSuiteExecutionsSchema,
+    handler: "listFunctionalTestingSuiteExecutions",
+    readOnly: true,
   },
 ];

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,7 +1,7 @@
 import {
   GetFunctionalTestingExecutionTestSchema,
-  ListFunctionalTestingSuiteExecutionsSchema,
   GetFunctionalTestingSuiteExecutionSchema,
+  ListFunctionalTestingSuiteExecutionsSchema,
   RunFunctionalTestingSuiteParamsSchema,
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -48,5 +48,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: ListFunctionalTestingSuiteExecutionsSchema,
     handler: "listFunctionalTestingSuiteExecutions",
     readOnly: true,
+    idempotent: true,
   },
 ];

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -33,3 +33,17 @@ export type GetFunctionalTestingExecutionTestParams = z.infer<
 export type ListFunctionalTestingSuiteExecutionsParams = z.infer<
   typeof ListFunctionalTestingSuiteExecutionsSchema
 >;
+
+export interface SuiteExecution {
+  executionId: number;
+  url: string;
+  status: string;
+  isFinished: boolean;
+}
+
+export interface ListSuiteExecutionsResponse {
+  suiteId: string;
+  executions: {
+    data: SuiteExecution[];
+  };
+}

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -36,7 +36,8 @@ export type ListFunctionalTestingSuiteExecutionsParams = z.infer<
 
 export interface SuiteExecution {
   executionId: number;
-  url: string;
+  // Will be brought back after https://smartbear.atlassian.net/browse/RF-5271 is done
+  // url: string;
   status: string;
   isFinished: boolean;
 }

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -16,9 +16,20 @@ export const GetFunctionalTestingExecutionTestSchema = z.object({
     .min(1),
 });
 
+export const ListFunctionalTestingSuiteExecutionsSchema = z.object({
+  suiteId: z
+    .string()
+    .describe("ID of the Functional Testing suite to list executions for")
+    .trim()
+    .min(1),
+});
+
 export type RunFunctionalTestingTestParams = z.infer<
   typeof RunFunctionalTestingTestParamsSchema
 >;
 export type GetFunctionalTestingExecutionTestParams = z.infer<
   typeof GetFunctionalTestingExecutionTestSchema
+>;
+export type ListFunctionalTestingSuiteExecutionsParams = z.infer<
+  typeof ListFunctionalTestingSuiteExecutionsSchema
 >;

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -163,6 +163,88 @@ describe("FunctionalTestingAPI", () => {
     });
   });
 
+  describe("listSuiteExecutions", () => {
+    const suiteExecutionsMock = {
+      suiteId: "regression-tests",
+      executions: {
+        data: [
+          { executionId: 12, status: "pending", isFinished: false },
+          { executionId: 47, status: "passed", isFinished: true },
+          { executionId: 30, status: "failed", isFinished: true },
+        ],
+      },
+    };
+
+    it("should call the correct endpoint with GET method and X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionsMock));
+
+      await api.listSuiteExecutions({ suiteId: "regression-tests" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/regression-tests/executions",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should return executions in the order the API returns them", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionsMock));
+
+      const result = (await api.listSuiteExecutions({
+        suiteId: "regression-tests",
+      })) as typeof suiteExecutionsMock;
+
+      expect(result.executions.data.map((e) => e.executionId)).toEqual([
+        12, 47, 30,
+      ]);
+    });
+
+    it("should return empty list as-is when no executions exist", async () => {
+      const empty = { suiteId: "regression-tests", executions: { data: [] } };
+      fetchMock.mockResponseOnce(JSON.stringify(empty));
+
+      const result = await api.listSuiteExecutions({
+        suiteId: "regression-tests",
+      });
+
+      expect(result).toEqual(empty);
+    });
+
+    it("should throw ToolError when suiteId is missing", async () => {
+      await expect(
+        api.listSuiteExecutions({ suiteId: "" }),
+      ).rejects.toThrow("suiteId argument is required");
+    });
+
+    it("should map 404 to a suite-not-found message", async () => {
+      fetchMock.mockResponseOnce("Not Found", { status: 404 });
+
+      await expect(
+        api.listSuiteExecutions({ suiteId: "missing" }),
+      ).rejects.toThrow(
+        "Test suite not found. Verify the suiteId is correct and belongs to your workspace.",
+      );
+    });
+
+    it("should fall back to a generic message for other HTTP errors", async () => {
+      fetchMock.mockResponseOnce("Boom", { status: 500 });
+
+      await expect(
+        api.listSuiteExecutions({ suiteId: "regression-tests" }),
+      ).rejects.toThrow("Failed to list suite executions: 500");
+    });
+
+    it("should propagate network errors", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(
+        api.listSuiteExecutions({ suiteId: "regression-tests" }),
+      ).rejects.toThrow("Network error");
+    });
+  });
+
   describe("getFtHeaders", () => {
     it("should return headers with X-API-KEY and Content-Type", () => {
       const headers = api.getFtHeaders();

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -213,9 +213,9 @@ describe("FunctionalTestingAPI", () => {
     });
 
     it("should throw ToolError when suiteId is missing", async () => {
-      await expect(
-        api.listSuiteExecutions({ suiteId: "" }),
-      ).rejects.toThrow("suiteId argument is required");
+      await expect(api.listSuiteExecutions({ suiteId: "" })).rejects.toThrow(
+        "suiteId argument is required",
+      );
     });
 
     it("should map 404 to a suite-not-found message", async () => {

--- a/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/tests/unit/swagger/functional-testing/functional-testing-api.test.ts
@@ -10,6 +10,12 @@ const testsMock = [
   { id: "test-2", name: "Checkout Test" },
 ];
 
+const UNREACHABLE_MESSAGE =
+  "Swagger Functional Testing service is currently unreachable. Retry after a moment.";
+
+const AUTH_FAILED_MESSAGE =
+  "Authentication failed. Verify your API token is valid and has not expired.";
+
 describe("FunctionalTestingAPI", () => {
   let api: FunctionalTestingAPI;
 
@@ -53,17 +59,17 @@ describe("FunctionalTestingAPI", () => {
     });
 
     it("should throw ToolError on HTTP error", async () => {
-      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
 
       await expect(api.listTests()).rejects.toThrow(
         "Failed to list Functional Testing tests",
       );
     });
 
-    it("should propagate network errors", async () => {
+    it("should map network errors to an unreachable message", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
-      await expect(api.listTests()).rejects.toThrow("Network error");
+      await expect(api.listTests()).rejects.toThrow(UNREACHABLE_MESSAGE);
     });
   });
 
@@ -106,11 +112,11 @@ describe("FunctionalTestingAPI", () => {
       );
     });
 
-    it("should propagate network errors", async () => {
+    it("should map network errors to an unreachable message", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(api.runTest({ testId: "94" })).rejects.toThrow(
-        "Network error",
+        UNREACHABLE_MESSAGE,
       );
     });
   });
@@ -154,11 +160,11 @@ describe("FunctionalTestingAPI", () => {
       );
     });
 
-    it("should propagate network errors", async () => {
+    it("should map network errors to an unreachable message", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(api.getTestExecution({ executionId: "42" })).rejects.toThrow(
-        "Network error",
+        UNREACHABLE_MESSAGE,
       );
     });
   });
@@ -236,12 +242,26 @@ describe("FunctionalTestingAPI", () => {
       ).rejects.toThrow("Failed to list suite executions: 500");
     });
 
-    it("should propagate network errors", async () => {
+    it("should map network errors to an unreachable message", async () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(
         api.listSuiteExecutions({ suiteId: "regression-tests" }),
-      ).rejects.toThrow("Network error");
+      ).rejects.toThrow(UNREACHABLE_MESSAGE);
+    });
+  });
+
+  describe("ftFetch authentication errors", () => {
+    it("should map 401 responses to an auth-failed message", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(api.listTests()).rejects.toThrow(AUTH_FAILED_MESSAGE);
+    });
+
+    it("should map 403 responses to an auth-failed message", async () => {
+      fetchMock.mockResponseOnce("Forbidden", { status: 403 });
+
+      await expect(api.listTests()).rejects.toThrow(AUTH_FAILED_MESSAGE);
     });
   });
 

--- a/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/tests/unit/swagger/functional-testing/swagger-client-ft.test.ts
@@ -210,4 +210,55 @@ describe("SwaggerClient — Functional Testing integration", () => {
       expect(result).toEqual(testsMock);
     });
   });
+
+  describe("listFunctionalTestingSuiteExecutions", () => {
+    it("should register the List Suite Executions tool when FT token is configured", async () => {
+      await client.configure({} as any, {
+        functional_testing_api_token: "ft-token",
+      });
+
+      const mockRegister = vi.fn();
+      await client.registerTools(mockRegister, vi.fn());
+
+      const registeredTitles = mockRegister.mock.calls.map(
+        (call) => call[0].title,
+      );
+      expect(registeredTitles).toContain("List Suite Executions");
+    });
+
+    it("should call the suite executions endpoint and return results", async () => {
+      const suiteExecutionsMock = {
+        suiteId: "regression-tests",
+        executions: {
+          data: [
+            { executionId: 12, status: "pending" },
+            { executionId: 47, status: "passed" },
+          ],
+        },
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(suiteExecutionsMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = (await requestContextStorage.run({ headers: {} }, () =>
+        client.listFunctionalTestingSuiteExecutions({
+          suiteId: "regression-tests",
+        }),
+      )) as typeof suiteExecutionsMock;
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites/regression-tests/executions",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result.executions.data.map((e) => e.executionId)).toEqual([
+        12, 47,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Goal
Implements RF-4891 (https://smartbear.atlassian.net/browse/RF-4891)

Extends the SFT toolset with `list_suite_executions`.
- `list_suite_executions` lists all executions for a given test suite by `suiteId`, for reviewing execution history and timings. Returns each execution's `executionId`, `status`, and `isFinished`.

## Design
New tool delegates through a `SwaggerClient` method, the API call lives in `FunctionalTestingAPI`, and the input schema is defined with Zod in the dedicated types file. Return shape is typed via dedicated `SuiteExecution` / `ListSuiteExecutionsResponse` interfaces. Tool is marked `readOnly`.

Maps Reflect API `404` to a clear suite-not-found message; falls back to a generic message for other HTTP errors. Empty execution lists are returned as-is.

## Changeset
- Added `list_suite_executions` tool to `FunctionalTestingAPI` and wired it through `SwaggerClient`
- Added `ListFunctionalTestingSuiteExecutionsSchema` Zod input schema (`suiteId`, trimmed, min 1)
- Added `SuiteExecution` and `ListSuiteExecutionsResponse` return-type interfaces; typed `listSuiteExecutions` return
- Added suite-not-found (404) handling with generic error fallback
- Updated docs (swagger-functional-testing-integration.md)
- Updated CHANGELOG.md
- Added `ftFetch` wrapper for all the function in `functional-testing-api.ts`

## Testing
- [x] Unit tests added
- [x] Manual local testing of new SFT tool performed
- [x] Manual local regression testing of other SFT tools performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
