### PR TITLE
fix(functional-testing): Bring back 'url' parameter inside response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
+- [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
 - [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
 
 ### Changed
@@ -22,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Added output schemas to Swagger Portal and Registry tools, enabling structured, validated responses for all portal, product, section, document, table-of-contents, and registry operations.
 - [Swagger] Introduced tool constants (`READ_ONLY`, `WRITE`, `WRITE_DESTRUCTIVE`) to annotate each Swagger tool with semantic flags (`readOnly`, `openWorld`, `destructive`) for better client-side tool classification.
+- [Swagger] Added `get_test_history` Functional Testing tool that retrieves the execution history for a given test, returning past runs with pass/fail status, run time, creation timestamp, and per-step failure details for failed runs.
 
 ### Changed
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -167,7 +167,7 @@ export class FunctionalTestingAPI {
             executionId,
             status,
             isFinished,
-            url
+            url,
           }),
         ),
       },

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -159,15 +159,15 @@ export class FunctionalTestingAPI {
     );
 
     const data: ListSuiteExecutionsResponse = await response.json();
-    // Will be adjusted after https://smartbear.atlassian.net/browse/RF-5271 is done
     return {
       ...data,
       executions: {
         data: data.executions.data.map(
-          ({ executionId, status, isFinished }) => ({
+          ({ executionId, status, isFinished, url }) => ({
             executionId,
             status,
             isFinished,
+            url
           }),
         ),
       },
@@ -238,9 +238,7 @@ export class FunctionalTestingAPI {
       errorMessageFor("run suite"),
     );
 
-    // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
-    // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    return this.withoutField("url", response);
+    return response;
   }
 
   async getSuiteExecution(
@@ -260,9 +258,7 @@ export class FunctionalTestingAPI {
       errorMessageFor("get suite execution status"),
     );
 
-    // Reflect API returns suite URL, in format which currently is not supported within Private Workspaces epic.
-    // We remove it for now, but will bring it back corrected in scope of https://smartbear.atlassian.net/browse/RF-5271.
-    const data = await this.withoutField("url", response);
+    const data = (await response.json()) as Record<string, unknown>;
     // Reflect API returns video recording URL for each test run within suite, which SFT does not need so we remove it.
     const testsData = (data.tests as Record<string, unknown> | undefined)?.data;
     if (Array.isArray(testsData)) {
@@ -302,15 +298,6 @@ export class FunctionalTestingAPI {
     );
 
     return response.json();
-  }
-
-  private async withoutField(
-    field: string,
-    response: Response,
-  ): Promise<Record<string, unknown>> {
-    const data = (await response.json()) as Record<string, unknown>;
-    delete data[field];
-    return data;
   }
 }
 

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -238,7 +238,7 @@ export class FunctionalTestingAPI {
       errorMessageFor("run suite"),
     );
 
-    return response;
+    return response.json();
   }
 
   async getSuiteExecution(

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -87,8 +87,7 @@ export type GetFunctionalTestingSuiteExecutionParams = z.infer<
 
 export interface SuiteExecution {
   executionId: number;
-  // Will be brought back after https://smartbear.atlassian.net/browse/RF-5271 is done
-  // url: string;
+  url: string;
   status: string;
   isFinished: boolean;
 }

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -531,7 +531,7 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(executionMock);
     });
 
-    it("should strip url field from response", async () => {
+    it("should include url field in response", async () => {
       fetchMock.mockResponseOnce(
         JSON.stringify({
           ...executionMock,
@@ -541,7 +541,9 @@ describe("FunctionalTestingAPI", () => {
 
       const result = await api.runSuite({ suiteId: "checkout-suite" });
 
-      expect((result as Record<string, unknown>).url).toBeUndefined();
+      expect((result as Record<string, unknown>).url).toBe(
+        "https://app.reflect.run/suites/checkout-suite/executions/7",
+      );
     });
 
     it("should throw ToolError when suiteId is missing", async () => {
@@ -620,7 +622,7 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(suiteExecutionMock);
     });
 
-    it("should strip url field from response", async () => {
+    it("should include url field in response", async () => {
       fetchMock.mockResponseOnce(
         JSON.stringify({
           ...suiteExecutionMock,
@@ -633,7 +635,9 @@ describe("FunctionalTestingAPI", () => {
         executionId: "7",
       });
 
-      expect((result as Record<string, unknown>).url).toBeUndefined();
+      expect((result as Record<string, unknown>).url).toBe(
+        "https://app.reflect.run/suites/checkout-suite/executions/7",
+      );
     });
 
     it("should strip videoUrl from each run in tests.data array", async () => {


### PR DESCRIPTION
Fixes https://smartbear.atlassian.net/browse/RF-5395

~~⚠️ This PR will be tested and merged only after https://smartbear.atlassian.net/browse/RF-5394 is done (subtask of fixing urls on API layer)~~

## Goal

Corrects few SFT tools to return proper responses. 
Previously we stripped `url` parameter from some of them as they were broken on the API layer.
After corrections we bring them back.

## Design

<!-- Why was this approach used? -->
Just simple revert of the code that blocked `url` from appearing in some responses.

## Changeset

1. Bring back `url` params to some SFT tool responses

## Testing

<!-- How was it tested? -->
- [x] Smoke tested all SFT tools, verifying the `url` is present
- [x] Smoke tested Swagger tools
