### PR TITLE
chore: track client info for pactflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Pactflow]: Send the MCP client's name and version to Pactflow via a `SOURCE_APPLICATION` header on requests, captured from the client info supplied in the MCP `initialize` request. [#556](https://github.com/SmartBear/smartbear-mcp/pull/556)
+
 ## [0.27.1] - 2026-06-29
 - [Swagger]: Removed the https://swagger.mcp.smartbear.com/mcp streamable-http remote from the remotes array in server.json.[#550](https://github.com/SmartBear/smartbear-mcp/pull/550)
 ## [0.27.0] - 2026-06-29

--- a/src/common/initialize.ts
+++ b/src/common/initialize.ts
@@ -1,0 +1,49 @@
+import type { SmartBearMcpServer } from "./server";
+import type { ClientInfo } from "./types";
+
+/**
+ * Applies the client info and capability flags carried by an MCP `initialize`
+ * request onto the given server instance. No-ops for any other message.
+ *
+ * clientInfo has been a required field of `initialize` params since the
+ * original 2024-11-05 MCP spec version, so it is captured unconditionally.
+ * Capability detection (sampling/elicitation) predates that and stays gated
+ * behind protocolVersion 2025-11-25 to preserve existing behavior.
+ */
+export function handleInitializeMessage(
+  server: SmartBearMcpServer,
+  message: unknown,
+): void {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("method" in message) ||
+    (message as { method: unknown }).method !== "initialize"
+  ) {
+    return;
+  }
+
+  const params = (message as { params?: Record<string, unknown> }).params;
+  const clientInfo = params?.clientInfo as ClientInfo | undefined;
+  if (clientInfo) {
+    server.setClientInfo(clientInfo);
+  }
+
+  if (params?.protocolVersion === "2025-11-25") {
+    const clientCapabilities = (params.capabilities ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    if (Object.hasOwn(clientCapabilities, "sampling")) {
+      server.setSamplingSupported(true);
+    }
+
+    if (Object.hasOwn(clientCapabilities, "elicitation")) {
+      server.setElicitationSupported(true);
+    }
+  }
+
+  // Other protocolVersion handling can be added below
+  // to maintain backwards compatibility.
+}

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -20,7 +20,7 @@ import {
   isElicitationPolyfillResult,
 } from "./pollyfills";
 import { ToolError } from "./tools";
