### PR TITLE
[BearQ] add environment targeting and list tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Added `list_suite_executions` tool for reviewing the execution history and timings of a test suite in your Swagger Functional Testing workspace. Requires `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN` env var.
 
+- [BearQ] Add environment targeting to the run tools and a `bearq_list_environments` tool [#565](https://github.com/SmartBear/smartbear-mcp/pull/565)
+
 ## [0.28.0] - 2026-07-07
 
 ### Changed

--- a/docs/products/SmartBear MCP Server/bearq-integration.md
+++ b/docs/products/SmartBear MCP Server/bearq-integration.md
@@ -18,21 +18,21 @@ The BearQ client provides AI-powered QA test management and execution capabiliti
 #### `bearq_run_regression_tests`
 
 - Purpose: Runs the full BearQ regression suite — every regression-ready test case in the workspace.
-- Parameters: None.
+- Parameters: `environment` (optional) — target environment name to run against; omit to use the workspace default.
 - Returns: Task IDs for the started run.
 - Use case: CI/CD pipelines or pre-release smoke checks.
 
 #### `bearq_run_test_cases`
 
 - Purpose: Runs specific BearQ regression test cases by ID.
-- Parameters: `testCaseIds` — list of regression test case IDs.
+- Parameters: `testCaseIds` — list of regression test case IDs. `environment` (optional) — target environment name to run against; omit to use the workspace default.
 - Returns: Task IDs for the started run.
 - Use case: Targeted re-run of a subset of regression tests after a code change.
 
 #### `bearq_run_tests_in_functional_areas`
 
 - Purpose: Runs every regression test case tagged with one or more functional areas.
-- Parameters: `functionalAreas` — list of functional area IDs or names.
+- Parameters: `functionalAreas` — list of functional area IDs or names. `environment` (optional) — target environment name to run against; omit to use the workspace default.
 - Returns: Task IDs for the started run.
 - Use case: Run only the tests relevant to a feature area touched by a change.
 
@@ -82,6 +82,17 @@ The BearQ client provides AI-powered QA test management and execution capabiliti
 - Parameters: `instruction` — natural language instruction.
 - Returns: Task ID for the started QA lead task.
 - Use case: Catch-all when no other BearQ tool fits. The QA lead can list, create, and update test cases, manage functional areas, and read the application model — enough surface area to handle most QA workflow requests.
+
+---
+
+### Environments
+
+#### `bearq_list_environments`
+
+- Purpose: Lists the environments configured in the workspace.
+- Parameters: None.
+- Returns: `{ environments }` — each with `id`, `name`, `url`, `isDefault`, `createdAt`, and `updatedAt`.
+- Use case: Discover valid environment names to pass to the run tools, and identify the workspace default.
 
 ---
 

--- a/src/bearq/client.ts
+++ b/src/bearq/client.ts
@@ -10,6 +10,7 @@ import type {
   RegisterToolsFunction,
 } from "../common/types";
 import { AUTHORIZATION_HEADER, DEFAULT_API_BASE_URL } from "./config/constants";
+import { ListEnvironments } from "./tool/environments/list-environments";
 import { ChatWithQaLead } from "./tool/tasks/chat-with-qa-lead";
 import { ExpandApplicationModel } from "./tool/tasks/expand-application-model";
 import { GetTask } from "./tool/tasks/get-task";
@@ -97,6 +98,7 @@ export class BearQClient implements Client {
       new GetTaskStatus(this),
       new StopTask(this),
       new WaitForTask(this),
+      new ListEnvironments(this),
     ];
     for (const tool of tools) {
       register(tool.specification, tool.handle);

--- a/src/bearq/tool/environments/list-environments.ts
+++ b/src/bearq/tool/environments/list-environments.ts
@@ -1,0 +1,33 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { z } from "zod";
+import { Tool, ToolError } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { BearQClient } from "../../client";
+
+const inputSchema = z.object({});
+
+export class ListEnvironments extends Tool<BearQClient> {
+  specification: ToolParams = {
+    title: "List Environments",
+    toolset: "Tasks",
+    summary:
+      "Lists the environments configured in the workspace. Use this to discover valid environment names to pass to the test-running tools, and to identify the workspace default.",
+    inputSchema,
+    readOnly: true,
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (_args) => {
+    const res = await fetch(`${this.client.getBaseUrl()}/environments`, {
+      method: "GET",
+      headers: this.client.getHeaders(),
+    });
+    if (!res.ok)
+      throw new ToolError(
+        `GET /environments failed: ${res.status} ${res.statusText}`,
+      );
+    return {
+      content: [{ type: "text", text: JSON.stringify(await res.json()) }],
+    };
+  };
+}

--- a/src/bearq/tool/environments/list-environments.ts
+++ b/src/bearq/tool/environments/list-environments.ts
@@ -10,7 +10,7 @@ const inputSchema = z.object({});
 export class ListEnvironments extends Tool<BearQClient> {
   specification: ToolParams = {
     title: "List Environments",
-    toolset: "Tasks",
+    toolset: "Environments",
     summary:
       "Lists the environments configured in the workspace. Use this to discover valid environment names to pass to the test-running tools, and to identify the workspace default.",
     inputSchema,

--- a/src/bearq/tool/tasks/run-regression-tests.ts
+++ b/src/bearq/tool/tasks/run-regression-tests.ts
@@ -5,7 +5,15 @@ import { Tool, ToolError } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
-const inputSchema = z.object({});
+const inputSchema = z.object({
+  environment: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Target environment name to run tests against. Omit to use the workspace default.",
+    ),
+});
 
 export class RunRegressionTests extends Tool<BearQClient> {
   specification: ToolParams = {
@@ -16,11 +24,14 @@ export class RunRegressionTests extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (_args) => {
+  handle: ToolCallback<ZodRawShape> = async (args) => {
+    const { environment } = inputSchema.parse(args);
+    const body: Record<string, unknown> = { agent: "tester", mode: "run" };
+    if (environment !== undefined) body.environment = environment;
     const res = await fetch(`${this.client.getBaseUrl()}/tasks`, {
       method: "POST",
       headers: this.client.getHeaders(),
-      body: JSON.stringify({ agent: "tester", mode: "run" }),
+      body: JSON.stringify(body),
     });
     if (!res.ok)
       throw new ToolError(

--- a/src/bearq/tool/tasks/run-test-cases.ts
+++ b/src/bearq/tool/tasks/run-test-cases.ts
@@ -10,6 +10,13 @@ const inputSchema = z.object({
     .array(z.number().int().positive())
     .min(1)
     .describe("IDs of BearQ regression test cases to run."),
+  environment: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Target environment name to run tests against. Omit to use the workspace default.",
+    ),
 });
 
 export class RunTestCases extends Tool<BearQClient> {
@@ -22,11 +29,17 @@ export class RunTestCases extends Tool<BearQClient> {
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
-    const { testCaseIds } = inputSchema.parse(args);
+    const { testCaseIds, environment } = inputSchema.parse(args);
+    const body: Record<string, unknown> = {
+      agent: "tester",
+      mode: "run",
+      testCaseIds,
+    };
+    if (environment !== undefined) body.environment = environment;
     const res = await fetch(`${this.client.getBaseUrl()}/tasks`, {
       method: "POST",
       headers: this.client.getHeaders(),
-      body: JSON.stringify({ agent: "tester", mode: "run", testCaseIds }),
+      body: JSON.stringify(body),
     });
     if (!res.ok)
       throw new ToolError(

--- a/src/bearq/tool/tasks/run-tests-in-functional-areas.ts
+++ b/src/bearq/tool/tasks/run-tests-in-functional-areas.ts
@@ -10,6 +10,13 @@ const inputSchema = z.object({
     .array(z.union([z.number().int().positive(), z.string().min(1)]))
     .min(1)
     .describe("Functional areas to target, by ID or name."),
+  environment: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Target environment name to run tests against. Omit to use the workspace default.",
+    ),
 });
 
 export class RunTestsInFunctionalAreas extends Tool<BearQClient> {
@@ -22,11 +29,17 @@ export class RunTestsInFunctionalAreas extends Tool<BearQClient> {
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
-    const { functionalAreas } = inputSchema.parse(args);
+    const { functionalAreas, environment } = inputSchema.parse(args);
+    const body: Record<string, unknown> = {
+      agent: "tester",
+      mode: "run",
+      functionalAreas,
+    };
+    if (environment !== undefined) body.environment = environment;
     const res = await fetch(`${this.client.getBaseUrl()}/tasks`, {
       method: "POST",
       headers: this.client.getHeaders(),
-      body: JSON.stringify({ agent: "tester", mode: "run", functionalAreas }),
+      body: JSON.stringify(body),
     });
     if (!res.ok)
       throw new ToolError(

--- a/src/tests/unit/bearq/tool/environments/list-environments.test.ts
+++ b/src/tests/unit/bearq/tool/environments/list-environments.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+import { ListEnvironments } from "../../../../../bearq/tool/environments/list-environments";
+
+const fetchMock = createFetchMock(vi);
+fetchMock.enableMocks();
+
+describe("ListEnvironments", () => {
+  let mockClient: any;
+  let instance: ListEnvironments;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    mockClient = {
+      getBaseUrl: vi.fn().mockReturnValue("https://api.bearq.smartbear.com"),
+      getHeaders: vi.fn().mockReturnValue({
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      }),
+    };
+    instance = new ListEnvironments(mockClient);
+  });
+
+  it("should set specification correctly", () => {
+    expect(instance.specification.title).toBe("List Environments");
+    expect(instance.specification.readOnly).toBe(true);
+  });
+
+  it("should GET /environments with correct method and headers", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        environments: [
+          { id: 1, name: "Staging", isDefault: true },
+          { id: 2, name: "Production", isDefault: false },
+        ],
+      }),
+    );
+
+    const result = await instance.handle({}, {} as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.bearq.smartbear.com/environments",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.environments).toHaveLength(2);
+    expect(parsed.environments[0].name).toBe("Staging");
+  });
+
+  it("should throw ToolError on non-2xx response", async () => {
+    fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+    await expect(instance.handle({}, {} as any)).rejects.toThrow(
+      "GET /environments failed: 401",
+    );
+  });
+});

--- a/src/tests/unit/bearq/tool/tasks/run-regression-tests.test.ts
+++ b/src/tests/unit/bearq/tool/tasks/run-regression-tests.test.ts
@@ -45,6 +45,23 @@ describe("RunRegressionTests", () => {
     expect(parsed.taskIds).toEqual([7]);
   });
 
+  it("should include environment in body when provided", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ taskIds: [7] }));
+
+    await instance.handle({ environment: "Staging" }, {} as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.bearq.smartbear.com/tasks",
+      expect.objectContaining({
+        body: JSON.stringify({
+          agent: "tester",
+          mode: "run",
+          environment: "Staging",
+        }),
+      }),
+    );
+  });
+
   it("should throw ToolError on non-2xx response", async () => {
     fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
     await expect(instance.handle({}, {} as any)).rejects.toThrow(

--- a/src/tests/unit/bearq/tool/tasks/run-test-cases.test.ts
+++ b/src/tests/unit/bearq/tool/tasks/run-test-cases.test.ts
@@ -49,6 +49,27 @@ describe("RunTestCases", () => {
     expect(parsed.taskIds).toEqual([42]);
   });
 
+  it("should include environment in body when provided", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ taskIds: [42] }));
+
+    await instance.handle(
+      { testCaseIds: [1, 2, 3], environment: "Staging" },
+      {} as any,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.bearq.smartbear.com/tasks",
+      expect.objectContaining({
+        body: JSON.stringify({
+          agent: "tester",
+          mode: "run",
+          testCaseIds: [1, 2, 3],
+          environment: "Staging",
+        }),
+      }),
+    );
+  });
+
   it("should throw ToolError on non-2xx response", async () => {
     fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
     await expect(

--- a/src/tests/unit/bearq/tool/tasks/run-tests-in-functional-areas.test.ts
+++ b/src/tests/unit/bearq/tool/tasks/run-tests-in-functional-areas.test.ts
@@ -72,6 +72,27 @@ describe("RunTestsInFunctionalAreas", () => {
     );
   });
 
+  it("should include environment in body when provided", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ taskIds: [8] }));
+
+    await instance.handle(
+      { functionalAreas: [1, "Cart"], environment: "Staging" },
+      {} as any,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.bearq.smartbear.com/tasks",
+      expect.objectContaining({
+        body: JSON.stringify({
+          agent: "tester",
+          mode: "run",
+          functionalAreas: [1, "Cart"],
+          environment: "Staging",
+        }),
+      }),
+    );
+  });
+
   it("should throw ToolError on non-2xx response", async () => {
     fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
     await expect(

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -122,7 +122,7 @@ exports[`server definitions are not changed unexpectedly > registered tools 1`] 
     },
     "description": "Lists the environments configured in the workspace. Use this to discover valid environment names to pass to the test-running tools, and to identify the workspace default.
 
-**Toolset:** Tasks
+**Toolset:** Environments
 
 **Parameters:**
 None",

--- a/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/server-definitions.test.ts.snap
@@ -112,6 +112,24 @@ exports[`server definitions are not changed unexpectedly > registered tools 1`] 
     "outputSchema": undefined,
     "title": "BearQ: Get Task Status",
   },
+  "bearq_list_environments": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "BearQ: List Environments",
+    },
+    "description": "Lists the environments configured in the workspace. Use this to discover valid environment names to pass to the test-running tools, and to identify the workspace default.
+
+**Toolset:** Tasks
+
+**Parameters:**
+None",
+    "inputSchema": [],
+    "outputSchema": undefined,
+    "title": "BearQ: List Environments",
+  },
   "bearq_refine_all_draft_tests": {
     "annotations": {
       "destructiveHint": false,
@@ -183,8 +201,10 @@ None",
 **Toolset:** Tasks
 
 **Parameters:**
-None",
-    "inputSchema": [],
+- environment (string): Target environment name to run tests against. Omit to use the workspace default.",
+    "inputSchema": [
+      "environment",
+    ],
     "outputSchema": undefined,
     "title": "BearQ: Run Regression Tests",
   },
@@ -201,8 +221,10 @@ None",
 **Toolset:** Tasks
 
 **Parameters:**
-- testCaseIds (array) *required*: IDs of BearQ regression test cases to run.",
+- testCaseIds (array) *required*: IDs of BearQ regression test cases to run.
+- environment (string): Target environment name to run tests against. Omit to use the workspace default.",
     "inputSchema": [
+      "environment",
       "testCaseIds",
     ],
     "outputSchema": undefined,
@@ -221,8 +243,10 @@ None",
 **Toolset:** Tasks
 
 **Parameters:**
-- functionalAreas (array) *required*: Functional areas to target, by ID or name.",
+- functionalAreas (array) *required*: Functional areas to target, by ID or name.
+- environment (string): Target environment name to run tests against. Omit to use the workspace default.",
     "inputSchema": [
+      "environment",
       "functionalAreas",
     ],
     "outputSchema": undefined,


### PR DESCRIPTION
## Goal
Let BearQ MCP users run tests against a specific environment and discover which environments exist.

## Design
Adds an optional `environment` name param to the run tools and a read-only environment listing tool.

## Changeset
- Add `environment` param to `run_regression_tests`, `run_test_cases`, `run_tests_in_functional_areas`
- Add `bearq_list_environments` tool
- Update BearQ docs

## Testing
- Verified new tool + param works for BearQ