### PR TITLE
refactor(functional-testing): Unify error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Common] Co-located all unit test files with their source files (`path/to/file.ts` → `path/to/file.test.ts`), removing the top-level `src/tests/unit/` directory. Updated `vitest.config.ts` include/exclude globs and coverage excludes accordingly.
+- [Swagger] Refactor error handling for Functional Testing tools
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Reflect] Add create_test and create_segment tools to enable agents to port tests from open source frameworks (Selenium, Cypress, Playwright) and other SmartBear products (TestComplete, BearQ) to Reflect.
 
+- [Swagger] Refactor error handling for Functional Testing tools
+
 ### Fixed
 
 - [Pactflow] Corrected MCP tool hint annotations for all 102 PactFlow tools. Previously, `readOnlyHint` defaulted to `true` for every tool because no tool explicitly set `readOnly`, causing write/delete operations to be misreported as read-only. All tools now declare all four hints explicitly: `readOnly` (58 read-only, 44 write), `destructive` (true for DELETE ops, `resetAdminRoles`, and `regenerateToken`), `idempotent` (false for creates, records, patch, execute, and invite operations), and `openWorld` (true for `executeWebhook`, `executeWebhooks`, and `inviteUsers` which trigger external HTTP requests or send emails).
@@ -27,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Common] Co-located all unit test files with their source files (`path/to/file.ts` → `path/to/file.test.ts`), removing the top-level `src/tests/unit/` directory. Updated `vitest.config.ts` include/exclude globs and coverage excludes accordingly.
-- [Swagger] Refactor error handling for Functional Testing tools
 
 ### Security
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -38,10 +38,22 @@ export class FunctionalTestingAPI {
     };
   }
 
-  private async ftFetch(input: string, init: RequestInit): Promise<Response> {
+  /**
+   * Wrapper around the fetch function for the Functional Testting API. It generates the full URL and performs
+   * common error handling.
+   * @param relativePath Path of the resource to fetch relative to the base URL
+   * @param init RequestInit passed to the fetch function
+   * @param onFailure Handler that generates the error message for failed responses
+   * @returns Response having asserted it has not failed (status is 2xx)
+   */
+  private async ftFetch(
+    relativePath: string,
+    init: RequestInit,
+    onFailure: errorMessageFn,
+  ): Promise<Response> {
     let response: Response;
     try {
-      response = await fetch(input, init);
+      response = await fetch(`${this.baseUrl}/${relativePath}`, init);
     } catch {
       throw new ToolError(
         "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
@@ -54,20 +66,22 @@ export class FunctionalTestingAPI {
       );
     }
 
+    if (!response.ok) {
+      throw new ToolError(onFailure(response));
+    }
+
     return response;
   }
 
   async listTests(): Promise<unknown> {
-    const response = await this.ftFetch(`${this.baseUrl}/tests`, {
-      method: "GET",
-      headers: this.getFtHeaders(),
-    });
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to list Functional Testing tests: ${response.status} ${response.statusText}`,
-      );
-    }
+    const response = await this.ftFetch(
+      `tests`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+      errorMessageFor(`list Functional Testing tests`),
+    );
 
     return response.json();
   }
@@ -76,18 +90,13 @@ export class FunctionalTestingAPI {
     if (!args.testId) throw new ToolError("testId argument is required");
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/tests/${encodeURIComponent(args.testId)}/executions`,
+      `tests/${encodeURIComponent(args.testId)}/executions`,
       {
         method: "POST",
         headers: this.getFtHeaders(),
       },
+      errorMessageFor(`run test`),
     );
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to run test: ${response.status} ${response.statusText}`,
-      );
-    }
 
     return response.json();
   }
@@ -100,18 +109,13 @@ export class FunctionalTestingAPI {
     }
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/executions/${encodeURIComponent(args.executionId)}`,
+      `executions/${encodeURIComponent(args.executionId)}`,
       {
         method: "GET",
         headers: this.getFtHeaders(),
       },
+      errorMessageFor("get test status"),
     );
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to get test status: ${response.status} ${response.statusText}`,
-      );
-    }
 
     const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns video recording URL for each test run, which SFT does not need so we remove it.
@@ -132,16 +136,25 @@ export class FunctionalTestingAPI {
     if (!args.suiteId) throw new ToolError("suiteId argument is required");
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/suites/${encodeURIComponent(args.suiteId)}/executions`,
+      `suites/${encodeURIComponent(args.suiteId)}/executions`,
       {
         method: "GET",
         headers: this.getFtHeaders(),
       },
+      handleStatus(
+        new Map([
+          // Defensive: the Reflect API currently returns 200 with an empty
+          // `executions.data` list for an unknown suiteId rather than a 404, so this
+          // branch is not expected to fire today. Kept in case the API starts
+          // returning 404 for missing suites.
+          [
+            404,
+            "Test suite not found. Verify the suiteId is correct and belongs to your workspace.",
+          ],
+        ]),
+        errorMessageFor("list suite executions"),
+      ),
     );
