### PR TITLE
[Common] TM4J-17877: Add toProviderSchema for nullable-object LLM compatibility

### DIFF
--- a/src/common/provider-schema.ts
+++ b/src/common/provider-schema.ts
@@ -1,0 +1,86 @@
+import { type ZodType, z } from "zod";
+
+/**
+ * LLM providers whose Structured Output / JSON Schema modes enforce a
+ * restricted subset of JSON Schema.
+ *
+ * See the investigation write-up for the full context (TM4J-17877):
+ * https://smartbear.atlassian.net/wiki/spaces/KT/pages/6447890562
+ */
+export type LlmProvider = "openai" | "gemini";
+
+/** Loosely-typed JSON Schema node. */
+export type JsonSchema = Record<string, unknown>;
+
+/**
+ * Context object passed to Zod v4's `toJSONSchema` `override` callback, invoked
+ * once per generated JSON Schema node. Mutating `jsonSchema` in place rewrites
+ * the emitted node.
+ */
+interface OverrideContext {
+  jsonSchema: JsonSchema;
+}
+
+/**
+ * Rewrites the `X | null` union that Zod emits for `.nullable()` /`.nullish()`
+ * into a JSON Schema type-array (`{ "type": ["object", "null"] }`).
+ *
+ * By default Zod v4 serialises a nullable type as
+ * `{ "anyOf": [ <schema>, { "type": "null" } ] }`. OpenAI's Structured Outputs
+ * reject `anyOf` that contains a `null` branch; the only nullable form they
+ * accept is the type-array pattern. This override folds the two branches back
+ * into a single node so nullable objects (and primitives) stay compatible.
+ *
+ * Genuine multi-type unions (e.g. `z.union([z.string(), z.number()]).nullable()`)
+ * are intentionally left untouched — they cannot be expressed as a type-array
+ * and remain unsupported by both providers.
+ */
+export function foldNullableUnionsForOpenAi(ctx: OverrideContext): void {
+  const js = ctx.jsonSchema;
+  const anyOf = js.anyOf;
+  if (!Array.isArray(anyOf) || anyOf.length !== 2) {
+    return;
+  }
+
+  const nullBranch = anyOf.find((s) => s?.type === "null");
+  const realBranch = anyOf.find((s) => s?.type !== "null");
+  // Only fold `<single-typed schema> | null`. If the non-null branch has no
+  // concrete `type` (e.g. it is itself a union), a type-array cannot represent
+  // it, so leave the schema as-is.
+  if (!nullBranch || !realBranch || realBranch.type === undefined) {
+    return;
+  }
+
+  delete js.anyOf;
+  Object.assign(js, realBranch);
+  js.type = Array.isArray(realBranch.type)
+    ? [...realBranch.type, "null"]
+    : [realBranch.type, "null"];
+}
+
+/**
+ * Converts a Zod schema to a JSON Schema that the given LLM provider's
+ * structured-output mode accepts — in particular, one that keeps **nullable
+ * objects** valid instead of tripping the provider's `anyOf`/union restrictions.
+ *
+ * - `openai`: emits draft-2020-12 and folds `X | null` unions into the
+ *   `{ "type": [..., "null"] }` type-array form OpenAI requires.
+ * - `gemini`: emits the OpenAPI 3.0 dialect, which expresses nullability as the
+ *   `nullable: true` annotation Gemini / Vertex AI expects.
+ *
+ * Model fields as `.nullable()` (not `.nullish()`): both providers require every
+ * declared property to be present, so keep the key required and let it be
+ * nullable rather than optional.
+ */
+export function toProviderSchema(
+  schema: ZodType,
+  provider: LlmProvider,
+): JsonSchema {
+  if (provider === "gemini") {
+    return z.toJSONSchema(schema, { target: "openapi-3.0" }) as JsonSchema;
+  }
+  return z.toJSONSchema(schema, {
+    target: "draft-2020-12",
+    override: foldNullableUnionsForOpenAi,
+  }) as JsonSchema;
+}

