### PR TITLE
feat: Extend swagger_create_documentation_page to accept optional pageSlug param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- [Swagger] `create_documentation_page` now accepts an optional `slug` parameter. When provided, it is used as the page URL slug; otherwise the slug is generated from the page title.
+
 ## [0.27.1] - 2026-06-29
 - [Swagger]: Removed the https://swagger.mcp.smartbear.com/mcp streamable-http remote from the remotes array in server.json.[#550](https://github.com/SmartBear/smartbear-mcp/pull/550)
 ## [0.27.0] - 2026-06-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] `create_documentation_page` now accepts an optional `slug` parameter. When provided, it is used as the page URL slug; otherwise the slug is generated from the page title.
+- [Swagger] `create_documentation_page` now accepts an optional `pageSlug` parameter. When provided, it is used as the page URL slug; otherwise the slug is generated from the page title.
 - [Swagger] Added `list_suites` tool for discovering test suites in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
 ### Fixed

--- a/docs/products/SmartBear MCP Server/swagger-portal-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-portal-integration.md
@@ -226,8 +226,9 @@ The Swagger Portal client provides comprehensive portal and product management c
 | ------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- | -------- |
 | `portalId`    | Portal UUID or subdomain - unique identifier for the portal                                                            | string      | Yes      |
 | `productId`   | Product UUID - unique identifier for the product                                                                       | string      | Yes      |
-| `pageTitle`   | Title of the documentation page - displayed in navigation and used to generate the page slug (3-255 characters)        | string      | Yes      |
+| `pageTitle`   | Title of the documentation page - displayed in navigation (3-255 characters)                                           | string      | Yes      |
 | `pageContent` | Content of the documentation page. Provide HTML when `contentType` is `html`, Markdown when `contentType` is `markdown` | string      | No       |
