### PR TITLE
feat(functional-testing): add test history tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
+
 ## [0.30.0] - 2026-07-16
 
 ### Added
 
 - [Swagger] Added output schemas to Swagger Portal and Registry tools, enabling structured, validated responses for all portal, product, section, document, table-of-contents, and registry operations.
 - [Swagger] Introduced tool constants (`READ_ONLY`, `WRITE`, `WRITE_DESTRUCTIVE`) to annotate each Swagger tool with semantic flags (`readOnly`, `openWorld`, `destructive`) for better client-side tool classification.
-- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Added output schemas to Swagger Portal and Registry tools, enabling structured, validated responses for all portal, product, section, document, table-of-contents, and registry operations.
 - [Swagger] Introduced tool constants (`READ_ONLY`, `WRITE`, `WRITE_DESTRUCTIVE`) to annotate each Swagger tool with semantic flags (`readOnly`, `openWorld`, `destructive`) for better client-side tool classification.
+- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
 
 ### Changed
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -22,6 +22,7 @@ import type {
   ListFunctionalTestingSuiteExecutionsParams,
   RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
+  TestRunHistoryResponse,
 } from "./client/functional-testing-types";
 import {
   type ApiDefinitionParams,
@@ -425,7 +426,7 @@ export class SwaggerClient implements Client {
 
   async getFunctionalTestingTestHistory(
     args: GetFunctionalTestHistoryParams,
-  ): Promise<unknown> {
+  ): Promise<TestRunHistoryResponse> {
     return this.withFunctionalTesting((ftApi) => ftApi.getTestHistory(args));
   }
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,6 +16,7 @@ import {
 } from "./client/functional-testing-api";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
   ListFunctionalTestingSuiteExecutionsParams,
@@ -420,6 +421,12 @@ export class SwaggerClient implements Client {
 
   async listFunctionalTestingSuites(): Promise<unknown> {
     return this.withFunctionalTesting((ftApi) => ftApi.listSuites());
+  }
+
+  async getFunctionalTestingTestHistory(
+    args: GetFunctionalTestHistoryParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.getTestHistory(args));
   }
 
   async registerTools(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -287,27 +287,13 @@ export class FunctionalTestingAPI {
     if (args.offset !== undefined) params.set("offset", String(args.offset));
     const query = params.toString() ? `?${params.toString()}` : "";
 
-    const headers = this.getFtHeaders();
-    let response: Response;
-    try {
-      response = await fetch(
-        `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/runs${query}`,
-        {
-          method: "GET",
-          headers,
-        },
-      );
-    } catch {
-      throw new ToolError(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
-      );
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      throw new ToolError(
-        "Authentication failed. Verify your API token is valid and has not expired.",
-      );
-    }
+    const response = await this.ftFetch(
+      `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/runs${query}`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+    );
 
     if (response.status === 404) {
       throw new ToolError(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -285,13 +285,13 @@ export class FunctionalTestingAPI {
     const params = new URLSearchParams();
     if (args.limit !== undefined) params.set("limit", String(args.limit));
     if (args.offset !== undefined) params.set("offset", String(args.offset));
-    const query = params.toString() ? `?${params}` : "";
+    const query = params.toString() ? `?${params.toString()}` : "";
 
     const headers = this.getFtHeaders();
     let response: Response;
     try {
       response = await fetch(
-        `${this.baseUrl}/tests/${args.testId}/runs${query}`,
+        `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/runs${query}`,
         {
           method: "GET",
           headers,

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -2,6 +2,7 @@ import { appendClientIdentity } from "../../common/info";
 import { ToolError } from "../../common/tools";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
   ListFunctionalTestingSuiteExecutionsParams,
@@ -9,6 +10,7 @@ import type {
   ListSuitesResponse,
   RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
+  TestRunHistoryResponse,
 } from "./functional-testing-types";
 
 const API_HOSTNAME = "api.reflect.run";
@@ -273,6 +275,53 @@ export class FunctionalTestingAPI {
       }
     }
     return data;
+  }
+
+  async getTestHistory(
+    args: GetFunctionalTestHistoryParams,
+  ): Promise<TestRunHistoryResponse> {
+    if (!args.testId) throw new ToolError("testId argument is required");
+
+    const params = new URLSearchParams();
+    if (args.limit !== undefined) params.set("limit", String(args.limit));
+    if (args.offset !== undefined) params.set("offset", String(args.offset));
+    const query = params.toString() ? `?${params}` : "";
+
+    const headers = this.getFtHeaders();
+    let response: Response;
+    try {
+      response = await fetch(
+        `${this.baseUrl}/tests/${args.testId}/runs${query}`,
+        {
+          method: "GET",
+          headers,
+        },
+      );
+    } catch {
+      throw new ToolError(
+        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
+      );
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ToolError(
+        "Authentication failed. Verify your API token is valid and has not expired.",
+      );
+    }
+
+    if (response.status === 404) {
+      throw new ToolError(
+        "Test not found. Verify the testId belongs to your workspace.",
+      );
+    }
+
+    if (!response.ok) {
+      throw new ToolError(
+        `Failed to get test execution history: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
   }
 
   private async withoutField(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -295,10 +295,7 @@ export class FunctionalTestingAPI {
       },
       handleStatus(
         new Map([
-          [
-            404,
-            "Test not found. Verify the testId belongs to your workspace.",
-          ],
+          [404, "Test not found. Verify the testId belongs to your workspace."],
         ]),
         errorMessageFor("get test execution history"),
       ),

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -288,24 +288,21 @@ export class FunctionalTestingAPI {
     const query = params.toString() ? `?${params.toString()}` : "";
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/runs${query}`,
+      `tests/${encodeURIComponent(args.testId)}/runs${query}`,
       {
         method: "GET",
         headers: this.getFtHeaders(),
       },
+      handleStatus(
+        new Map([
+          [
+            404,
+            "Test not found. Verify the testId belongs to your workspace.",
+          ],
+        ]),
+        errorMessageFor("get test execution history"),
+      ),
     );
-
-    if (response.status === 404) {
-      throw new ToolError(
-        "Test not found. Verify the testId belongs to your workspace.",
-      );
-    }
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to get test execution history: ${response.status} ${response.statusText}`,
-      );
-    }
 
     return response.json();
   }

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -112,6 +112,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     toolset: "Functional Testing",
     summary:
       "Retrieves the execution history for a given test in your Swagger Functional Testing workspace. " +
+      "Returns a list of past runs, each including pass/fail status, run time, creation timestamp, " +
+      "and — for failed runs — a per-step breakdown of failure details. " +
       "Use this tool when you need to check past run results, identify failures, or assess test reliability over time. " +
       "Do not use this tool to run a test or retrieve suite-level execution results.",
     inputSchema: GetFunctionalTestHistoryParamsSchema,

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,5 +1,6 @@
 import {
   CancelFunctionalTestingSuiteExecutionSchema,
+  GetFunctionalTestHistoryParamsSchema,
   GetFunctionalTestingExecutionTestSchema,
   GetFunctionalTestingSuiteExecutionSchema,
   ListFunctionalTestingSuiteExecutionsSchema,
@@ -103,6 +104,18 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Requires both `suiteId` and the `executionId` arguments returned by `swagger_run_suite`.",
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
+    idempotent: true,
+    readOnly: true,
+  },
+  {
+    title: "Get Test Execution History",
+    toolset: "Functional Testing",
+    summary:
+      "Retrieves the execution history for a given test in your Swagger Functional Testing workspace. " +
+      "Use this tool when you need to check past run results, identify failures, or assess test reliability over time. " +
+      "Do not use this tool to run a test or retrieve suite-level execution results.",
+    inputSchema: GetFunctionalTestHistoryParamsSchema,
+    handler: "getFunctionalTestingTestHistory",
     idempotent: true,
     readOnly: true,
   },

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -147,7 +147,7 @@ export type GetFunctionalTestHistoryParams = z.infer<
 export interface TestRun {
   id: number;
   passed: boolean;
-  created: string;
+  created: number;
   runTime: number;
   failureDetails?: {
     stepCount: number;

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -118,3 +118,49 @@ export interface ListSuitesResponse {
     cumExecTimeSecs: number;
   };
 }
+
+export const GetFunctionalTestHistoryParamsSchema = z.object({
+  testId: z
+    .string()
+    .describe("ID of the Functional Testing test")
+    .trim()
+    .min(1),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Number of most recent runs to return (default: 10)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Pagination offset (default: 0)"),
+});
+
+export type GetFunctionalTestHistoryParams = z.infer<
+  typeof GetFunctionalTestHistoryParamsSchema
+>;
+
+export interface TestRun {
+  id: number;
+  passed: boolean;
+  created: string;
+  runTime: number;
+  failureDetails?: {
+    stepCount: number;
+    failedStepsByIndex: Record<string, { summaryErrorMessage: string | null }>;
+  };
+  suiteExecution?: {
+    executionId: number;
+    slug: string;
+    attemptNumber: number;
+    originExecutionId: number | null;
+  };
+}
+
+export interface TestRunHistoryResponse {
+  totalRuns: number;
+  runs: TestRun[];
+}

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -129,8 +129,9 @@ export const GetFunctionalTestHistoryParamsSchema = z.object({
     .number()
     .int()
     .min(1)
+    .max(100)
     .optional()
-    .describe("Number of most recent runs to return (default: 10)"),
+    .describe("Number of most recent runs to return (default: 25, max: 100)"),
   offset: z
     .number()
     .int()

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -402,4 +402,64 @@ describe("SwaggerClient — Functional Testing integration", () => {
       expect(result).toEqual(suiteExecutionMock);
     });
   });
+
+  describe("getFunctionalTestingTestHistory", () => {
+    const historyMock = {
+      totalRuns: 5,
+      runs: [
+        { id: 1, passed: true, created: "2026-06-10T10:00:00Z", runTime: 4200 },
+      ],
+    };
+
+    it("should delegate to the API and return results", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(historyMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.getFunctionalTestingTestHistory({ testId: "test-1" }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests/test-1/runs",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(historyMock);
+    });
+
+    it("should pass limit and offset query params through", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(historyMock));
+
+      await client.configure({} as any, {
+        functional_testing_api_token: "ft-token",
+      });
+
+      await requestContextStorage.run({ headers: {} }, () =>
+        client.getFunctionalTestingTestHistory({
+          testId: "test-1",
+          limit: 5,
+          offset: 20,
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests/test-1/runs?limit=5&offset=20",
+        expect.anything(),
+      );
+    });
+
+    it("should throw when FT API is not configured", async () => {
+      await client.configure({} as any, { api_key: "swagger-key" });
+
+      await expect(
+        client.getFunctionalTestingTestHistory({ testId: "test-1" }),
+      ).rejects.toThrow("Functional Testing API not configured");
+    });
+  });
 });


### PR DESCRIPTION
## Goal
Implements Functional Testing tool for test history fetching.

Extends the SFT toolset with `get_test_execution_history`.
- `get_test_execution_history` retrieves the execution history for a given test, returning a paginated list of past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.

## Design
New tool delegates through a `SwaggerClient` method, the API call lives in `FunctionalTestingAPI`. The endpoint is called via `GET /tests/{testId}/runs` with optional `limit` and `offset` query parameters for pagination. 

## Changeset
- Added `getTestHistory` method to `FunctionalTestingAPI` and wired it through `SwaggerClient`
as `getFunctionalTestingTestHisto
- Added `GetFunctionalTestHistoryParamsSchema` Zod input schema
- Added `TestRun` and `TestRunHis

## Testing
- [X] Unit tests added
- [X] Manual local testing of new SFT tool performed