-
-    if (!response.ok) {
-      throw new ToolError(suiteExecutionsErrorMessage(response));
-    }
 
     const data: ListSuiteExecutionsResponse = await response.json();
     // Will be adjusted after https://smartbear.atlassian.net/browse/RF-5271 is done
@@ -159,16 +172,14 @@ export class FunctionalTestingAPI {
     };
   }
   async listSuites(): Promise<ListSuitesResponse> {
-    const response = await this.ftFetch(`${this.baseUrl}/suites`, {
-      method: "GET",
-      headers: this.getFtHeaders(),
-    });
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to list Functional Testing suites: ${response.status} ${response.statusText}`,
-      );
-    }
+    const response = await this.ftFetch(
+      `suites`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+      errorMessageFor("list Functional Testing suites"),
+    );
 
     return response.json();
   }
@@ -182,16 +193,25 @@ export class FunctionalTestingAPI {
     }
 
     const response = await this.ftFetch(
-      `${this.baseUrl}/suites/${encodeURIComponent(args.suiteId)}/executions/${encodeURIComponent(args.executionId)}/cancel`,
+      `suites/${encodeURIComponent(args.suiteId)}/executions/${encodeURIComponent(args.executionId)}/cancel`,
       {
         method: "PATCH",
         headers: this.getFtHeaders(),
       },
+      handleStatus(
+        new Map([
+          [
+            404,
+            "Suite execution not found. Verify the suiteId and executionId are correct and belong to your workspace.",
+          ],
+          [
+            409,
+            "Suite execution cannot be cancelled because it has already finished.",
+          ],
+        ]),
+        errorMessageFor("cancel suite execution"),
+      ),
     );
-
-    if (!response.ok) {
-      throw new ToolError(cancelSuiteExecutionErrorMessage(response));
-    }
 
     return response.json();
   }
@@ -205,33 +225,15 @@ export class FunctionalTestingAPI {
         })
       : undefined;
 
-    let response: Response;
-    try {
-      response = await fetch(
-        `${this.baseUrl}/suites/${args.suiteId}/executions`,
-        {
-          method: "POST",
-          headers: this.getFtHeaders(),
-          body,
-        },
-      );
-    } catch {
-      throw new ToolError(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
-      );
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      throw new ToolError(
-        "Authentication failed. Verify your API token is valid and has not expired.",
-      );
-    }
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to run suite: ${response.status} ${response.statusText}`,
-      );
-    }
+    const response = await this.ftFetch(
+      `suites/${args.suiteId}/executions`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+        body,
+      },
+      errorMessageFor("run suite"),
+    );
 
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
@@ -246,32 +248,14 @@ export class FunctionalTestingAPI {
       throw new ToolError("executionId argument is required");
     }
 
-    let response: Response;
-    try {
-      response = await fetch(
-        `${this.baseUrl}/suites/${args.suiteId}/executions/${args.executionId}`,
-        {
-          method: "GET",
-          headers: this.getFtHeaders(),
-        },
-      );
-    } catch {
-      throw new ToolError(
-        "Swagger Functional Testing service is currently unreachable. Retry after a moment.",
-      );
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      throw new ToolError(
-        "Authentication failed. Verify your API token is valid and has not expired.",
-      );
-    }
-
-    if (!response.ok) {
-      throw new ToolError(
-        `Failed to get suite execution status: ${response.status} ${response.statusText}`,
-      );
-    }
+    const response = await this.ftFetch(
+      `suites/${args.suiteId}/executions/${args.executionId}`,
+      {
+        method: "GET",
+        headers: this.getFtHeaders(),
+      },
+      errorMessageFor("get suite execution status"),
+    );
 
     // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
     // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
@@ -300,26 +284,32 @@ export class FunctionalTestingAPI {
   }
 }
 
