### PR TITLE
[Reflect] RF-5198: Add new create_test and create_segment MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- [Reflect] Add create_test and create_segment tools to enable agents to port tests from open source frameworks (Selenium, Cypress, Playwright) and other SmartBear products (TestComplete, BearQ) to Reflect.
+
 ### Fixed
 
 - [Pactflow] Corrected MCP tool hint annotations for all 102 PactFlow tools. Previously, `readOnlyHint` defaulted to `true` for every tool because no tool explicitly set `readOnly`, causing write/delete operations to be misreported as read-only. All tools now declare all four hints explicitly: `readOnly` (58 read-only, 44 write), `destructive` (true for DELETE ops, `resetAdminRoles`, and `regenerateToken`), `idempotent` (false for creates, records, patch, execute, and invite operations), and `openWorld` (true for `executeWebhook`, `executeWebhooks`, and `inviteUsers` which trigger external HTTP requests or send emails).

--- a/docs/products/SmartBear MCP Server/reflect-integration.md
+++ b/docs/products/SmartBear MCP Server/reflect-integration.md
@@ -75,12 +75,26 @@ The Reflect client provides test management, execution, and test authoring capab
 
 ### Test Authoring & Agent Interaction
 
+#### `create_test`
+
+- Purpose: Create a new Reflect test from an ordered list of steps.
+- Parameters: Name (`name`), platform (`type`: `web`, `api`, or `native-mobile`), ordered `steps`, and optional `description`, `parameters`, and `deviceProfile` (for `web` tests). Each step's `type` (e.g. `click`, `input`, `text-validation`, `prompt`, `segment`) determines its required fields; the tool schema describes the available options.
+- Returns: The id of the created test.
+- Use case: Import tests from other frameworks (Selenium, Cypress, Playwright) or SmartBear products (TestComplete, BearQ) into Reflect.
+
 #### `list_segments`
 
 - Purpose: List reusable test step segments available in the account.
 - Parameters: Platform (`platform`), optional offset and limit for pagination (`offset`, `limit`).
 - Returns: List of segments along with relevant metadata.
 - Use case: Discover reusable steps that can help accomplish a task more efficiently.
+
+#### `create_segment`
+
+- Purpose: Create a new reusable segment from an ordered list of steps. Segments can be referenced from tests but cannot reference other segments.
+- Parameters: Name (`name`), platform (`type`: `web`, `api`, or `native-mobile`), ordered `steps`, and optional `description`, `parameters`, and `deviceProfile` (for `web` segments).
+- Returns: The id of the created segment.
+- Use case: Build reusable step groups to share across multiple tests.
 
 #### `connect_to_session`
 

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -10584,6 +10584,66 @@ Expected Output: Tool is NOT called yet. Inform the user that 'critical' was not
     "outputSchema": undefined,
     "title": "Reflect: Connect To Session",
   },
