### PR TITLE
feat(functional-testing): add test creation tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Added `create_test` Functional Testing tool that creates a new API test from a name, optional description, and set of steps (URL, HTTP method, request body/headers, redirect handling), returning the ID of the newly created test for use with `swagger_run_test`.
+- [Swagger] Added `create_test` Functional Testing tool that creates a new API test with set of steps.
 
 ## [0.32.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
 - [Swagger] Added `create_test` Functional Testing tool that creates a new API test from a name, optional description, and set of steps (URL, HTTP method, request body/headers, redirect handling), returning the ID of the newly created test for use with `swagger_run_test`.
 
 ## [0.32.0] - 2026-07-23
@@ -28,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [BearQ] Remove draft-test refinement tools and add `bearq_delete_test_cases` [#593](https://github.com/SmartBear/smartbear-mcp/pull/593)
+
+### Fixed
+
+- [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
 
 ## [0.30.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
+- [Swagger] Added `create_test` Functional Testing tool that creates a new API test from a name, optional description, and set of steps (URL, HTTP method, request body/headers, redirect handling), returning the ID of the newly created test for use with `swagger_run_test`.
 
 ## [0.32.0] - 2026-07-23
 
@@ -32,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
 - [Swagger] Added output schemas to Swagger Portal and Registry tools, enabling structured, validated responses for all portal, product, section, document, table-of-contents, and registry operations.
 - [Swagger] Introduced tool constants (`READ_ONLY`, `WRITE`, `WRITE_DESTRUCTIVE`) to annotate each Swagger tool with semantic flags (`readOnly`, `openWorld`, `destructive`) for better client-side tool classification.
 - [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -364,7 +364,7 @@ export class SwaggerClient implements Client {
 
   // Functional Testing methods
 
-  async createFunctionalTest(
+  async createFunctionalTestingTest(
     args: CreateFunctionalTestingTestParams,
   ): Promise<CreateFunctionalTestingTestResponse> {
     return this.withFunctionalTesting((ftApi) => ftApi.createTest(args));

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -17,6 +17,7 @@ import {
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
   CreateFunctionalTestingTestParams,
+  CreateFunctionalTestingTestResponse,
   GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
@@ -365,7 +366,7 @@ export class SwaggerClient implements Client {
 
   async createFunctionalTest(
     args: CreateFunctionalTestingTestParams,
-  ): Promise<unknown> {
+  ): Promise<CreateFunctionalTestingTestResponse> {
     return this.withFunctionalTesting((ftApi) => ftApi.createTest(args));
   }
 

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,6 +16,7 @@ import {
 } from "./client/functional-testing-api";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  CreateFunctionalTestingTestParams,
   GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
@@ -361,6 +362,12 @@ export class SwaggerClient implements Client {
   }
 
   // Functional Testing methods
+
+  async createFunctionalTest(
+    args: CreateFunctionalTestingTestParams,
+  ): Promise<unknown> {
+    return this.withFunctionalTesting((ftApi) => ftApi.createTest(args));
+  }
 
   async listFunctionalTestingTests(): Promise<unknown> {
     return this.withFunctionalTesting((ftApi) => ftApi.listTests());

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -2,6 +2,7 @@ import { appendClientIdentity } from "../../common/info";
 import { ToolError } from "../../common/tools";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  CreateFunctionalTestingTestParams,
   GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
@@ -73,6 +74,20 @@ export class FunctionalTestingAPI {
     }
 
     return response;
+  }
+
+  async createTest(args: CreateFunctionalTestingTestParams): Promise<unknown> {
+    const response = await this.ftFetch(
+      `tests`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+        body: JSON.stringify(args),
+      },
+      errorMessageFor(`create Functional Testing test`),
+    );
+
+    return response.json();
   }
 
   async listTests(): Promise<unknown> {

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -82,7 +82,7 @@ export class FunctionalTestingAPI {
       {
         method: "POST",
         headers: this.getFtHeaders(),
-        body: JSON.stringify(args),
+        body: JSON.stringify({ type: "api", ...args }),
       },
       errorMessageFor(`create Functional Testing test`),
     );

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -3,6 +3,7 @@ import { ToolError } from "../../common/tools";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
   CreateFunctionalTestingTestParams,
+  CreateFunctionalTestingTestResponse,
   GetFunctionalTestHistoryParams,
   GetFunctionalTestingExecutionTestParams,
   GetFunctionalTestingSuiteExecutionParams,
@@ -76,13 +77,19 @@ export class FunctionalTestingAPI {
     return response;
   }
 
-  async createTest(args: CreateFunctionalTestingTestParams): Promise<unknown> {
+  async createTest(
+    args: CreateFunctionalTestingTestParams,
+  ): Promise<CreateFunctionalTestingTestResponse> {
     const response = await this.ftFetch(
       `tests`,
       {
         method: "POST",
         headers: this.getFtHeaders(),
-        body: JSON.stringify({ type: "api", ...args }),
+        body: JSON.stringify({
+          type: "api",
+          ...args,
+          steps: args.steps?.map((step) => ({ type: "api", ...step })),
+        }),
       },
       errorMessageFor(`create Functional Testing test`),
     );

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -80,15 +80,26 @@ export class FunctionalTestingAPI {
   async createTest(
     args: CreateFunctionalTestingTestParams,
   ): Promise<CreateFunctionalTestingTestResponse> {
+    const {
+      type: _type,
+      steps,
+      ...rest
+    } = args as Record<string, unknown> & {
+      steps?: unknown[];
+    };
+    const sanitizedSteps = steps?.map((step) => {
+      const { type: _stepType, ...stepRest } = step as Record<string, unknown>;
+      return { ...stepRest, type: "api" };
+    });
     const response = await this.ftFetch(
       `tests`,
       {
         method: "POST",
         headers: this.getFtHeaders(),
         body: JSON.stringify({
-          ...args,
+          ...rest,
           type: "api",
-          steps: args.steps?.map((step) => ({ ...step, type: "api" })),
+          steps: sanitizedSteps,
         }),
       },
       errorMessageFor(`create Functional Testing test`),

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -86,9 +86,9 @@ export class FunctionalTestingAPI {
         method: "POST",
         headers: this.getFtHeaders(),
         body: JSON.stringify({
-          type: "api",
           ...args,
-          steps: args.steps?.map((step) => ({ type: "api", ...step })),
+          type: "api",
+          steps: args.steps?.map((step) => ({ ...step, type: "api" })),
         }),
       },
       errorMessageFor(`create Functional Testing test`),

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,5 +1,6 @@
 import {
   CancelFunctionalTestingSuiteExecutionSchema,
+  CreateFunctionalTestingTestParamsSchema,
   GetFunctionalTestHistoryParamsSchema,
   GetFunctionalTestingExecutionTestSchema,
   GetFunctionalTestingSuiteExecutionSchema,
@@ -10,6 +11,20 @@ import {
 import type { SwaggerToolParams } from "./tools";
 
 export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
+  {
+    title: "Create Test",
+    toolset: "Functional Testing",
+    summary:
+      "Creates a new test in your Swagger Functional Testing workspace. " +
+      "Use this when you need to programmatically create an API test with a defined set of steps. " +
+      'Defaults to type "api" for API testing. ' +
+      'API steps ("type": "api") execute HTTP calls but do not support inline assertions — use a "javascript" step after an API step to validate the response. ' +
+      "Returns the ID of the newly created test, which can be used with swagger_run_test.",
+    inputSchema: CreateFunctionalTestingTestParamsSchema,
+    handler: "createFunctionalTest",
+    idempotent: false,
+    readOnly: false,
+  },
   {
     title: "List Tests",
     toolset: "Functional Testing",

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -15,10 +15,9 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     title: "Create Test",
     toolset: "Functional Testing",
     summary:
-      "Creates a new test in your Swagger Functional Testing workspace. " +
-      "Use this when you need to programmatically create an API test with a defined set of steps. " +
-      'Defaults to type "api" for API testing. ' +
-      'API steps ("type": "api") execute HTTP calls but do not support inline assertions — use a "javascript" step after an API step to validate the response. ' +
+      "Creates a new API test in your Swagger Functional Testing workspace. " +
+      "Use this when you need to programmatically create a test with a defined set of steps. " +
+      'API steps execute HTTP calls but do not support inline assertions — use a "javascript" step after an API step to validate the response. ' +
       "Returns the ID of the newly created test, which can be used with swagger_run_test.",
     inputSchema: CreateFunctionalTestingTestParamsSchema,
     handler: "createFunctionalTest",

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,6 +1,7 @@
 import {
   CancelFunctionalTestingSuiteExecutionSchema,
   CreateFunctionalTestingTestParamsSchema,
+  CreateFunctionalTestingTestResponseSchema,
   GetFunctionalTestHistoryParamsSchema,
   GetFunctionalTestingExecutionTestSchema,
   GetFunctionalTestingSuiteExecutionSchema,
@@ -30,8 +31,9 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "This tool only creates API tests (not browser or native-mobile tests). " +
       "Use this when you need to programmatically create a test with a defined set of API request steps. " +
       "Each step requires a URL and may specify an HTTP method (defaults to GET), request body, headers, and redirect handling. " +
-      "Returns the ID of the newly created test, which can be used with `swagger_run_test`.",
+      "Returns the ID and the URL to definition of the newly created test; the ID can be used with `swagger_run_test` to run it.",
     inputSchema: CreateFunctionalTestingTestParamsSchema,
+    outputSchema: CreateFunctionalTestingTestResponseSchema,
     handler: "createFunctionalTestingTest",
     idempotent: false,
     readOnly: false,

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -17,7 +17,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     summary:
       "Creates a new API test in your Swagger Functional Testing workspace. " +
       "Use this when you need to programmatically create a test with a defined set of steps. " +
-      'API steps execute HTTP calls but do not support inline assertions — use a "javascript" step after an API step to validate the response. ' +
       "Returns the ID of the newly created test, which can be used with swagger_run_test.",
     inputSchema: CreateFunctionalTestingTestParamsSchema,
     handler: "createFunctionalTest",

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -12,18 +12,6 @@ import type { SwaggerToolParams } from "./tools";
 
 export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
   {
-    title: "Create Test",
-    toolset: "Functional Testing",
-    summary:
-      "Creates a new API test in your Swagger Functional Testing workspace. " +
-      "Use this when you need to programmatically create a test with a defined set of steps. " +
-      "Returns the ID of the newly created test, which can be used with swagger_run_test.",
-    inputSchema: CreateFunctionalTestingTestParamsSchema,
-    handler: "createFunctionalTest",
-    idempotent: false,
-    readOnly: false,
-  },
-  {
     title: "List Tests",
     toolset: "Functional Testing",
     summary:
@@ -35,12 +23,26 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     readOnly: true,
   },
   {
+    title: "Create Test",
+    toolset: "Functional Testing",
+    summary:
+      "Creates a new API test in your Swagger Functional Testing workspace. " +
+      "This tool only creates API tests (not browser or native-mobile tests). " +
+      "Use this when you need to programmatically create a test with a defined set of API request steps. " +
+      "Each step requires a URL and may specify an HTTP method (defaults to GET), request body, headers, and redirect handling. " +
+      "Returns the ID of the newly created test, which can be used with `swagger_run_test`.",
+    inputSchema: CreateFunctionalTestingTestParamsSchema,
+    handler: "createFunctionalTestingTest",
+    idempotent: false,
+    readOnly: false,
+  },
+  {
     title: "Run Test",
     toolset: "Functional Testing",
     summary:
       "Runs a specific API test in your Swagger Functional Testing workspace. " +
       "The execution is asynchronous — it returns an executionId, not the result directly. " +
-      "Use swagger_get_test_status with that executionId to track progress and retrieve the final result.",
+      "Use `swagger_get_test_status` with that executionId to track progress and retrieve the final result.",
     inputSchema: RunFunctionalTestingTestParamsSchema,
     handler: "runFunctionalTestingTest",
     idempotent: false,

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -211,10 +211,6 @@ export const CreateFunctionalTestingTestStepSchema = z.object({
 
 export const CreateFunctionalTestingTestParamsSchema = z.object({
   name: z.string().describe("Name for the new test").trim().min(1),
-  type: z
-    .enum(["api", "web", "native-mobile"])
-    .describe('Test type. Defaults to "api" for API testing.')
-    .default("api"),
   description: z
     .string()
     .describe("Optional description for the test")

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -215,7 +215,9 @@ export const CreateFunctionalTestingTestResponseSchema = z.object({
   id: z.number().describe("ID of the newly created test"),
   url: z
     .string()
-    .describe("Link to the created test definition in the Swagger UI"),
+    .describe(
+      "Link to the created test definition in Swagger Functional Testing UI",
+    ),
 });
 
 export type CreateFunctionalTestingTestResponse = z.infer<

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -211,6 +211,13 @@ export type CreateFunctionalTestingTestParams = z.infer<
   typeof CreateFunctionalTestingTestParamsSchema
 >;
 
-export interface CreateFunctionalTestingTestResponse {
-  id: number;
-}
+export const CreateFunctionalTestingTestResponseSchema = z.object({
+  id: z.number().describe("ID of the newly created test"),
+  url: z
+    .string()
+    .describe("Link to the created test definition in the Swagger UI"),
+});
+
+export type CreateFunctionalTestingTestResponse = z.infer<
+  typeof CreateFunctionalTestingTestResponseSchema
+>;

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -172,10 +172,7 @@ export const CreateFunctionalTestingTestHeaderSchema = z.object({
 
 export const CreateFunctionalTestingTestStepSchema = z.object({
   url: z.string().url().describe("URL for the API call").optional(),
-  httpMethod: z
-    .string()
-    .describe('HTTP method, e.g. "GET", "POST"')
-    .optional(),
+  httpMethod: z.string().describe('HTTP method, e.g. "GET", "POST"').optional(),
   requestBody: z.string().describe("Request body").optional(),
   requestHeaders: z
     .array(CreateFunctionalTestingTestHeaderSchema)

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -166,13 +166,18 @@ export interface TestRunHistoryResponse {
 }
 
 export const CreateFunctionalTestingTestHeaderSchema = z.object({
-  name: z.string().describe("Header name"),
+  name: z.string().describe("Header name").trim().min(1),
   value: z.string().describe("Header value"),
 });
 
+export const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
 export const CreateFunctionalTestingTestStepSchema = z.object({
-  url: z.string().url().describe("URL for the API call").optional(),
-  httpMethod: z.string().describe('HTTP method, e.g. "GET", "POST"').optional(),
+  url: z.url().describe("URL for the API call"),
+  httpMethod: z
+    .enum(HTTP_METHODS)
+    .describe("HTTP method for the API call (defaults to GET server-side)")
+    .optional(),
   requestBody: z.string().describe("Request body").optional(),
   requestHeaders: z
     .array(CreateFunctionalTestingTestHeaderSchema)
@@ -184,6 +189,7 @@ export const CreateFunctionalTestingTestStepSchema = z.object({
     .optional(),
   description: z
     .string()
+    .trim()
     .describe("Human-readable label for this step")
     .optional(),
 });
@@ -192,6 +198,7 @@ export const CreateFunctionalTestingTestParamsSchema = z.object({
   name: z.string().describe("Name for the new test").trim().min(1),
   description: z
     .string()
+    .trim()
     .describe("Optional description for the test")
     .optional(),
   steps: z
@@ -205,5 +212,5 @@ export type CreateFunctionalTestingTestParams = z.infer<
 >;
 
 export interface CreateFunctionalTestingTestResponse {
-  id: string;
+  id: number;
 }

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -171,41 +171,23 @@ export const CreateFunctionalTestingTestHeaderSchema = z.object({
 });
 
 export const CreateFunctionalTestingTestStepSchema = z.object({
-  type: z
-    .string()
-    .describe('Step type, e.g. "api", "browser-navigate", "wait"')
-    .trim()
-    .min(1),
-  url: z.string().describe("URL for navigate or API call steps").optional(),
+  url: z.string().url().describe("URL for the API call").optional(),
   httpMethod: z
     .string()
-    .describe('HTTP method for API steps, e.g. "GET", "POST"')
+    .describe('HTTP method, e.g. "GET", "POST"')
     .optional(),
-  requestBody: z
-    .string()
-    .describe("Request body for API steps")
-    .optional(),
+  requestBody: z.string().describe("Request body").optional(),
   requestHeaders: z
     .array(CreateFunctionalTestingTestHeaderSchema)
-    .describe("HTTP headers for API steps")
+    .describe("HTTP headers")
     .optional(),
   followRedirects: z
     .boolean()
-    .describe("Whether to follow redirects for API steps")
+    .describe("Whether to follow redirects")
     .optional(),
   description: z
     .string()
     .describe("Human-readable label for this step")
-    .optional(),
-  inputText: z.string().describe("Text to type for input steps").optional(),
-  selector: z
-    .string()
-    .describe("CSS selector for element-targeting steps")
-    .optional(),
-  seconds: z
-    .number()
-    .int()
-    .describe("Wait duration in seconds for wait steps")
     .optional(),
 });
 
@@ -214,12 +196,6 @@ export const CreateFunctionalTestingTestParamsSchema = z.object({
   description: z
     .string()
     .describe("Optional description for the test")
-    .optional(),
-  deviceProfile: z
-    .string()
-    .describe(
-      "Optional device profile name (required for native-mobile tests)",
-    )
     .optional(),
   steps: z
     .array(CreateFunctionalTestingTestStepSchema)
@@ -230,3 +206,7 @@ export const CreateFunctionalTestingTestParamsSchema = z.object({
 export type CreateFunctionalTestingTestParams = z.infer<
   typeof CreateFunctionalTestingTestParamsSchema
 >;
+
+export interface CreateFunctionalTestingTestResponse {
+  id: string;
+}

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -164,3 +164,73 @@ export interface TestRunHistoryResponse {
   totalRuns: number;
   runs: TestRun[];
 }
+
+export const CreateFunctionalTestingTestHeaderSchema = z.object({
+  name: z.string().describe("Header name"),
+  value: z.string().describe("Header value"),
+});
+
+export const CreateFunctionalTestingTestStepSchema = z.object({
+  type: z
+    .string()
+    .describe('Step type, e.g. "api", "browser-navigate", "wait"')
+    .trim()
+    .min(1),
+  url: z.string().describe("URL for navigate or API call steps").optional(),
+  httpMethod: z
+    .string()
+    .describe('HTTP method for API steps, e.g. "GET", "POST"')
+    .optional(),
+  requestBody: z
+    .string()
+    .describe("Request body for API steps")
+    .optional(),
+  requestHeaders: z
+    .array(CreateFunctionalTestingTestHeaderSchema)
+    .describe("HTTP headers for API steps")
+    .optional(),
+  followRedirects: z
+    .boolean()
+    .describe("Whether to follow redirects for API steps")
+    .optional(),
+  description: z
+    .string()
+    .describe("Human-readable label for this step")
+    .optional(),
+  inputText: z.string().describe("Text to type for input steps").optional(),
+  selector: z
+    .string()
+    .describe("CSS selector for element-targeting steps")
+    .optional(),
+  seconds: z
+    .number()
+    .int()
+    .describe("Wait duration in seconds for wait steps")
+    .optional(),
+});
+
+export const CreateFunctionalTestingTestParamsSchema = z.object({
+  name: z.string().describe("Name for the new test").trim().min(1),
+  type: z
+    .enum(["api", "web", "native-mobile"])
+    .describe('Test type. Defaults to "api" for API testing.')
+    .default("api"),
+  description: z
+    .string()
+    .describe("Optional description for the test")
+    .optional(),
+  deviceProfile: z
+    .string()
+    .describe(
+      "Optional device profile name (required for native-mobile tests)",
+    )
+    .optional(),
+  steps: z
+    .array(CreateFunctionalTestingTestStepSchema)
+    .describe("Test steps to include in the test")
+    .optional(),
+});
+
+export type CreateFunctionalTestingTestParams = z.infer<
+  typeof CreateFunctionalTestingTestParamsSchema
+>;

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -55,7 +55,7 @@ describe("FunctionalTestingAPI", () => {
   });
 
   describe("createTest", () => {
-    const createResponseMock = { id: "test-abc123" };
+    const createResponseMock = { id: 12345 };
 
     it("should POST to the correct endpoint with X-API-KEY header", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
@@ -98,6 +98,63 @@ describe("FunctionalTestingAPI", () => {
       expect(body.steps[0].type).toBe("api");
       expect(body.steps[1].type).toBe("api");
       expect(body.steps[0].url).toBe("https://example.com/api");
+      expect(body.steps[0].httpMethod).toBe("GET");
+      expect(body.steps[1].url).toBe("https://example.com/api/users");
+      expect(body.steps[1].httpMethod).toBe("POST");
+    });
+
+    it("should forward all step fields to the request body", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await api.createTest({
+        name: "Full Test",
+        description: "Test description",
+        steps: [
+          {
+            url: "https://example.com/api",
+            httpMethod: "POST",
+            requestBody: '{"key":"value"}',
+            requestHeaders: [{ name: "X-Custom", value: "abc" }],
+            followRedirects: true,
+            description: "Step 1",
+          },
+        ],
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body).toMatchObject({
+        name: "Full Test",
+        description: "Test description",
+        type: "api",
+        steps: [
+          {
+            type: "api",
+            url: "https://example.com/api",
+            httpMethod: "POST",
+            requestBody: '{"key":"value"}',
+            requestHeaders: [{ name: "X-Custom", value: "abc" }],
+            followRedirects: true,
+            description: "Step 1",
+          },
+        ],
+      });
+    });
+
+    it("should not allow caller to override the injected type", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      const rogueArgs: any = {
+        name: "Override Test",
+        type: "browser",
+        steps: [{ url: "https://example.com", type: "click" }],
+      };
+      await api.createTest(rogueArgs);
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.type).toBe("api");
+      expect(body.steps[0].type).toBe("api");
     });
 
     it("should handle test with no steps", async () => {
@@ -115,7 +172,7 @@ describe("FunctionalTestingAPI", () => {
 
       const result = await api.createTest({ name: "My New Test" });
 
-      expect(result).toEqual({ id: "test-abc123" });
+      expect(result).toEqual({ id: 12345 });
     });
 
     it("should throw ToolError on HTTP error", async () => {

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -55,7 +55,10 @@ describe("FunctionalTestingAPI", () => {
   });
 
   describe("createTest", () => {
-    const createResponseMock = { id: 12345 };
+    const createResponseMock = {
+      id: 12345,
+      url: "https://app.reflect.run/tests/12345/definition?accountId=54321",
+    };
 
     it("should POST to the correct endpoint with X-API-KEY header", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
@@ -167,12 +170,12 @@ describe("FunctionalTestingAPI", () => {
       expect(body.steps).toBeUndefined();
     });
 
-    it("should return the new test id", async () => {
+    it("should return the new test id and url", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
 
       const result = await api.createTest({ name: "My New Test" });
 
-      expect(result).toEqual({ id: 12345 });
+      expect(result).toEqual(createResponseMock);
     });
 
     it("should throw ToolError on HTTP error", async () => {

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -54,6 +54,87 @@ describe("FunctionalTestingAPI", () => {
     );
   });
 
+  describe("createTest", () => {
+    const createResponseMock = { id: "test-abc123" };
+
+    it("should POST to the correct endpoint with X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await api.createTest({ name: "My New Test" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+        }),
+      );
+    });
+
+    it("should inject type: api at top level of request body", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await api.createTest({ name: "My New Test" });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.type).toBe("api");
+      expect(body.name).toBe("My New Test");
+    });
+
+    it("should inject type: api into each step", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await api.createTest({
+        name: "My New Test",
+        steps: [
+          { url: "https://example.com/api", httpMethod: "GET" },
+          { url: "https://example.com/api/users", httpMethod: "POST" },
+        ],
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.steps[0].type).toBe("api");
+      expect(body.steps[1].type).toBe("api");
+      expect(body.steps[0].url).toBe("https://example.com/api");
+    });
+
+    it("should handle test with no steps", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await api.createTest({ name: "Empty Test" });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.steps).toBeUndefined();
+    });
+
+    it("should return the new test id", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      const result = await api.createTest({ name: "My New Test" });
+
+      expect(result).toEqual({ id: "test-abc123" });
+    });
+
+    it("should throw ToolError on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
+
+      await expect(api.createTest({ name: "My New Test" })).rejects.toThrow(
+        "Failed to create Functional Testing test",
+      );
+    });
+
+    it("should map network errors to an unreachable message", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(api.createTest({ name: "My New Test" })).rejects.toThrow(
+        UNREACHABLE_MESSAGE,
+      );
+    });
+  });
+
   describe("listTests", () => {
     it("should call the correct endpoint with X-API-KEY header", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(testsMock));

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -405,8 +405,11 @@ describe("SwaggerClient — Functional Testing integration", () => {
   });
 
   describe("createFunctionalTestingTest", () => {
-    it("should POST to api.reflect.run and return the new test id", async () => {
-      const createResponseMock = { id: 12345 };
+    it("should POST to api.reflect.run and return the new test id and url", async () => {
+      const createResponseMock = {
+        id: 12345,
+        url: "https://app.reflect.run/tests/12345/definition?accountId=54321",
+      };
       fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
 
       await client.configure({} as any, {

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -404,9 +404,9 @@ describe("SwaggerClient — Functional Testing integration", () => {
     });
   });
 
-  describe("createFunctionalTest", () => {
+  describe("createFunctionalTestingTest", () => {
     it("should POST to api.reflect.run and return the new test id", async () => {
-      const createResponseMock = { id: "test-abc123" };
+      const createResponseMock = { id: 12345 };
       fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
 
       await client.configure({} as any, {
@@ -415,7 +415,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
       });
 
       const result = await requestContextStorage.run({ headers: {} }, () =>
-        client.createFunctionalTest({ name: "My New Test" }),
+        client.createFunctionalTestingTest({ name: "My New Test" }),
       );
 
       expect(fetchMock).toHaveBeenCalledWith(
@@ -432,7 +432,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
       await client.configure({} as any, { api_key: "swagger-key" });
 
       await expect(
-        client.createFunctionalTest({ name: "My New Test" }),
+        client.createFunctionalTestingTest({ name: "My New Test" }),
       ).rejects.toThrow("Functional Testing API not configured");
     });
   });

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -137,6 +137,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
       const registeredTitles = mockRegister.mock.calls.map(
         (call) => call[0].title,
       );
+      expect(registeredTitles).toContain("Create Test");
       expect(registeredTitles).toContain("List Tests");
       expect(registeredTitles).toContain("List Suites");
     });
@@ -400,6 +401,39 @@ describe("SwaggerClient — Functional Testing integration", () => {
         }),
       );
       expect(result).toEqual(suiteExecutionMock);
+    });
+  });
+
+  describe("createFunctionalTest", () => {
+    it("should POST to api.reflect.run and return the new test id", async () => {
+      const createResponseMock = { id: "test-abc123" };
+      fetchMock.mockResponseOnce(JSON.stringify(createResponseMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.createFunctionalTest({ name: "My New Test" }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/tests",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(createResponseMock);
+    });
+
+    it("should throw when FT API is not configured", async () => {
+      await client.configure({} as any, { api_key: "swagger-key" });
+
+      await expect(
+        client.createFunctionalTest({ name: "My New Test" }),
+      ).rejects.toThrow("Functional Testing API not configured");
     });
   });
 


### PR DESCRIPTION
## Goal
Implements Functional Testing tool for test creation.

Extends the SFT toolset with test creation. The tool creates new test entry in Functional Testing with or without test steps defined.

## Design
New tool delegates through a `SwaggerClient` method, the API call lives in `FunctionalTestingAPI`. 

## Changeset
- Added `createTest` method to `FunctionalTestingAPI`
- Wired through `SwaggerClient` as `createFunctionalTest`
- Registered `Create Test` tool entry

## Testing
- [X] Unit tests added
- [X] Manual local testing of new SFT tool performed