--- a/src/tests/unit/common/provider-schema.test.ts
+++ b/src/tests/unit/common/provider-schema.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  foldNullableUnionsForOpenAi,
+  toProviderSchema,
+} from "../../../common/provider-schema";
+
+// A nullable object plus a nullable primitive and a required field — the exact
+// shapes that break provider structured outputs when emitted as `anyOf` unions.
+const schema = z.object({
+  folder: z
+    .object({ id: z.number().min(1) })
+    .nullable()
+    .describe("ID and link to the folder resource, or null."),
+  tag: z.string().nullable(),
+  name: z.string(),
+});
+
+describe("provider-schema", () => {
+  describe("toProviderSchema (openai)", () => {
+    const json = toProviderSchema(schema, "openai") as any;
+
+    it("emits no anyOf/oneOf unions", () => {
+      const serialized = JSON.stringify(json);
+      expect(serialized).not.toContain("anyOf");
+      expect(serialized).not.toContain("oneOf");
+    });
+
+    it("expresses a nullable object as a `[object, null]` type-array", () => {
+      expect(json.properties.folder.type).toEqual(["object", "null"]);
+      // The nested object shape is preserved.
+      expect(json.properties.folder.properties.id).toMatchObject({
+        type: "number",
+      });
+      // Description on the nullable wrapper is preserved.
+      expect(json.properties.folder.description).toContain("folder resource");
+    });
+
+    it("expresses a nullable primitive as a `[string, null]` type-array", () => {
+      expect(json.properties.tag.type).toEqual(["string", "null"]);
+    });
+
+    it("keeps every declared property in `required`", () => {
+      expect(json.required).toEqual(
+        expect.arrayContaining(["folder", "tag", "name"]),
+      );
+    });
+  });
+
+  describe("toProviderSchema (gemini)", () => {
+    const json = toProviderSchema(schema, "gemini") as any;
+
+    it("emits no anyOf/oneOf unions", () => {
+      const serialized = JSON.stringify(json);
+      expect(serialized).not.toContain("anyOf");
+      expect(serialized).not.toContain("oneOf");
+    });
+
+    it("expresses a nullable object via the `nullable: true` annotation", () => {
+      expect(json.properties.folder.type).toBe("object");
+      expect(json.properties.folder.nullable).toBe(true);
+      expect(json.properties.folder.properties.id).toMatchObject({
+        type: "number",
+      });
+    });
+
+    it("expresses a nullable primitive via the `nullable: true` annotation", () => {
+      expect(json.properties.tag.type).toBe("string");
+      expect(json.properties.tag.nullable).toBe(true);
+    });
+  });
+
+  describe("foldNullableUnionsForOpenAi", () => {
+    it("folds `<schema> | null` into a type-array", () => {
+      const ctx = {
+        jsonSchema: {
+          anyOf: [{ type: "string" }, { type: "null" }],
+        },
+      };
+      foldNullableUnionsForOpenAi(ctx);
+      expect(ctx.jsonSchema).not.toHaveProperty("anyOf");
+      expect((ctx.jsonSchema as any).type).toEqual(["string", "null"]);
+    });
+
+    it("leaves genuine multi-type unions untouched", () => {
+      // `string | number | null` cannot be a single type-array — it must stay
+      // a union, which both providers reject (documented limitation).
+      const ctx = {
+        jsonSchema: {
+          anyOf: [
+            { anyOf: [{ type: "string" }, { type: "number" }] },
+            { type: "null" },
+          ],
+        },
+      };
+      const before = JSON.parse(JSON.stringify(ctx.jsonSchema));
+      foldNullableUnionsForOpenAi(ctx);
+      expect(ctx.jsonSchema).toEqual(before);
+    });
+
+    it("ignores nodes without an anyOf", () => {
+      const ctx = { jsonSchema: { type: "object", properties: {} } };
+      const before = JSON.parse(JSON.stringify(ctx.jsonSchema));
+      foldNullableUnionsForOpenAi(ctx);
+      expect(ctx.jsonSchema).toEqual(before);
+    });
+  });
+});