+  "reflect_create_segment": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Create Segment",
+    },
+    "description": "Create a new Reflect segment which contains an ordered list of steps. Segments are reusable groups of steps that can be referenced from tests, and cannot reference other segments.
+
+**Toolset:** Tests
+
+**Parameters:**
+- name (string) *required*: Name of the segment to create.
+- type (enum) *required*: Platform of the segment.
+- description (string): Optional description of the segment.
+- deviceProfile (string): Device profile id. Required for a 'web' segment; ignored for 'api' and 'native-mobile'. One of: 'desktop', 'tablet', 'mobile'.
+- steps (array) *required*: Ordered list of steps that make up the segment. Segments cannot reference other segments. Prefer deterministic, selector-based steps ('click', 'input', 'submit', 'text-validation', 'hover', etc.) over AI-driven 'prompt' steps whenever a stable selector is available. Reserve 'prompt' steps for behavior that can't be expressed with a selector. Any text field in a step (e.g. 'inputText', 'url', 'expectedText', 'requestBody', header values, prompt text) may embed Reflect variable and function references using '\${...}' syntax, which are resolved at run time: '\${var(name)}' inserts the value of a parameter/variable named 'name' (declare parameters via the top-level 'parameters' field, or assign them mid-run with an 'update-parameters' step); '\${sec(name)}' inserts the value of the account secret 'name'. Functions generate dynamic values: '\${alphanum(n)}', '\${alpha(n)}', '\${num(n)}' (random alphanumeric / alphabetic / numeric string of length n), '\${range(min, max)}' (random integer, inclusive), '\${time(offsetMs)}' and '\${datetime(offsetMs)}' (current epoch-millis / date-time, with an optional millisecond offset), and '\${date(format, offsetDays)}' (current date formatted with tokens like 'MM/dd/yyyy', with an optional day offset).
+- parameters (array): Optional named parameters (variables) for the segment, each with a 'name' and optional default 'value'. Reference a parameter's value inside any step text field with '\${var(name)}'.",
+    "inputSchema": [
+      "description",
+      "deviceProfile",
+      "name",
+      "parameters",
+      "steps",
+      "type",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Create Segment",
+  },
+  "reflect_create_test": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Reflect: Create Test",
+    },
+    "description": "Create a new Reflect test which contains an ordered list of steps.
+
+**Toolset:** Tests
+
+**Parameters:**
+- name (string) *required*: Name of the test to create.
+- type (enum) *required*: Platform of the test.
+- description (string): Optional description of the test.
+- deviceProfile (string): Device profile id. Required for a 'web' test; ignored for 'api' and 'native-mobile'. One of: 'desktop', 'tablet', 'mobile'.
+- steps (array) *required*: Ordered list of steps that make up the test. Web tests must begin with a 'browser-navigate' step. Prefer deterministic, selector-based steps ('click', 'input', 'submit', 'text-validation', 'hover', etc.) over AI-driven 'prompt' steps whenever a stable selector is available. Reserve 'prompt' steps for behavior that can't be expressed with a selector. Any text field in a step (e.g. 'inputText', 'url', 'expectedText', 'requestBody', header values, prompt text) may embed Reflect variable and function references using '\${...}' syntax, which are resolved at run time: '\${var(name)}' inserts the value of a parameter/variable named 'name' (declare parameters via the top-level 'parameters' field, or assign them mid-run with an 'update-parameters' step); '\${sec(name)}' inserts the value of the account secret 'name'. Functions generate dynamic values: '\${alphanum(n)}', '\${alpha(n)}', '\${num(n)}' (random alphanumeric / alphabetic / numeric string of length n), '\${range(min, max)}' (random integer, inclusive), '\${time(offsetMs)}' and '\${datetime(offsetMs)}' (current epoch-millis / date-time, with an optional millisecond offset), and '\${date(format, offsetDays)}' (current date formatted with tokens like 'MM/dd/yyyy', with an optional day offset).
+- parameters (array): Optional named parameters (variables) for the test, each with a 'name' and optional default 'value'. Reference a parameter's value inside any step text field with '\${var(name)}'.",
+    "inputSchema": [
+      "description",
+      "deviceProfile",
+      "name",
+      "parameters",
+      "steps",
+      "type",
+    ],
+    "outputSchema": undefined,
+    "title": "Reflect: Create Test",
+  },
   "reflect_delete_previous_step": {
     "annotations": {
       "destructiveHint": true,

--- a/src/reflect/client.ts
+++ b/src/reflect/client.ts
@@ -26,6 +26,8 @@ import { ExecuteSuite } from "./tool/suites/execute-suite";
 import { GetSuiteExecutionStatus } from "./tool/suites/get-suite-execution-status";
 import { ListSuiteExecutions } from "./tool/suites/list-suite-executions";
 import { ListSuites } from "./tool/suites/list-suites";
+import { CreateSegment } from "./tool/tests/create-segment";
+import { CreateTest } from "./tool/tests/create-test";
 import { GetTestDetail } from "./tool/tests/get-test-detail";
 import { GetTestStatus } from "./tool/tests/get-test-status";
 import { ListSegments } from "./tool/tests/list-segments";
@@ -189,6 +191,8 @@ export class ReflectClient implements Client {
       new GetTestDetail(this),
       new RunTest(this),
       new GetTestStatus(this),
+      new CreateTest(this),
+      new CreateSegment(this),
     ];
 
     // Available for both OAuth and API key authentication

--- a/src/reflect/tool/tests/create-segment.test.ts
+++ b/src/reflect/tool/tests/create-segment.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+import { CreateSegment } from "./create-segment";
+
+const fetchMock = createFetchMock(vi);
+fetchMock.enableMocks();
+
+const segmentArgs = {
+  name: "Login Flow",
+  type: "web",
+  deviceProfile: "desktop",
+  steps: [
+    { type: "input", selector: "#user", inputText: "alice" },
+    { type: "click", selector: "#submit" },
+  ],
+};
+
+describe("CreateSegment", () => {
+  let mockClient: any;
+  let instance: CreateSegment;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+
+    mockClient = {
+      getHeaders: vi.fn().mockReturnValue({
+        "X-API-KEY": "test-api-key",
+        "Content-Type": "application/json",
+      }),
+    };
+
+    instance = new CreateSegment(mockClient as any);
+  });
+
+  it("should set specification correctly", () => {
+    expect(instance.specification.title).toBe("Create Segment");
+    expect(instance.specification.toolset).toBe("Tests");
+    expect(instance.specification.readOnly).toBe(false);
+    expect(instance.specification.idempotent).toBe(false);
+  });
+
+  it("should not expose the 'segment' step type for segments", () => {
+    const shape = (instance.specification.inputSchema as any).shape;
+    const stepShape = shape.steps.element.shape;
+    expect(stepShape.type.options).not.toContain("segment");
+    expect(stepShape.type.options).toContain("click");
+  });
+
+  it("should POST to /v1/segments and return the created id", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ id: 7 }));
+
+    const result = await instance.handle(segmentArgs as any, {} as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.reflect.run/v1/segments",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        body: JSON.stringify(segmentArgs),
+      }),
+    );
+
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.id).toBe(7);
+    expect(parsed.message).toContain("7");
+  });
+
+  it("should throw a ToolError with the server message on failure", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        message: "Segment with name Login Flow already exists.",
+        errorId: "abc-123",
+      }),
+      { status: 400 },
+    );
+
+    await expect(
+      instance.handle(segmentArgs as any, {} as any),
+    ).rejects.toThrow("Segment with name Login Flow already exists.");
+  });
+});