-import type { Client, ToolParams } from "./types";
+import type { Client, ClientInfo, ToolParams } from "./types";
 import {
   getDefaultValue,
   getReadableTypeName,
@@ -32,6 +32,7 @@ export class SmartBearMcpServer extends McpServer {
   private cache: CacheService;
   private samplingSupported = false;
   private elicitationSupported = false;
+  private clientInfo?: ClientInfo;
   private clients: Client[] = [];
   private enabledToolsets?: string[];
 
@@ -75,6 +76,14 @@ export class SmartBearMcpServer extends McpServer {
 
   isElicitationSupported(): boolean {
     return this.elicitationSupported;
+  }
+
+  setClientInfo(info: ClientInfo): void {
+    this.clientInfo = info;
+  }
+
+  getClientInfo(): ClientInfo | undefined {
+    return this.clientInfo;
   }
 
   getClients(): Client[] {

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -8,6 +8,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 
 import { clientRegistry } from "./client-registry";
+import { handleInitializeMessage } from "./initialize";
 import { withRequestContext } from "./request-context";
 import { SmartBearMcpServer } from "./server";
 import { isDraining, registerShutdownHandler } from "./shutdown";
@@ -356,27 +357,7 @@ async function createNewTransport(
       transports.set(newSessionId, { server, transport });
     },
   });
-  transport.onmessage = (message) => {
-    if ("method" in message && message.method === "initialize") {
-      if (message.params?.protocolVersion === "2025-11-25") {
-        const clientCapabilities = message.params?.capabilities as Record<
-          string,
-          unknown
-        >;
-
-        if (Object.hasOwn(clientCapabilities, "sampling")) {
-          server.setSamplingSupported(true);
-        }
-
-        if (Object.hasOwn(clientCapabilities, "elicitation")) {
-          server.setElicitationSupported(true);
-        }
-      }
-
-      // Other protocolVersion handling can be added below
-      // to maintain backwards compatibility.
-    }
-  };
+  transport.onmessage = (message) => handleInitializeMessage(server, message);
 
   // Clean up session on close
   transport.onclose = () => {

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 
 import { clientRegistry } from "./client-registry";
 import { USER_AGENT } from "./info";
+import { handleInitializeMessage } from "./initialize";
 import { SmartBearMcpServer } from "./server";
 import { registerShutdownHandler } from "./shutdown";
 import { getTypeDescription, isOptionalType } from "./zod-utils";
@@ -92,27 +93,7 @@ export async function runStdioMode() {
     }
   });
 
-  transport.onmessage = (message) => {
-    if ("method" in message && message.method === "initialize") {
-      if (message.params?.protocolVersion === "2025-11-25") {
-        const clientCapabilities = message.params?.capabilities as Record<
-          string,
-          unknown
-        >;
-
-        if (Object.hasOwn(clientCapabilities, "sampling")) {
-          server.setSamplingSupported(true);
-        }
-
-        if (Object.hasOwn(clientCapabilities, "elicitation")) {
-          server.setElicitationSupported(true);
-        }
-      }
-
-      // Other protocolVersion handling can be added below
-      // to maintain backwards compatibility.
-    }
-  };
+  transport.onmessage = (message) => handleInitializeMessage(server, message);
   await server.connect(transport);
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -74,6 +74,12 @@ export type GetInputFunction = (
   options?: RequestOptions,
 ) => Promise<ElicitResult>;
 
+export interface ClientInfo {
+  name: string;
+  version: string;
+  title?: string;
+}
+
 export interface Client {
   /** Human-readable name for the client - usually the product name */
   name: string;

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -285,6 +285,13 @@ export class PactflowClient implements Client {
       contextToken = contextToken[0];
     }
 
+    const clientInfo = this._server?.getClientInfo();
+    const sourceApplicationHeader: Record<string, string> = {
+      SOURCE_APPLICATION: clientInfo
+        ? `${clientInfo.name}/${clientInfo.version}`
+        : "unknown",
+    };
+
     if (contextToken) {
       let authHeader = contextToken;
       if (
@@ -298,6 +305,7 @@ export class PactflowClient implements Client {
         Authorization: authHeader,
         "Content-Type": "application/json",
         "User-Agent": USER_AGENT,
+        ...sourceApplicationHeader,
       };
     }
 
@@ -314,6 +322,7 @@ export class PactflowClient implements Client {
         Authorization: authHeader,
         "Content-Type": "application/json",
         "User-Agent": USER_AGENT,
+        ...sourceApplicationHeader,
       };
     } else if (this.username && this.password) {
       const authString = `${this.username}:${this.password}`;
@@ -321,6 +330,7 @@ export class PactflowClient implements Client {
         Authorization: `Basic ${Buffer.from(authString).toString("base64")}`,
         "Content-Type": "application/json",
         "User-Agent": USER_AGENT,
+        ...sourceApplicationHeader,
       };
     }
     return undefined;

--- a/src/tests/unit/common/initialize.test.ts
+++ b/src/tests/unit/common/initialize.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleInitializeMessage } from "../../../common/initialize";
+import type { SmartBearMcpServer } from "../../../common/server";
+
+function fakeServer() {
+  return {
+    setClientInfo: vi.fn(),
+    setSamplingSupported: vi.fn(),
+    setElicitationSupported: vi.fn(),
+  } as unknown as SmartBearMcpServer;
+}
+
+describe("handleInitializeMessage", () => {
+  it("ignores messages that are not an initialize request", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "tools/list",
+      params: { clientInfo: { name: "Claude Code", version: "1.0.0" } },
+    });
+
+    expect(server.setClientInfo).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-object messages", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, null);
+    handleInitializeMessage(server, "initialize");
+    handleInitializeMessage(server, 42);
+
+    expect(server.setClientInfo).not.toHaveBeenCalled();
+  });
+
+  it("captures clientInfo regardless of protocolVersion", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "Claude Code", version: "1.2.3" },
+      },
+    });
+
+    expect(server.setClientInfo).toHaveBeenCalledWith({
+      name: "Claude Code",
+      version: "1.2.3",
+    });
+    // Capability detection stays gated behind 2025-11-25.
+    expect(server.setSamplingSupported).not.toHaveBeenCalled();
+    expect(server.setElicitationSupported).not.toHaveBeenCalled();
+  });
+
+  it("does not call setClientInfo when clientInfo is absent", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {} },
+    });
+
+    expect(server.setClientInfo).not.toHaveBeenCalled();
+  });
+
+  it("detects sampling and elicitation capabilities on protocolVersion 2025-11-25", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { sampling: {}, elicitation: {} },
+        clientInfo: { name: "Claude Code", version: "1.2.3" },
+      },
+    });
+
+    expect(server.setClientInfo).toHaveBeenCalledWith({
+      name: "Claude Code",
+      version: "1.2.3",
+    });
+    expect(server.setSamplingSupported).toHaveBeenCalledWith(true);
+    expect(server.setElicitationSupported).toHaveBeenCalledWith(true);
+  });
+
+  it("does not set sampling/elicitation flags when absent from capabilities", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "Claude Code", version: "1.2.3" },
+      },
+    });
+
+    expect(server.setSamplingSupported).not.toHaveBeenCalled();
+    expect(server.setElicitationSupported).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when protocolVersion is 2025-11-25 and capabilities is missing", () => {
+    const server = fakeServer();
+
+    expect(() =>
+      handleInitializeMessage(server, {
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          clientInfo: { name: "Claude Code", version: "1.2.3" },
+        },
+      }),
+    ).not.toThrow();
+
+    expect(server.setClientInfo).toHaveBeenCalledWith({
+      name: "Claude Code",
+      version: "1.2.3",
+    });
+    expect(server.setSamplingSupported).not.toHaveBeenCalled();
+    expect(server.setElicitationSupported).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/common/server.test.ts
+++ b/src/tests/unit/common/server.test.ts
@@ -40,6 +40,31 @@ describe("SmartBearMcpServer", () => {
     vi.mocked(Bugsnag.notify).mockClear();
   });
 