-function suiteExecutionsErrorMessage(response: Response): string {
-  switch (response.status) {
-    // Defensive: the Reflect API currently returns 200 with an empty
-    // `executions.data` list for an unknown suiteId rather than a 404, so this
-    // branch is not expected to fire today. Kept in case the API starts
-    // returning 404 for missing suites.
-    case 404:
-      return "Test suite not found. Verify the suiteId is correct and belongs to your workspace.";
-    default:
-      return `Failed to list suite executions: ${response.status} ${response.statusText}`;
-  }
+/**
+ * Maps a failed (status code other than 2xx) HTTP response to a string explaining the failure.
+ */
+type errorMessageFn = (response: Response) => string;
+
+/**
+ * Returns an error message handler that selects the message to return based on the
+ * response's status code. If no match is found, delegates on the default function
+ * @param messages Map associating status code -> error message
+ * @param defaultMessage Default function if no entry is found in the map for the responses status code
+ */
+function handleStatus(
+  messages: Map<number, string>,
+  defaultMessage: errorMessageFn,
+): errorMessageFn {
+  return (response) =>
+    messages.get(response.status) || defaultMessage(response);
 }
 
-function cancelSuiteExecutionErrorMessage(response: Response): string {
-  switch (response.status) {
-    case 404:
-      return "Suite execution not found. Verify the suiteId and executionId are correct and belong to your workspace.";
-    case 409:
-      return "Suite execution cannot be cancelled because it has already finished.";
-    default:
-      return `Failed to cancel suite execution: ${response.status} ${response.statusText}`;
-  }
+/**
+ * Returns an error message handler that renders a message based on the responses
+ * status code, status text as well as the given operation. The operation is concatenated
+ * so must not start with uppercase
+ * @param operation description of the attempted operation
+ */
+function errorMessageFor(operation: string): errorMessageFn {
+  return (response) =>
+    `Failed to ${operation}: ${response.status} ${response.statusText}`;
 }

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -39,7 +39,7 @@ export class FunctionalTestingAPI {
   }
 
   /**
-   * Wrapper around the fetch function for the Functional Testting API. It generates the full URL and performs
+   * Wrapper around the fetch function for the Functional Testing API. It generates the full URL and performs
    * common error handling.
    * @param relativePath Path of the resource to fetch relative to the base URL
    * @param init RequestInit passed to the fetch function
@@ -49,7 +49,7 @@ export class FunctionalTestingAPI {
   private async ftFetch(
     relativePath: string,
     init: RequestInit,
-    onFailure: errorMessageFn,
+    onFailure: ErrorMessageFn,
   ): Promise<Response> {
     let response: Response;
     try {
@@ -171,6 +171,7 @@ export class FunctionalTestingAPI {
       },
     };
   }
+
   async listSuites(): Promise<ListSuitesResponse> {
     const response = await this.ftFetch(
       `suites`,
@@ -287,7 +288,7 @@ export class FunctionalTestingAPI {
 /**
  * Maps a failed (status code other than 2xx) HTTP response to a string explaining the failure.
  */
-type errorMessageFn = (response: Response) => string;
+type ErrorMessageFn = (response: Response) => string;
 
 /**
  * Returns an error message handler that selects the message to return based on the
@@ -297,8 +298,8 @@ type errorMessageFn = (response: Response) => string;
  */
 function handleStatus(
   messages: Map<number, string>,
-  defaultMessage: errorMessageFn,
-): errorMessageFn {
+  defaultMessage: ErrorMessageFn,
+): ErrorMessageFn {
   return (response) =>
     messages.get(response.status) || defaultMessage(response);
 }
@@ -309,7 +310,7 @@ function handleStatus(
  * so must not start with uppercase
  * @param operation description of the attempted operation
  */
-function errorMessageFor(operation: string): errorMessageFn {
+function errorMessageFor(operation: string): ErrorMessageFn {
   return (response) =>
     `Failed to ${operation}: ${response.status} ${response.statusText}`;
 }


### PR DESCRIPTION
## Goal

As the Swagger Functional Testing toolset grows, common logic such as error handling from the Functional Testing API responses is appearing. The goal of this PR is to make the addition of new tools easier, as well as to follow DRY principles.

## Design

Refactor the Functional Testing API to extend the utility wrapper around the `fetch` function with common error handling and base URL

## Changeset

* Handle common error responses (authentication errors)
* Add extensibility to handle error responses specific to the given operation
* Remove need to include base URL in every API call

## Testing

No new functionality was added, testing that the existing tools behave as before and unit tests are not broken