--- a/src/reflect/tool/tests/create-segment.ts
+++ b/src/reflect/tool/tests/create-segment.ts
@@ -1,0 +1,26 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { ReflectClient } from "../../client";
+import {
+  buildCreateDefinitionSchema,
+  createReflectDefinition,
+} from "./definition";
+
+export class CreateSegment extends Tool<ReflectClient> {
+  specification: ToolParams = {
+    title: "Create Segment",
+    toolset: "Tests",
+    summary:
+      "Create a new Reflect segment which contains an ordered list of steps. Segments are reusable groups of steps " +
+      "that can be referenced from tests, and cannot reference other segments.",
+    readOnly: false,
+    idempotent: false,
+    inputSchema: buildCreateDefinitionSchema({ isSegment: true }),
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args) => {
+    return createReflectDefinition(this.client, "segments", "segment", args);
+  };
+}

--- a/src/reflect/tool/tests/create-test.test.ts
+++ b/src/reflect/tool/tests/create-test.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createFetchMock from "vitest-fetch-mock";
+import { CreateTest } from "./create-test";
+
+const fetchMock = createFetchMock(vi);
+fetchMock.enableMocks();
+
+const webTestArgs = {
+  name: "Login Test",
+  type: "web",
+  deviceProfile: "desktop",
+  steps: [
+    { type: "browser-navigate", url: "https://example.com" },
+    { type: "click", selector: "#login" },
+  ],
+};
+
+describe("CreateTest", () => {
+  let mockClient: any;
+  let instance: CreateTest;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+
+    mockClient = {
+      getHeaders: vi.fn().mockReturnValue({
+        "X-API-KEY": "test-api-key",
+        "Content-Type": "application/json",
+      }),
+    };
+
+    instance = new CreateTest(mockClient as any);
+  });
+
+  it("should set specification correctly", () => {
+    expect(instance.specification.title).toBe("Create Test");
+    expect(instance.specification.toolset).toBe("Tests");
+    expect(instance.specification.readOnly).toBe(false);
+    expect(instance.specification.idempotent).toBe(false);
+  });
+
+  it("should expose the 'segment' step type for tests", () => {
+    const shape = (instance.specification.inputSchema as any).shape;
+    const stepShape = shape.steps.element.shape;
+    expect(stepShape.type.options).toContain("segment");
+    expect(stepShape.type.options).toContain("browser-navigate");
+  });
+
+  it("should POST to /v1/tests and return the created id", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ id: 42 }));
+
+    const result = await instance.handle(webTestArgs as any, {} as any);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.reflect.run/v1/tests",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        body: JSON.stringify(webTestArgs),
+      }),
+    );
+
+    const parsed = JSON.parse((result.content[0] as any).text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.id).toBe(42);
+    expect(parsed.message).toContain("42");
+  });
+
+  it("should throw a ToolError with the server message on failure", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        message: "Web tests must begin with a navigation step.",
+        errorId: "abc-123",
+      }),
+      { status: 400 },
+    );
+
+    await expect(
+      instance.handle(webTestArgs as any, {} as any),
+    ).rejects.toThrow("Web tests must begin with a navigation step.");
+  });
+
+  it("should throw a ToolError even when the error body is not JSON", async () => {
+    fetchMock.mockResponseOnce("Bad Request", { status: 400 });
+
+    await expect(
+      instance.handle(webTestArgs as any, {} as any),
+    ).rejects.toThrow("Failed to create test: 400");
+  });
+
+  it("accepts valid input through the declared input schema", () => {
+    const schema = instance.specification.inputSchema as any;
+    const result = schema.safeParse(webTestArgs);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(webTestArgs);
+  });
+});

