### PR TITLE
extract swagger-mcp publish

### DIFF
--- a/.github/workflows/publish-swagger-mcp.yaml
+++ b/.github/workflows/publish-swagger-mcp.yaml
@@ -1,0 +1,50 @@
+name: Publish Swagger MCP
+
+# Publishes the standalone com.smartbear/swagger-mcp registry entry(server.swagger.json).
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish from (e.g. v1.0.0). Defaults to the current ref."
+        required: false
+        type: string
+
+jobs:
+  publish-swagger-mcp:
+    name: Publish swagger-mcp to MCP Registry
+    runs-on: ubuntu-24.04
+    environment: Production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Extract version from package.json
+        id: extract_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update server.swagger.json version
+        run: |
+          jq --arg v "${{ steps.extract_version.outputs.VERSION }}" \
+            '.version = $v' \
+            server.swagger.json > server.swagger.json.tmp && mv server.swagger.json.tmp server.swagger.json
+
+      - name: prepare mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Login
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher login dns --domain smartbear.com --private-key "${{ secrets.GH_MCP_REGISTRY_KEY }}"
+
+      - name: Publish swagger-mcp to MCP Registry
+        run: ./mcp-publisher publish server.swagger.json

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -251,9 +251,6 @@ jobs:
           jq --arg v "${{ steps.extract_version.outputs.VERSION }}" \
             '.version = $v | .packages[0].version = $v' \
             server.json > server.json.tmp && mv server.json.tmp server.json
-          jq --arg v "${{ steps.extract_version.outputs.VERSION }}" \
-            '.version = $v' \
-            server.swagger.json > server.swagger.json.tmp && mv server.swagger.json.tmp server.swagger.json
 
       - name: Install dependencies
         run: npm ci
@@ -278,10 +275,6 @@ jobs:
       - name: Publish to MCP Registry
         if: ${{ env.RUN_PUBLISH_MCP == 'true' }}
         run: ./mcp-publisher publish
-
-      - name: Publish swagger-mcp to MCP Registry
-        if: ${{ env.RUN_PUBLISH_MCP == 'true' }}
-        run: ./mcp-publisher publish server.swagger.json
 
       - name: Build and pack .mcpb
         if: ${{ env.RUN_PUBLISH_MCPB == 'true' }}


### PR DESCRIPTION
## Goal                                                                                                                                                                                  
                                                                                                                                                                                           
  The release of `com.smartbear/smartbear-mcp` is currently blocked. SWG-20002 added a                                                                                                     
  `Publish swagger-mcp to MCP Registry` step to the main `Publish` workflow, but it fails                                                                                                  
  with HTTP 400:                                                                                                                                                                           
                                                                                                                                                                                           
  > remote URL https://swagger.mcp.smartbear.com/mcp is already used by server com.smartbear/smartbear-mcp                                                                                 
                                                                                                                                                                                           
  The MCP registry enforces that each remote URL is owned by exactly one server entry, and                                                                                                 
  the URL is still claimed by older (non-deleted) versions of `smartbear-mcp`. Because that                                                                                                
  step runs inside the main release job, its failure aborts the whole release (npm, the                                                                                                    
  `smartbear-mcp` registry entry, `.mcpb`, Docker). This change decouples the two so a                                                                                                     
  `swagger-mcp` publish failure can no longer block the `smartbear-mcp` release.                                                                                                           
                                                                                                                                                                                           
## Design                                                                                                                                                                                
                                                                                                                                                                                           
  Rather than make the failing step non-blocking with `continue-on-error` (which hides real                                                                                                
  failures and leaves dead config in the release job), the `swagger-mcp` publish is moved to                                                                                               
  its own manually-triggered workflow. This keeps the main release path clean and lets us run                                                                                              
  the `swagger-mcp` publish independently once the URL-ownership conflict is resolved. The new                                                                                             
  workflow reproduces exactly the steps that were removed (version bump, `mcp-publisher`                                                                                                   
  download, `github-oidc` + `dns smartbear.com` login, publish) and runs under the same                                                                                                    
  `Production` environment so it has access to `GH_MCP_REGISTRY_KEY`. It is `workflow_dispatch`                                                                                            
  (manual) because the publish will return 400 until the shared remote URL is freed.                                                                                                       
                                                                                                                                                                                           
## Changeset                                                                                                                                                                             
                                                                                                                                                                                           
  - `.github/workflows/publish.yaml`: removed the `server.swagger.json` version-bump lines from                                                                                            
    the "Update server.json version" step and removed the "Publish swagger-mcp to MCP Registry"                                                                                            
    step. The `smartbear-mcp` release path is otherwise unchanged.                                                                                                                         
  - `.github/workflows/publish-swagger-mcp.yaml` (new): standalone `workflow_dispatch` workflow                                                                                            
    that bumps the version in `server.swagger.json` and publishes the `com.smartbear/swagger-mcp`                                                                                          
    entry to the MCP registry.                                                                                                                                                             
  - `server.swagger.json` and `check-server-json.yml` are intentionally left in place (the file                                                                                            
    is still validated in CI and is consumed by the new workflow).

## Testing                                                                                                                                                                               
                                                                                                                                                                                           
  - Validated both workflow YAML files parse (`js-yaml`).                                                                                                                                  
  - Verified `git diff main` for `publish.yaml` contains only the two intended removals, with no                                                                                           
    other changes to the release path.                                                                                                                                                     
  - Confirmed the new workflow reproduces every removed step (version bump → mcp-publisher                                                                                                 
    download → login → publish).                                                                                                                                                           
  - Note: a successful end-to-end `swagger-mcp` publish still requires freeing the shared remote                                                                                           
    URL (deleting the `smartbear-mcp` versions 0.25.0–0.27.0 that still carry it); that is a                                                                                               
    separate follow-up and out of scope for this PR, whose goal is solely to unblock the                                                                                                   
    `smartbear-mcp` release.   