### PR TITLE
chore: avoid exposing unnecessary organization fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Pactflow] Corrected MCP tool hint annotations for all 102 PactFlow tools. Previously, `readOnlyHint` defaulted to `true` for every tool because no tool explicitly set `readOnly`, causing write/delete operations to be misreported as read-only. All tools now declare all four hints explicitly: `readOnly` (58 read-only, 44 write), `destructive` (true for DELETE ops, `resetAdminRoles`, and `regenerateToken`), `idempotent` (false for creates, records, patch, execute, and invite operations), and `openWorld` (true for `executeWebhook`, `executeWebhooks`, and `inviteUsers` which trigger external HTTP requests or send emails).
 
+### Security
+
+- [Swagger] Prevented organization admin email addresses from being exposed through the `list_organizations` tool. Introduced `OrganizationListItem` type that omits the `email` field, filtered organization list data at the MCP boundary, and updated the output schema and documentation accordingly.
+
 ## [0.29.0] - 2026-07-13
 
 ### Changed

--- a/docs/products/SmartBear MCP Server/swagger-studio-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-studio-integration.md
@@ -107,7 +107,7 @@ The Swagger Studio client provides comprehensive API and Domain management capab
 #### `list_organizations`
 
 -   Purpose: Get organizations for the authenticated user. Returns a list of organizations that the authenticating user is a member of. On-Premise admins get a list of all organizations in the system.
--   Returns: Paged list of organizations, each including id, name, description, email, url, and memberCount.
+-   Returns: Paged list of organizations, each including id, name, description, url, and memberCount.
 -   Use case: Discover which organizations the current user belongs to before performing organization-scoped operations (e.g., `scan_api_standardization`, creating APIs under a specific owner), or enumerate organizations on On-Premise installations.
 -   Parameters:
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -58,6 +58,7 @@ import type {
 } from "./registry-types";
 import type {
   Organization,
+  OrganizationListItem,
   OrganizationsListResponse,
   OrganizationsQueryParams,
 } from "./user-management-types";
@@ -268,7 +269,16 @@ export class SwaggerAPI {
       response,
       defaultResponse,
     );
-    return result as OrganizationsListResponse;
+    const list = result as OrganizationsListResponse;
+    if (list.items) {
+      // The User Management API returns admin email addresses by default.
+      // Filter them out at the MCP boundary before exposing the list to agents.
+      list.items = list.items.map((org) => {
+        const { email: _email, ...rest } = org as Organization;
+        return rest as OrganizationListItem;
+      });
+    }
+    return list;
   }
 
   async createPortal(body: CreatePortalArgs): Promise<Portal> {
@@ -427,7 +437,7 @@ export class SwaggerAPI {
    */
   private async findOrganizationById(
     organizationId: string,
-  ): Promise<Organization | undefined> {
+  ): Promise<OrganizationListItem | undefined> {
     const pageSize = 100;
     const maxPages = 10;
     const target = organizationId.toLowerCase();

--- a/src/swagger/client/user-management-types.ts
+++ b/src/swagger/client/user-management-types.ts
@@ -13,6 +13,9 @@ export interface Organization {
   memberCount?: number; // Total number of members
 }
 
+// Exposed to agents. The User Management API may return admin email addresses, but we strip them at the MCP boundary.
+export type OrganizationListItem = Omit<Organization, "email">;
+
 // Pagination support for User Management API
 export interface PagedResult {
   totalCount: number; // Total number of results
@@ -22,7 +25,7 @@ export interface PagedResult {
 
 // Response from User Management API /orgs endpoint
 export interface OrganizationsListResponse extends PagedResult {
-  items: Organization[]; // List of organizations
+  items: OrganizationListItem[]; // List of organizations
 }
 
 // Query parameters for getting organizations
@@ -62,7 +65,8 @@ export const OrganizationsListOutputSchema = z.object({
       z.looseObject({
         id: z.string().optional(),
         name: z.string().optional(),
-        email: z.string().optional(),
+        description: z.string().optional(),
+        url: z.string().optional(),
         memberCount: z.number().optional(),
       }),
     )


### PR DESCRIPTION
This pull request updates how organization data is exposed to agents by ensuring that admin email addresses are no longer included in organization lists returned by the API. The changes introduce a new `OrganizationListItem` type that omits the `email` field, filters organization data at the MCP boundary, and updates type definitions and schemas accordingly.

**API response filtering and type safety:**

* The `list_organizations` API now returns organization items without the `email` field; the documentation and return type have been updated to reflect this change. 

**Schema and documentation updates:**

* Updated the Zod schema for organization list items to match the new structure (no `email`, added `description` and `url`).
* Updated the API documentation to remove references to the `email` field in organization list responses.