+  describe("clientInfo", () => {
+    it("returns undefined before any clientInfo is set", () => {
+      expect(server.getClientInfo()).toBeUndefined();
+    });
+
+    it("stores and returns the client info set via setClientInfo", () => {
+      server.setClientInfo({ name: "Claude Code", version: "1.2.3" });
+
+      expect(server.getClientInfo()).toEqual({
+        name: "Claude Code",
+        version: "1.2.3",
+      });
+    });
+
+    it("overwrites previously stored client info", () => {
+      server.setClientInfo({ name: "Claude Code", version: "1.2.3" });
+      server.setClientInfo({ name: "Cursor", version: "0.9.0" });
+
+      expect(server.getClientInfo()).toEqual({
+        name: "Cursor",
+        version: "0.9.0",
+      });
+    });
+  });
+
   describe("addClient", () => {
     let mockClient: any;
 

--- a/src/tests/unit/pactflow/client.test.ts
+++ b/src/tests/unit/pactflow/client.test.ts
@@ -15,9 +15,13 @@ async function createConfiguredClient(config: {
   username?: string;
   password?: string;
   base_url?: string;
+  clientInfo?: { name: string; version: string };
 }): Promise<PactflowClient> {
   const client = new PactflowClient();
-  const mockServer = { server: vi.fn() } as any;
+  const mockServer = {
+    server: vi.fn(),
+    getClientInfo: vi.fn().mockReturnValue(config.clientInfo),
+  } as any;
   const defaultConfig = {
     base_url: "https://example.com",
     token: config.token,
@@ -67,6 +71,29 @@ describe("PactFlowClient", () => {
             `Basic ${Buffer.from("user:pass").toString("base64")}`,
           ),
           "Content-Type": expect.stringContaining("application/json"),
+        }),
+      );
+    });
+
+    it("includes SOURCE_APPLICATION header when client info is available", async () => {
+      client = await createConfiguredClient({
+        token: "my-token",
+        clientInfo: { name: "Claude Code", version: "1.2.3" },
+      });
+
+      expect(client.requestHeaders).toEqual(
+        expect.objectContaining({
+          SOURCE_APPLICATION: "Claude Code/1.2.3",
+        }),
+      );
+    });
+
+    it("sends SOURCE_APPLICATION header as 'unknown' when client info is not available", async () => {
+      client = await createConfiguredClient({ token: "my-token" });
+
+      expect(client.requestHeaders).toEqual(
+        expect.objectContaining({
+          SOURCE_APPLICATION: "unknown",
         }),
       );
     });


### PR DESCRIPTION
## Goal

This change tracks host application info, which enables individual products to know which app is using the mcp server eg:- vscode, claude code, etc.

## Testing

Tested using unit tests and on existing pactflow tools