+| `pageSlug`    | URL slug for the page - 3-255 characters, lowercase, alphanumeric with hyphens, underscores, or dots (e.g. `my-page`). If not provided, the slug is generated from the page title. | string      | No       |
 | `contentType` | Content type of the page: `markdown` (default) or `html`.                                                              | string      | No       |
 | `source`      | Where content is managed: `internal` (default, editable in portal UI and API) or `external` (API only).               | string      | No       |
 | `order`       | Order position of the page within its parent section or item (default: 0)                                              | number      | No       |

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -974,6 +974,7 @@ export class SwaggerAPI {
       source = "internal",
       order = 0,
       parentId = null,
+      pageSlug,
     } = args;
 
     if (
@@ -999,13 +1000,13 @@ export class SwaggerAPI {
     }
     const section = sections.items[0];
 
-    const pageSlug = normalizeSlug(pageTitle);
+    const resolvedPageSlug = pageSlug ?? normalizeSlug(pageTitle);
     const normalizedTitle = pageTitle.slice(0, 255);
 
     const tocItem = await this.createTableOfContents(section.id, {
       type: "new",
       title: normalizedTitle,
-      slug: pageSlug,
+      slug: resolvedPageSlug,
       order,
       parentId,
       content: {
@@ -1035,7 +1036,7 @@ export class SwaggerAPI {
       sectionSlug: section.slug,
       pageDetails: {
         tableOfContentsId: tocItem.id,
-        slug: pageSlug,
+        slug: resolvedPageSlug,
         title: normalizedTitle,
         content: {
           type: contentType,

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1000,7 +1000,7 @@ export class SwaggerAPI {
     }
     const section = sections.items[0];
 
-    const resolvedPageSlug = pageSlug ?? normalizeSlug(pageTitle);
+    const resolvedPageSlug = pageSlug || normalizeSlug(pageTitle);
     const normalizedTitle = pageTitle.slice(0, 255);
 
     const tocItem = await this.createTableOfContents(section.id, {

--- a/src/swagger/client/portal-types.ts
+++ b/src/swagger/client/portal-types.ts
@@ -594,7 +594,13 @@ export const CreateDocumentationPageArgsSchema = z.object({
   pageTitle: z
     .string()
     .describe(
-      "Title of the documentation page - will be displayed in navigation (3-255 characters, used to generate the page slug)",
+      "Title of the documentation page - will be displayed in navigation (3-255 characters)",
+    ),
+  pageSlug: z
+    .string()
+    .optional()
+    .describe(
+      "URL slug for the documentation page. 3-255 characters, lowercase, alphanumeric with hyphens, underscores, or dots (e.g. 'my-page'). If not provided, the slug is generated from the page title.",
     ),
   pageContent: z
     .string()

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -10825,7 +10825,8 @@ None",
 **Parameters:**
 - portalId (string) *required*: Portal UUID or subdomain - unique identifier for the portal
 - productId (string) *required*: Product UUID - unique identifier for the product
-- pageTitle (string) *required*: Title of the documentation page - will be displayed in navigation (3-255 characters, used to generate the page slug)
+- pageTitle (string) *required*: Title of the documentation page - will be displayed in navigation (3-255 characters)
+- pageSlug (string): URL slug for the documentation page. 3-255 characters, lowercase, alphanumeric with hyphens, underscores, or dots (e.g. 'my-page'). If not provided, the slug is generated from the page title.
 - pageContent (string): Content of the documentation page. Provide HTML when contentType is 'html', Markdown when contentType is 'markdown'.
 - contentType (enum): Content type of the documentation page. 'markdown' works with both 'internal' and 'external' source. 'html' only works with 'external' source — html + internal is not supported by the API and will return an error. (default: "markdown")
 - source (enum): Where the document content is managed. 'internal': editable in both the portal UI and via API. 'external': editable via API only, not in the portal UI. Constraint: 'html' content type only supports 'external' source. (default: "internal")
@@ -10835,6 +10836,7 @@ None",
       "contentType",
       "order",
       "pageContent",
+      "pageSlug",
       "pageTitle",
       "parentId",
       "portalId",

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -986,6 +986,34 @@ describe("SwaggerAPI", () => {
         }),
       );
     });
+
+    it("should fall back to title-derived slug when pageSlug is undefined", async () => {
+      setupFetchRoutes();
+
+      const result = await api.createDocumentationPage({
+        portalId,
+        productId,
+        pageTitle: "Hello World! 123",
+        pageContent: "content",
+        pageSlug: undefined,
+      });
+
+      expect(result.pageDetails.slug).toBe("hello-world-123");
+    });
+
+    it("should fall back to title-derived slug when pageSlug is empty string", async () => {
+      setupFetchRoutes();
+
+      const result = await api.createDocumentationPage({
+        portalId,
+        productId,
+        pageTitle: "Hello World! 123",
+        pageContent: "content",
+        pageSlug: "",
+      });
+
+      expect(result.pageDetails.slug).toBe("hello-world-123");
+    });
   });
 
   describe("error handling", () => {

--- a/src/tests/unit/swagger/api.test.ts
+++ b/src/tests/unit/swagger/api.test.ts
@@ -966,6 +966,26 @@ describe("SwaggerAPI", () => {
       expect(result.pageDetails.slug).toBe("hello-world-123");
       expect(result.draftUrl).toContain(`/edit/content/${tocItemId}`);
     });
+
+    it("should use provided slug instead of generating one from title", async () => {
+      setupFetchRoutes();
+
+      const result = await api.createDocumentationPage({
+        portalId,
+        productId,
+        pageTitle: "Hello World! 123",
+        pageContent: "content",
+        pageSlug: "my-custom-slug",
+      });
+
+      expect(result.pageDetails.slug).toBe("my-custom-slug");
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/sections/${sectionId}/table-of-contents`,
+        expect.objectContaining({
+          body: expect.stringContaining('"slug":"my-custom-slug"'),
+        }),
+      );
+    });
   });
 
   describe("error handling", () => {


### PR DESCRIPTION
## Goal

Allow callers to control the URL slug of a documentation page instead of always having it auto-generated from the title.

## Design

Added pageSlug as an optional parameter. When provided it is passed directly to the table-of-contents API; when omitted the existing normalizeSlug(pageTitle) fallback runs unchanged. No existing behavior is affected.

## Changeset

Added optional pageSlug parameter to CreateDocumentationPageArgsSchema with format constraints documented in the description (3-255 chars, lowercase alphanumeric with hyphens/underscores/dots)
Updated createDocumentationPage handler to use pageSlug ?? normalizeSlug(pageTitle)
Updated swagger-portal-integration.md parameter table to include pageSlug
Updated CHANGELOG.md under Unreleased

## Testing

Added unit test: when pageSlug is provided. Tested locally
