### PR TITLE
[Zephyr] TM4J-17950: Adjust rest-api-schemas - include updateAfter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Zephyr] Fixed `get_test_case_steps` returning a schema validation error [#543](https://github.com/SmartBear/smartbear-mcp/pull/543)
+- [Zephyr] Update Zephyr schemas [#439](https://github.com/SmartBear/zephyr-scale-cloud-rest-api/pull/2453)
 
 ## [0.27.2] - 2026-07-01
 - [CI] Extracted publishing of the standalone `com.smartbear/swagger-mcp` registry entry (`server.swagger.json`) into a dedicated, manually triggered `publish-swagger-mcp.yaml` workflow (`workflow_dispatch`), removing those steps from the main `publish.yaml`. [#554](https://github.com/SmartBear/smartbear-mcp/pull/554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Zephyr] Fixed `get_test_case_steps` returning a schema validation error [#543](https://github.com/SmartBear/smartbear-mcp/pull/543)
-- [Zephyr] Update Zephyr schemas [#439](https://github.com/SmartBear/smartbear-mcp/pull/562)
+- [Zephyr] Update Zephyr schemas [#562](https://github.com/SmartBear/smartbear-mcp/pull/562)
 
 ## [0.27.2] - 2026-07-01
 - [CI] Extracted publishing of the standalone `com.smartbear/swagger-mcp` registry entry (`server.swagger.json`) into a dedicated, manually triggered `publish-swagger-mcp.yaml` workflow (`workflow_dispatch`), removing those steps from the main `publish.yaml`. [#554](https://github.com/SmartBear/smartbear-mcp/pull/554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Zephyr] Fixed `get_test_case_steps` returning a schema validation error [#543](https://github.com/SmartBear/smartbear-mcp/pull/543)
-- [Zephyr] Update Zephyr schemas [#439](https://github.com/SmartBear/zephyr-scale-cloud-rest-api/pull/2453)
+- [Zephyr] Update Zephyr schemas [#439](https://github.com/SmartBear/smartbear-mcp/pull/562)
 
 ## [0.27.2] - 2026-07-01
 - [CI] Extracted publishing of the standalone `com.smartbear/swagger-mcp` registry entry (`server.swagger.json`) into a dedicated, manually triggered `publish-swagger-mcp.yaml` workflow (`workflow_dispatch`), removing those steps from the main `publish.yaml`. [#554](https://github.com/SmartBear/smartbear-mcp/pull/554)

--- a/docs/products/SmartBear MCP Server/zephyr-integration.md
+++ b/docs/products/SmartBear MCP Server/zephyr-integration.md
@@ -49,6 +49,7 @@ The following environment variables configure the Zephyr integration:
   - optional Folder ID (`folderId`)
   - optional max results to return (`limit`)
   - optional starting cursor position for pagination (`startAtId`)
+  - optional filter for entities updated after a given time (`updatedAfter`)
 - **Returns**: A list of Test Cases along with their properties.
 - **Use case**: Retrieve the Test Cases, it can be filtered by Project Key and Folder ID.
 
@@ -309,6 +310,7 @@ The following environment variables configure the Zephyr integration:
   - optional flag to include only last executions (`onlyLastExecutions`)
   - optional max results to return (`limit`)
   - optional starting cursor position for pagination (`startAtId`)
+  - optional filter for entities updated after a given time (`updatedAfter`)
 - **Returns**: A list of Test Executions along with their properties. Results are filtered based on the provided parameters.
 - **Use case**: Retrieve Test Executions, filtered by various criteria such as project, test cycle, test case, or execution dates.
 

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -13127,6 +13127,7 @@ Expected Output: Test execution steps for the specified test data row",
 Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the limit value in the response to confirm how many results were actually returned.
  (default: 10)
 - startAtId (number): Zero-indexed starting position for ID-based pagination. (default: 0)
+- updatedAfter (string): Filter only entities updated after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
 
 **Examples:**
 1. Get the first 10 test executions
@@ -13173,6 +13174,7 @@ Expected Output: Test executions with step links included",
       "startAtId",
       "testCase",
       "testCycle",
+      "updatedAfter",
     ],
     "outputSchema": [
       "limit",

--- a/src/zephyr/common/rest-api-schemas.ts
+++ b/src/zephyr/common/rest-api-schemas.ts
@@ -5771,6 +5771,13 @@ export const ListTestPlansCursorPaginatedQueryParams = zod.object({
     .min(listTestPlansCursorPaginatedQueryStartAtIdMin)
     .default(listTestPlansCursorPaginatedQueryStartAtIdDefault)
     .describe("Zero-indexed starting position for ID-based pagination."),
+  updatedAfter: zod
+    .string()
+    .datetime({})
+    .optional()
+    .describe(
+      "Filter only entities updated after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'",
+    ),
 });
 
 export const listTestPlansCursorPaginated200ResponseOneNextStartAtIdMin = 0;
@@ -7215,6 +7222,13 @@ export const ListTestExecutionsNextgenQueryParams = zod.object({
     .min(listTestExecutionsNextgenQueryStartAtIdMin)
     .default(listTestExecutionsNextgenQueryStartAtIdDefault)
     .describe("Zero-indexed starting position for ID-based pagination."),
+  updatedAfter: zod
+    .string()
+    .datetime({})
+    .optional()
+    .describe(
+      "Filter only entities updated after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'",
+    ),
 });
 
 export const listTestExecutionsNextgen200ResponseOneNextStartAtIdMin = 0;


### PR DESCRIPTION
Goal
Regenerate the Zephyr REST API schemas to include new changes to rest-api

Include parameter UpdateAfter in 

- GET testplans/nextgen
- GET testexecutions/nextgen

Changeset
Regenerate rest-api-schemas.ts.