--- a/src/reflect/tool/tests/create-test.ts
+++ b/src/reflect/tool/tests/create-test.ts
@@ -1,0 +1,25 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { ReflectClient } from "../../client";
+import {
+  buildCreateDefinitionSchema,
+  createReflectDefinition,
+} from "./definition";
+
+export class CreateTest extends Tool<ReflectClient> {
+  specification: ToolParams = {
+    title: "Create Test",
+    toolset: "Tests",
+    summary:
+      "Create a new Reflect test which contains an ordered list of steps.",
+    readOnly: false,
+    idempotent: false,
+    inputSchema: buildCreateDefinitionSchema({ isSegment: false }),
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args) => {
+    return createReflectDefinition(this.client, "tests", "test", args);
+  };
+}

--- a/src/reflect/tool/tests/definition.ts
+++ b/src/reflect/tool/tests/definition.ts
@@ -1,0 +1,351 @@
+import { z } from "zod";
+import { ToolError } from "../../../common/tools";
+import type { ReflectClient } from "../../client";
+import { API_HOSTNAME } from "../../config/constants";
+
+/**
+ * Shared support for the "create test" and "create segment" tools.
+ */
+const BASE_STEP_TYPES = [
+  "click",
+  "text-validation",
+  "input",
+  "submit",
+  "scroll",
+  "focus",
+  "hover",
+  "drag-and-drop",
+  "text-highlight",
+  "browser-navigate",
+  "browser-back",
+  "browser-forward",
+  "browser-refresh",
+  "api",
+  "javascript",
+  "appium",
+  "prompt",
+  "update-parameters",
+  "wait",
+  "receive-email",
+  "receive-sms",
+  "rotate-device",
+  "reset-device",
+  "deeplink",
+  "set-device-location",
+] as const;
+
+// Tests may additionally reference an existing segment as a step; segments cannot.
+const TEST_STEP_TYPES = ["segment", ...BASE_STEP_TYPES] as const;
+
+const headerSchema = z.object({
+  name: z.string().describe("Header name."),
+  value: z.string().describe("Header value."),
+});
+
+const parameterSchema = z.object({
+  name: z.string().describe("Parameter name."),
+  value: z.string().optional().describe("Default value for the parameter."),
+});
+
+const emailFilterSchema = z.object({
+  fromAddress: z
+    .string()
+    .optional()
+    .describe("Only match emails sent from this address."),
+  fromName: z
+    .string()
+    .optional()
+    .describe("Only match emails sent from this sender name."),
+  subject: z
+    .string()
+    .optional()
+    .describe("Only match emails with this subject."),
+  toAddress: z
+    .string()
+    .optional()
+    .describe("Only match emails sent to this address."),
+});
+
+const emailSchema = z.object({
+  text: z
+    .string()
+    .optional()
+    .describe("Text to extract from, or validate against, the matched email."),
+  filters: emailFilterSchema.describe(
+    "Filters selecting which inbound email this step waits for.",
+  ),
+});
+
+const smsFilterSchema = z.object({
+  fromNumber: z
+    .string()
+    .optional()
+    .describe("Only match SMS messages sent from this number."),
+  toNumber: z
+    .string()
+    .optional()
+    .describe("Only match SMS messages sent to this number."),
+});
+
+const smsSchema = z.object({
+  text: z
+    .string()
+    .optional()
+    .describe("Text to extract from, or validate against, the matched SMS."),
+  filters: smsFilterSchema
+    .optional()
+    .describe("Filters selecting which inbound SMS this step waits for."),
+});
+
+function buildStepSchema(
+  stepTypes: readonly [string, ...string[]],
+  { includeSegmentReference }: { includeSegmentReference: boolean },
+) {
+  return z.object({
+    type: z
+      .enum(stepTypes)
+      .describe(
+        "The kind of step to perform. Determines which of the other fields are required.",
+      ),
+    description: z
+      .string()
+      .optional()
+      .describe(
+        "Human-readable description of the step. For 'prompt' steps, this field holds the natural-language instruction to execute.",
+      ),
+    selector: z
+      .string()
+      .optional()
+      .describe(
+        "CSS selector of the target element. Used by 'click', 'input', 'submit', 'scroll', 'focus', 'hover', 'text-validation', 'text-highlight', and the source element of 'drag-and-drop'.",
+      ),
+    tag: z
+      .string()
+      .optional()
+      .describe("Tag name of the target element (e.g. 'button', 'input')."),
+    toSelector: z
+      .string()
+      .optional()
+      .describe(
+        "CSS selector of the destination element for a 'drag-and-drop' step.",
+      ),
+    toTag: z
+      .string()
+      .optional()
+      .describe(
+        "Tag name of the destination element for a 'drag-and-drop' step.",
+      ),
+    inputText: z
+      .string()
+      .optional()
+      .describe("Text to type. Used by 'input' steps."),
+    url: z
+      .string()
+      .optional()
+      .describe(
+        "Target URL. Required by 'api' steps; used as the navigation URL for 'browser-navigate' and as the deep link for 'deeplink'.",
+      ),
+    script: z
+      .string()
+      .optional()
+      .describe("JavaScript source to execute. Used by 'javascript' steps."),
+    command: z
+      .string()
+      .optional()
+      .describe("Appium command to run. Required by 'appium' steps."),
+    argument: z
+      .string()
+      .optional()
+      .describe("Argument for the Appium command in an 'appium' step."),
+    httpMethod: z
+      .string()
+      .optional()
+      .describe(
+        "HTTP method for an 'api' step (e.g. 'GET', 'POST'). Defaults to 'GET'.",
+      ),
+    requestBody: z
+      .string()
+      .optional()
+      .describe("Request body for an 'api' step."),
+    requestHeaders: z
+      .array(headerSchema)
+      .optional()
+      .describe("Request headers for an 'api' step."),
+    followRedirects: z
+      .boolean()
+      .optional()
+      .describe("Whether an 'api' step should follow HTTP redirects."),
+    email: emailSchema
+      .optional()
+      .describe("Configuration for a 'receive-email' step."),
+    sms: smsSchema
+      .optional()
+      .describe("Configuration for a 'receive-sms' step."),
+    expectedText: z
+      .string()
+      .optional()
+      .describe(
+        "Text expected on the page. Used by 'text-validation' steps, which require an exact match of the target element's text (not a substring or case-insensitive match).",
+      ),
+    title: z
+      .string()
+      .optional()
+      .describe(
+        "Expected page title for a navigation step ('browser-navigate', 'browser-back', 'browser-forward', 'browser-refresh').",
+      ),
+    expectedResult: z
+      .string()
+      .optional()
+      .describe("Expected result text for a 'prompt' step."),
+    promptType: z
+      .enum(["action", "assert", "query"])
+      .optional()
+      .describe(
+        "The kind of AI 'prompt' step (required for 'prompt' steps): 'action' performs an action; 'assert' checks a condition; 'query' answers a question. Prompt steps only take into account what is currently visible on the screen.",
+      ),
+    expectedResponse: z
+      .union([z.boolean(), z.string()])
+      .optional()
+      .describe(
+        "Expected response for a 'prompt' step: a boolean for an 'assert' prompt, or a string for a 'query' prompt.",
+      ),
+    latitude: z
+      .number()
+      .optional()
+      .describe("Latitude for a 'set-device-location' step."),
+    longitude: z
+      .number()
+      .optional()
+      .describe("Longitude for a 'set-device-location' step."),
+    seconds: z
+      .number()
+      .optional()
+      .describe("Number of seconds to pause. Used by 'wait' steps."),
+    // Only tests can reference segments, so this field is omitted from segment steps.
+    ...(includeSegmentReference
+      ? {
+          id: z
+            .number()
+            .optional()
+            .describe(
+              "Id of the segment to reference. Required for 'segment' steps.",
+            ),
+        }
+      : {}),
+    name: z.string().optional().describe("Optional display name for the step."),
+    parameters: z
+      .array(parameterSchema)
+      .optional()
+      .describe(
+        "Parameter name/value assignments applied by an 'update-parameters' step.",
+      ),
+  });
+}
+
+export function buildCreateDefinitionSchema({
+  isSegment,
+}: {
+  isSegment: boolean;
+}) {
+  const definitionType = isSegment ? "segment" : "test";
+
+  const stepSchema = buildStepSchema(
+    isSegment ? BASE_STEP_TYPES : TEST_STEP_TYPES,
+    { includeSegmentReference: !isSegment },
+  );
+  const selectorGuidance =
+    "Prefer deterministic, selector-based steps ('click', 'input', 'submit', 'text-validation', 'hover', etc.) " +
+    "over AI-driven 'prompt' steps whenever a stable selector is available. Reserve 'prompt' steps for behavior that " +
+    "can't be expressed with a selector.";
+
+  const referenceGuidance =
+    `Any text field in a step (e.g. 'inputText', 'url', 'expectedText', 'requestBody', header values, prompt text) ` +
+    `may embed Reflect variable and function references using '\${...}' syntax, which are resolved at run time: ` +
+    `'\${var(name)}' inserts the value of a parameter/variable named 'name' (declare parameters via the top-level ` +
+    `'parameters' field, or assign them mid-run with an 'update-parameters' step); '\${sec(name)}' inserts the value ` +
+    `of the account secret 'name'. Functions generate dynamic values: '\${alphanum(n)}', '\${alpha(n)}', '\${num(n)}' ` +
+    `(random alphanumeric / alphabetic / numeric string of length n), '\${range(min, max)}' (random integer, ` +
+    `inclusive), '\${time(offsetMs)}' and '\${datetime(offsetMs)}' (current epoch-millis / date-time, with an optional ` +
+    `millisecond offset), and '\${date(format, offsetDays)}' (current date formatted with tokens like 'MM/dd/yyyy', ` +
+    `with an optional day offset).`;
+
+  const stepsDescription = isSegment
+    ? `Ordered list of steps that make up the segment. Segments cannot reference other segments. ${selectorGuidance} ${referenceGuidance}`
+    : `Ordered list of steps that make up the test. Web tests must begin with a 'browser-navigate' step. ${selectorGuidance} ${referenceGuidance}`;
+
+  return z.object({
+    name: z.string().describe(`Name of the ${definitionType} to create.`),
+    type: z
+      .enum(["web", "api", "native-mobile"])
+      .describe(`Platform of the ${definitionType}.`),
+    description: z
+      .string()
+      .optional()
+      .describe(`Optional description of the ${definitionType}.`),
+    deviceProfile: z
+      .string()
+      .optional()
+      .describe(
+        `Device profile id. Required for a 'web' ${definitionType}; ignored for 'api' and 'native-mobile'. One of: 'desktop', 'tablet', 'mobile'.`,
+      ),
+    steps: z.array(stepSchema).describe(stepsDescription),
+    parameters: z
+      .array(parameterSchema)
+      .optional()
+      .describe(
+        `Optional named parameters (variables) for the ${definitionType}, each with a 'name' and optional default 'value'. Reference a parameter's value inside any step text field with '\${var(name)}'.`,
+      ),
+  });
+}
+
+// Reflect's API returns errors as { message, errorId }
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (!text) {
+      return "";
+    }
+    try {
+      const parsed = JSON.parse(text) as { message?: string };
+      return parsed.message ? `: ${parsed.message}` : `: ${text}`;
+    } catch {
+      return `: ${text}`;
+    }
+  } catch {
+    return "";
+  }
+}
+
+export async function createReflectDefinition(
+  client: ReflectClient,
+  endpoint: "tests" | "segments",
+  noun: "test" | "segment",
+  body: unknown,
+) {
+  const response = await fetch(`https://${API_HOSTNAME}/v1/${endpoint}`, {
+    method: "POST",
+    headers: client.getHeaders(),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorMessage(response);
+    throw new ToolError(
+      `Failed to create ${noun}: ${response.status} ${response.statusText}${detail}`,
+    );
+  }
+
+  const data = (await response.json()) as { id: number };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          id: data.id,
+          message: `Created ${noun} with id ${data.id}`,
+        }),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Goal

The primary use-case for these endpoints are to import tests from other tools such as open source frameworks (Selenium, Cypress, Playwright) or other SmartBear products (TestComplete, BearQ).

## Design

The tool definitions provide guidance on how to construct a test or segment, and the API endpoints backing these tools provide feedback when an agent sends an invalid request.

## Changeset

Add two new Reflect tools: `create_test` and `create_segment`

## Testing
- Took a few Playwright tests and verified the agent could create equivalent web tests in Reflect
- Took a few OpenAPI specs and verified the agent could create API tests that exercised the endpoints documented in the OpenAPI specs.