### PR DESCRIPTION
**TL;DR:** Zod's `.nullable()`/`.nullish()` serialise to an `anyOf` union with `null`, which OpenAI and Vertex AI/Gemini structured-output modes reject — so nullable *objects* break. This PR adds a `toProviderSchema(schema, provider)` helper (+ tests) that emits provider-accepted nullable shapes, letting us keep nullable objects instead of flattening everything to primitives. **This is the tooling foundation; migrating existing schemas is the follow-up (see below).**

## Background

Investigation write-up: [Zod `.nullish()` compatibility issues](https://smartbear.atlassian.net/wiki/spaces/KT/pages/6447890562) · TM4J-17877.

Zod v4 serialises a nullable type as:

```json
{ "anyOf": [ { "type": "object", "...": "..." }, { "type": "null" } ] }
```

Both providers reject this:
- **OpenAI** forbids `anyOf` containing `{"type":"null"}`; the only nullable form it accepts is the type-array `{"type":["object","null"]}`, and it requires every property to be `required`.
- **Gemini/Vertex** reject `anyOf`/`oneOf` entirely; nullability must be the OpenAPI-style `nullable: true` annotation.

The previously-documented workaround was to flatten nullable objects to primitives (e.g. `folder` object → `folderId` number). That loses structure. This PR keeps nullable objects by fixing the **serialisation** instead.

## What this PR does

Adds `src/common/provider-schema.ts`:

- **`toProviderSchema(schema, provider)`** — converts a Zod schema to a provider-compatible JSON Schema.
  - `openai`: draft-2020-12 + an `override` that folds `X | null` unions into `{ "type": [..., "null"] }`.
  - `gemini`: `target: "openapi-3.0"`, which emits `nullable: true`.
- **`foldNullableUnionsForOpenAi(ctx)`** — the exported override transform (unit-tested in isolation).

Adds `src/tests/unit/common/provider-schema.test.ts` — 10 tests asserting the emitted shapes for nullable objects **and** primitives, for both providers, verified against the installed Zod v4.

Verification: `npx tsc --noEmit` clean, full suite green (1964 tests), `biome lint`/`format` clean on the new files.

## How to model schemas going forward

Use `.nullable()`, **not** `.nullish()`. Both providers require every declared property to be present, so keep the key **required but nullable** rather than optional:

```ts
// ✅ nullable object, still a required key
folder: z.object({ id: z.number().min(1) }).nullable().describe("Folder, or null"),
```

## Follow-up work (for whoever picks this up)

1. **Wire `toProviderSchema` into the places where we serialise Zod schemas for an LLM.** The one confirmed self-serialisation site today is `src/pactflow/client/prompts.ts:91` (`EndpointMatcherSchema.toJSONSchema()` embedded in a prompt) — route it through `toProviderSchema` with the provider that path targets. Audit for other `toJSONSchema()`/provider-facing conversions.
2. **Migrate `.nullish()` → `.nullable()`** in schemas consumed by LLMs. There are ~138 `.nullish()` usages (mostly `src/zephyr/common/rest-api-schemas.ts` and `src/qtm4j/schema/*`). ⚠️ Many of these describe **API responses**, where `.nullish()` also governs runtime response validation — changing `nullish → nullable` makes the key required at validation time, so migrate deliberately and test per-schema, don't bulk sed.
3. **Note the MCP-SDK boundary.** For MCP *tool input* schemas consumed directly by the host LLM, the MCP SDK does the Zod→JSON-Schema conversion, not us — so the durable fix there is the schema-authoring rule above (avoid `.nullish()` on objects), which `toProviderSchema` cannot retrofit.
4. **Gemini `additionalProperties`.** `openapi-3.0` output still carries `additionalProperties: false`; confirm Gemini's schema mode accepts (or ignores) it, and strip it in the gemini branch if it causes rejections.

### Known limitation
Genuine multi-type unions (e.g. `z.union([z.string(), z.number()]).nullable()`) can't be expressed as a type-array and are intentionally left as `anyOf` — still unsupported by both providers. There's a dedicated test documenting this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
