### PR TITLE
[Zephyr] Refactor to keep REST API Schema unmodified and enforce type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Added `create_test` Functional Testing tool that creates a new API test with set of steps.
 
+### Changed
+
+- [Zephyr] Refactor to keep REST API schemas unmodified and ensure correct payload for update operations [#609](https://github.com/SmartBear/smartbear-mcp/pull/609)
+
 ## [0.32.0] - 2026-07-23
 
 ### Added
@@ -27,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [BearQ] Remove draft-test refinement tools and add `bearq_delete_test_cases` [#593](https://github.com/SmartBear/smartbear-mcp/pull/593)
-- [Zephyr] Refactor to keep REST API schemas unmodified and ensure correct payload for update operations [#609](https://github.com/SmartBear/smartbear-mcp/pull/609)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [BearQ] Remove draft-test refinement tools and add `bearq_delete_test_cases` [#593](https://github.com/SmartBear/smartbear-mcp/pull/593)
+- [Zephyr] Refactor to keep REST API schemas unmodified and ensure correct payload for update operations [#609](https://github.com/SmartBear/smartbear-mcp/pull/609)
 
 ## [0.30.0] - 2026-07-16
 

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -14159,7 +14159,9 @@ Expected Output: The test cycle should be updated, but no output is expected.
 \`\`\`json
 {
   "testCycleIdOrKey": "SA-R40",
-  "folder": 100006,
+  "folder": {
+    "id": 100006
+  },
   "status": {
     "id": 10000
   }

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -14159,9 +14159,7 @@ Expected Output: The test cycle should be updated, but no output is expected.
 \`\`\`json
 {
   "testCycleIdOrKey": "SA-R40",
-  "folder": {
-    "id": 100006
-  },
+  "folder": 100006,
   "status": {
     "id": 10000
   }

--- a/src/zephyr/common/rest-api-schemas.ts
+++ b/src/zephyr/common/rest-api-schemas.ts
@@ -21,18 +21,36 @@ For accessing the API, you must generate an access key in Jira. To generate an a
 choose the option “Zephyr API keys". For more information, please check out the [documentation](https://support.smartbear.com/zephyr/docs/en/rest-api/api-access-tokens-management.html).
 
 ## Accessing the API
-The API is available at the following base URL:
+The API is available at different base URLs depending on your data residency region:
+
+**US region:**
 ```
 https://api.zephyrscale.smartbear.com/v2
 ```
-For example, the final URL for retrieving test cases would be:
-```
-https://api.zephyrscale.smartbear.com/v2/testcases
-```
-For EU region, the API can be accessed at the following base URL:
+
+**EU(eu-west-1) region:**
 ```
 https://eu.api.zephyrscale.smartbear.com/v2
 ```
+
+**AU(ap-southeast-1) region:**
+```
+https://au.api.zephyrscale.smartbear.com/v2
+```
+
+**DE(eu-central-1) region:**
+```
+https://de.api.zephyrscale.smartbear.com/v2
+```
+
+### Example API Calls
+
+Append the specific endpoint path to your region's base URL. For example, to retrieve test cases:
+
+- **US:** `https://api.zephyrscale.smartbear.com/v2/testcases`
+- **EU:** `https://eu.api.zephyrscale.smartbear.com/v2/testcases`
+- **AU:** `https://au.api.zephyrscale.smartbear.com/v2/testcases`
+- **DE:** `https://de.api.zephyrscale.smartbear.com/v2/testcases`
 
 ## Making Authenticated Requests
 To authenticate subsequent API requests, you must provide a valid token in an HTTP header, which is the key generated on the previous step:
@@ -370,19 +388,99 @@ export const ListTestCases200Response = zod
   })
   .strict();
 
-export const ListTestCases401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestCases400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestCases401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const ListTestCases404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The projectKey filter refers to a project that does not exist or is deactivated.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const ListTestCases500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestCasesDefaultResponse = zod
   .object({
@@ -401,8 +499,6 @@ export const createTestCaseBodyNameMax = 255;
 
 export const createTestCaseBodyNameRegExp = /^(?!\\s*$).+/;
 export const createTestCaseBodyEstimatedTimeMin = 0;
-
-export const createTestCaseBodyComponentIdMin = 1;
 
 export const createTestCaseBodyPriorityNameMax = 255;
 
@@ -437,7 +533,7 @@ export const CreateTestCaseBody = zod
       .describe("Estimated duration in milliseconds."),
     componentId: zod
       .number()
-      .min(createTestCaseBodyComponentIdMin)
+      .min(1)
       .optional()
       .describe("ID of a component from Jira."),
     priorityName: zod
@@ -484,19 +580,254 @@ export const CreateTestCase201Response = zod
   })
   .strict();
 
-export const CreateTestCase401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCase400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field has the wrong type or format (for example a non-ISO-8601 date).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId in the body refers to a folder that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId refers to a folder that is not a TEST_CYCLE folder.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId refers to a folder that belongs to a different project than the one being targeted.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains more than the maximum of 50 items."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains an empty or blank label."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A label in the labels array contains spaces, which is not allowed.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A custom field name in the body does not exist for the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A custom field value has the wrong type for the field definition. The message names the field and the expected type, e.g. "requires a number value", "requires a string value", "requires a boolean value", "requires a string which is in the format yyyy-MM-dd", or "requires a list".\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A choice custom field value references an option name that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project has required custom fields but the request omitted them.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "Custom fields were provided but not all required ones are present.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required custom field was provided with a null or empty value.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required multi-choice custom field was set to an empty collection.",
+    ),
+]);
+
+export const CreateTestCase401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestCase403Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("Referenced custom fields do not belong to the current client."),
+]);
+
+export const CreateTestCase404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The projectKey filter refers to a project that does not exist or is deactivated.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The statusName does not exist for the project."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The priorityName does not exist for the project."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestCase500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseDefaultResponse = zod
   .object({
@@ -821,19 +1152,99 @@ export const ListTestCasesCursorPaginated200Response = zod
   })
   .strict();
 
-export const ListTestCasesCursorPaginated401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestCasesCursorPaginated400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestCasesCursorPaginated401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const ListTestCasesCursorPaginated404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The projectKey filter refers to a project that does not exist or is deactivated.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const ListTestCasesCursorPaginated500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestCasesCursorPaginatedDefaultResponse = zod
   .object({
@@ -1077,26 +1488,88 @@ export const GetTestCase200Response = zod
   })
   .strict();
 
-export const GetTestCase401Response = zod
+export const GetTestCase400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestCase404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCase401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCase404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestCase500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseDefaultResponse = zod
   .object({
@@ -1176,10 +1649,16 @@ export const UpdateTestCaseBody = zod
       .optional()
       .describe("Array of labels associated to this entity."),
     component: zod
-      .number()
-      .min(1)
-      .nullable()
-      .optional()
+      .object({
+        id: zod.number().min(1).describe("The ID of the entity"),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe("The REST API endpoint to get more resource details."),
+      })
+      .strict()
+      .nullish()
       .describe("ID and link to the Jira component resource."),
     priority: zod
       .object({
@@ -1204,18 +1683,34 @@ export const UpdateTestCaseBody = zod
       .strict()
       .describe("ID and link to the status resource."),
     folder: zod
-      .number()
-      .min(1)
-      .nullable()
-      .optional()
-      .describe(
-        "The ID of the folder, to remove folder set it's value to null",
-      ),
+      .object({
+        id: zod.number().min(1).describe("The ID of the entity"),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe("The REST API endpoint to get more resource details."),
+      })
+      .strict()
+      .nullish()
+      .describe("ID and link to the folder resource."),
     owner: zod
-      .string()
-      .regex(updateTestCaseBodyOwnerAccountIdRegExp)
-      .nullable()
-      .describe("Atlassian Account ID of the Jira user."),
+      .object({
+        accountId: zod
+          .string()
+          .regex(updateTestCaseBodyOwnerAccountIdRegExp)
+          .nullable()
+          .describe("Atlassian Account ID of the Jira user."),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe(
+            "The Jira REST API endpoint to get the full representation of the Jira user.",
+          ),
+      })
+      .strict()
+      .nullish(),
     customFields: zod
       .record(zod.string(), zod.unknown())
       .optional()
@@ -1225,26 +1720,272 @@ export const UpdateTestCaseBody = zod
   })
   .strict();
 
-export const UpdateTestCase401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UpdateTestCase400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field has the wrong type or format (for example a non-ISO-8601 date).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The key in the request body does not match the testCaseKey in the path.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project id in the request body does not match the test case's actual project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId in the body refers to a folder that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId refers to a folder that is not a TEST_CYCLE folder.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId refers to a folder that belongs to a different project than the one being targeted.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The status id does not exist for the project."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The priority id does not exist for the project."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains more than the maximum of 50 items."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains an empty or blank label."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A label in the labels array contains spaces, which is not allowed.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A custom field name in the body does not exist for the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A custom field value has the wrong type for the field definition. The message names the field and the expected type, e.g. "requires a number value", "requires a string value", "requires a boolean value", "requires a string which is in the format yyyy-MM-dd", or "requires a list".\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A choice custom field value references an option name that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project has required custom fields but the request omitted them.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "Custom fields were provided but not all required ones are present.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required custom field was provided with a null or empty value.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required multi-choice custom field was set to an empty collection.",
+    ),
+]);
 
-export const UpdateTestCase404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UpdateTestCase401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const UpdateTestCase403Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("Referenced custom fields do not belong to the current client."),
+]);
+
+export const UpdateTestCase404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the id supplied in the request body (used by the update endpoint, which resolves the test case by its body id).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const UpdateTestCase500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const UpdateTestCaseDefaultResponse = zod
   .object({
@@ -1342,26 +2083,88 @@ export const GetTestCaseLinks200Response = zod
   .strict()
   .describe("A list of links for this test case.");
 
-export const GetTestCaseLinks401Response = zod
+export const GetTestCaseLinks400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestCaseLinks404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseLinks401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseLinks404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestCaseLinks500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseLinksDefaultResponse = zod
   .object({
@@ -1400,26 +2203,134 @@ export const CreateTestCaseIssueLink201Response = zod
   })
   .strict();
 
-export const CreateTestCaseIssueLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseIssueLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The Jira issue already has a coverage link to this test case. (Backend-asserted; not reproducible locally because the Jira issue lookup is unavailable and fails first.)",
+    ),
+]);
 
-export const CreateTestCaseIssueLink404Response = zod
+export const CreateTestCaseIssueLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestCaseIssueLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestCaseIssueLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A referenced Jira entity (e.g. jiraProjectVersion) does not exist or is not accessible.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestCaseIssueLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseIssueLinkDefaultResponse = zod
   .object({
@@ -1459,26 +2370,127 @@ export const CreateTestCaseWebLink201Response = zod
   })
   .strict();
 
-export const CreateTestCaseWebLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseWebLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A web link with the same URL and description already exists on the test case.",
+    ),
+]);
 
-export const CreateTestCaseWebLink404Response = zod
+export const CreateTestCaseWebLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestCaseWebLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestCaseWebLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the given testCaseKey (returned by the web-link and test-script write endpoints).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestCaseWebLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseWebLinkDefaultResponse = zod
   .object({
@@ -1582,26 +2594,99 @@ export const ListTestCaseVersions200Response = zod
   })
   .strict();
 
-export const ListTestCaseVersions401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestCaseVersions400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
 
-export const ListTestCaseVersions404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestCaseVersions401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const ListTestCaseVersions404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const ListTestCaseVersions500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestCaseVersionsDefaultResponse = zod
   .object({
@@ -1846,26 +2931,99 @@ export const GetTestCaseVersion200Response = zod
   })
   .strict();
 
-export const GetTestCaseVersion401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseVersion400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A numeric path parameter was sent with a non-numeric value (for example a non-numeric test case version).",
+    ),
+]);
 
-export const GetTestCaseVersion404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseVersion401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseVersion404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestCaseVersion500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseVersionDefaultResponse = zod
   .object({
@@ -1904,26 +3062,100 @@ export const GetTestCaseTestScript200Response = zod
   .strict()
   .describe("Response body when retrieving test scripts");
 
-export const GetTestCaseTestScript401Response = zod
+export const GetTestCaseTestScript400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestCaseTestScript404Response = zod
+export const GetTestCaseTestScript401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseTestScript404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test script (and no test case) exists for the given testCaseKey.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const GetTestCaseTestScript422Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The test case uses step-by-step test steps rather than a plain/BDD script; use the teststeps endpoint instead.",
+  );
 
 export const GetTestCaseTestScript500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseTestScriptDefaultResponse = zod
   .object({
@@ -1968,26 +3200,125 @@ export const CreateTestCaseTestScript201Response = zod
   })
   .strict();
 
-export const CreateTestCaseTestScript401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseTestScript400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The BDD test script text is not valid Gherkin."),
+]);
 
-export const CreateTestCaseTestScript404Response = zod
+export const CreateTestCaseTestScript401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestCaseTestScript403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestCaseTestScript404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the given testCaseKey (returned by the web-link and test-script write endpoints).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestCaseTestScript500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseTestScriptDefaultResponse = zod
   .object({
@@ -2172,26 +3503,116 @@ export const GetTestCaseTestSteps200Response = zod
   .strict()
   .describe("Response body when retrieving test steps");
 
-export const GetTestCaseTestSteps401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseTestSteps400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
 
-export const GetTestCaseTestSteps404Response = zod
+export const GetTestCaseTestSteps401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseTestSteps404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const GetTestCaseTestSteps422Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The test case uses a plain-text or BDD script rather than step-by-step steps; use the testscript endpoint instead.",
+  );
 
 export const GetTestCaseTestSteps500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseTestStepsDefaultResponse = zod
   .object({
@@ -2329,26 +3750,233 @@ export const CreateTestCaseTestSteps201Response = zod
   })
   .strict();
 
-export const CreateTestCaseTestSteps401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseTestSteps400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The test step write `mode` is not one of APPEND or OVERWRITE."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The request must contain at least 1 and at most 100 test steps.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A test step is malformed. Covers several variants that share this response shape:\n- "The step should be inline or call to test." (neither inline nor testCase set)\n- "The step should be inline or call to test, not both." (both set)\n- "Test Data, Description and Expected Result are empty." (inline step with no content)\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A call-to-test step references the same test case (circular reference).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A call-to-test step references a test case that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A custom field name in the body does not exist for the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A custom field value has the wrong type for the field definition. The message names the field and the expected type, e.g. "requires a number value", "requires a string value", "requires a boolean value", "requires a string which is in the format yyyy-MM-dd", or "requires a list".\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A choice custom field value references an option name that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project has required custom fields but the request omitted them.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "Custom fields were provided but not all required ones are present.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required custom field was provided with a null or empty value.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required multi-choice custom field was set to an empty collection.",
+    ),
+]);
 
-export const CreateTestCaseTestSteps404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseTestSteps401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestCaseTestSteps403Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("Referenced custom fields do not belong to the current client."),
+]);
+
+export const CreateTestCaseTestSteps404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the given testCaseKey (returned by the web-link and test-script write endpoints).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestCaseTestSteps500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseTestStepsDefaultResponse = zod
   .object({
@@ -2378,33 +4006,71 @@ export const GetTestCaseAttachmentParams = zod
   })
   .strict();
 
-export const GetTestCaseAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A numeric path parameter was sent with a non-numeric value (for example a non-numeric test case version).",
+    ),
+]);
 
-export const GetTestCaseAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const GetTestCaseAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const GetTestCaseAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseAttachmentDefaultResponse = zod
   .object({
@@ -2447,47 +4113,71 @@ export const UploadTestCaseAttachmentParams = zod
   })
   .strict();
 
-export const UploadTestCaseAttachment400Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UploadTestCaseAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+]);
 
-export const UploadTestCaseAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestCaseAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestCaseAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestCaseAttachment413Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UploadTestCaseAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const UploadTestCaseAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const UploadTestCaseAttachmentDefaultResponse = zod
   .object({
@@ -2538,47 +4228,80 @@ export const CreateTestCaseTestStepAttachmentParams = zod
   })
   .strict();
 
-export const CreateTestCaseTestStepAttachment400Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseTestStepAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A numeric path parameter was sent with a non-numeric value (for example a non-numeric test case version).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+]);
 
-export const CreateTestCaseTestStepAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestCaseTestStepAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestCaseTestStepAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestCaseTestStepAttachment413Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestCaseTestStepAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const CreateTestCaseTestStepAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestCaseTestStepAttachmentDefaultResponse = zod
   .object({
@@ -2611,33 +4334,71 @@ export const GetTestCaseStepAttachmentParams = zod
   })
   .strict();
 
-export const GetTestCaseStepAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseStepAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A numeric path parameter was sent with a non-numeric value (for example a non-numeric test case version).",
+    ),
+]);
 
-export const GetTestCaseStepAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const GetTestCaseStepAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseStepAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const GetTestCaseStepAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseStepAttachmentDefaultResponse = zod
   .object({
@@ -2691,26 +4452,104 @@ export const GetTestCaseTestStepAttachmentsReference200Response = zod
   })
   .strict();
 
-export const GetTestCaseTestStepAttachmentsReference401Response = zod
+export const GetTestCaseTestStepAttachmentsReference400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestCaseTestStepAttachmentsReference404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseTestStepAttachmentsReference401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseTestStepAttachmentsReference404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the given testCaseKey (returned by the web-link and test-script write endpoints).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The given test step id does not exist for the test case."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The test case step exists but has no attachment metadata."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestCaseTestStepAttachmentsReference500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseTestStepAttachmentsReferenceDefaultResponse = zod
   .object({
@@ -2756,26 +4595,97 @@ export const GetTestCaseAttachmentsReference200Response = zod
   })
   .strict();
 
-export const GetTestCaseAttachmentsReference401Response = zod
+export const GetTestCaseAttachmentsReference400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestCaseAttachmentsReference404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestCaseAttachmentsReference401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestCaseAttachmentsReference404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "No test case exists for the given testCaseKey (returned by the web-link and test-script write endpoints).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The test case exists but has no attachment metadata."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestCaseAttachmentsReference500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestCaseAttachmentsReferenceDefaultResponse = zod
   .object({
@@ -4343,10 +6253,16 @@ export const UpdateTestCycleBody = zod
       .strict()
       .describe("ID and link relative to Zephyr project."),
     jiraProjectVersion: zod
-      .number()
-      .min(1)
-      .nullable()
-      .optional()
+      .object({
+        id: zod.number().min(1).describe("The ID of the entity"),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe("The REST API endpoint to get more resource details."),
+      })
+      .strict()
+      .nullish()
       .describe(
         "ID and Link to fetch information about Jira Project version. Relates to 'Version' or 'Releases' in Jira projects.",
       ),
@@ -4362,10 +6278,16 @@ export const UpdateTestCycleBody = zod
       .strict()
       .describe("ID and link to the status resource."),
     folder: zod
-      .number()
-      .min(1)
-      .nullable()
-      .optional()
+      .object({
+        id: zod.number().min(1).describe("The ID of the entity"),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe("The REST API endpoint to get more resource details."),
+      })
+      .strict()
+      .nullish()
       .describe("ID and link to the folder resource."),
     description: zod
       .string()
@@ -4386,10 +6308,22 @@ export const UpdateTestCycleBody = zod
         "The planned end date of the test cycle. This field cannot be blank. Setting it as null or excluding it from the request will leave the field values unchanged. ISO 8601 Format (i.e., yyyy-MM-dd'T'HH:mm:ss'Z')",
       ),
     owner: zod
-      .string()
-      .regex(updateTestCycleBodyOwnerAccountIdRegExp)
-      .nullable()
-      .describe("Atlassian Account ID of the Jira user."),
+      .object({
+        accountId: zod
+          .string()
+          .regex(updateTestCycleBodyOwnerAccountIdRegExp)
+          .nullable()
+          .describe("Atlassian Account ID of the Jira user."),
+        self: zod
+          .string()
+          .url()
+          .optional()
+          .describe(
+            "The Jira REST API endpoint to get the full representation of the Jira user.",
+          ),
+      })
+      .strict()
+      .nullish(),
     customFields: zod
       .record(zod.string(), zod.unknown())
       .optional()
@@ -5624,19 +7558,69 @@ export const ListTestPlans200Response = zod
   })
   .strict();
 
-export const ListTestPlans401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestPlans400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestPlans401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const ListTestPlans500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestPlansDefaultResponse = zod
   .object({
@@ -5712,19 +7696,220 @@ export const CreateTestPlan201Response = zod
   })
   .strict();
 
-export const CreateTestPlan401Response = zod
+export const CreateTestPlan400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field has the wrong type or format (for example a non-ISO-8601 date).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The folderId in the body refers to a folder that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains more than the maximum of 50 items."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The labels array contains an empty or blank label."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A label in the labels array contains spaces, which is not allowed.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A custom field name in the body does not exist for the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A custom field value has the wrong type for the field definition. The message names the field and the expected type, e.g. "requires a number value", "requires a string value", "requires a boolean value", "requires a string which is in the format yyyy-MM-dd", or "requires a list".\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A choice custom field value references an option name that does not exist.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project has required custom fields but the request omitted them.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "Custom fields were provided but not all required ones are present.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required custom field was provided with a null or empty value.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required multi-choice custom field was set to an empty collection.",
+    ),
+]);
+
+export const CreateTestPlan401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestPlan403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestPlan404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The projectKey filter refers to a project that does not exist or is deactivated.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The statusName does not exist for the project."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestPlan500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestPlanDefaultResponse = zod
   .object({
@@ -6013,6 +8198,70 @@ export const ListTestPlansCursorPaginated200Response = zod
   })
   .strict();
 
+export const ListTestPlansCursorPaginated400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestPlansCursorPaginated401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const ListTestPlansCursorPaginated500Response = zod
+  .object({
+    errorCode: zod.number(),
+    message: zod.string(),
+  })
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
+
 export const ListTestPlansCursorPaginatedDefaultResponse = zod
   .object({
     errorCode: zod.number(),
@@ -6230,26 +8479,88 @@ export const GetTestPlan200Response = zod
   })
   .strict();
 
-export const GetTestPlan401Response = zod
+export const GetTestPlan400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestPlan404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestPlan401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestPlan404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test plan exists for the given ID or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestPlan500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestPlanDefaultResponse = zod
   .object({
@@ -6291,26 +8602,124 @@ export const CreateTestPlanWebLink201Response = zod
   })
   .strict();
 
-export const CreateTestPlanWebLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestPlanWebLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const CreateTestPlanWebLink404Response = zod
+export const CreateTestPlanWebLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestPlanWebLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestPlanWebLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test plan exists for the given ID or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const CreateTestPlanWebLink422Response = zod
+  .object({
+    errorCode: zod.number(),
+    message: zod.string(),
+  })
+  .strict()
+  .describe("A web link with the same URL already exists on the test plan.");
 
 export const CreateTestPlanWebLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestPlanWebLinkDefaultResponse = zod
   .object({
@@ -6350,26 +8759,135 @@ export const CreateTestPlanIssueLink201Response = zod
   })
   .strict();
 
-export const CreateTestPlanIssueLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestPlanIssueLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const CreateTestPlanIssueLink404Response = zod
+export const CreateTestPlanIssueLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestPlanIssueLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestPlanIssueLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test plan exists for the given ID or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A referenced Jira entity (e.g. jiraProjectVersion) does not exist or is not accessible.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const CreateTestPlanIssueLink422Response = zod
+  .object({
+    errorCode: zod.number(),
+    message: zod.string(),
+  })
+  .strict()
+  .describe(
+    "An issue link with the same issueId already exists on the entity.",
+  );
 
 export const CreateTestPlanIssueLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestPlanIssueLinkDefaultResponse = zod
   .object({
@@ -6415,26 +8933,131 @@ export const CreateTestPlanTestCycleLink201Response = zod
   })
   .strict();
 
-export const CreateTestPlanTestCycleLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestPlanTestCycleLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const CreateTestPlanTestCycleLink404Response = zod
+export const CreateTestPlanTestCycleLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestPlanTestCycleLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestPlanTestCycleLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test plan exists for the given ID or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test cycle exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const CreateTestPlanTestCycleLink422Response = zod
+  .object({
+    errorCode: zod.number(),
+    message: zod.string(),
+  })
+  .strict()
+  .describe("A link to the same test cycle already exists on the entity.");
 
 export const CreateTestPlanTestCycleLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestPlanTestCycleLinkDefaultResponse = zod
   .object({
@@ -6465,33 +9088,80 @@ export const GetTestPlanAttachmentParams = zod
   })
   .strict();
 
-export const GetTestPlanAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestPlanAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A numeric path parameter was sent with a non-numeric value (for example a non-numeric test case version).",
+    ),
+]);
 
-export const GetTestPlanAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const GetTestPlanAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestPlanAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const GetTestPlanAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestPlanAttachmentDefaultResponse = zod
   .object({
@@ -6504,10 +9174,14 @@ export const GetTestPlanAttachmentDefaultResponse = zod
  * Returns a paged list of attachments for a test plan, including their database ID and file name.
  * @summary Get test plan attachments
  */
+export const getTestPlanAttachmentsReferencePathTestPlanIdOrKeyRegExp =
+  /([0-9]+)|(.+-P[0-9]+)/;
+
 export const GetTestPlanAttachmentsReferenceParams = zod
   .object({
     testPlanIdOrKey: zod
       .string()
+      .regex(getTestPlanAttachmentsReferencePathTestPlanIdOrKeyRegExp)
       .describe(
         "The ID or key of the test plan. Test plan keys are of the format [A-Z]+-P[0-9]+",
       ),
@@ -6535,26 +9209,95 @@ export const GetTestPlanAttachmentsReference200Response = zod
   })
   .strict();
 
-export const GetTestPlanAttachmentsReference401Response = zod
+export const GetTestPlanAttachmentsReference400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestPlanAttachmentsReference404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestPlanAttachmentsReference401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestPlanAttachmentsReference404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test plan exists for the given ID or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The test plan exists but has no attachment metadata."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestPlanAttachmentsReference500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestPlanAttachmentsReferenceDefaultResponse = zod
   .object({
@@ -6598,47 +9341,71 @@ export const CreateTestPlanAttachmentParams = zod
   })
   .strict();
 
-export const CreateTestPlanAttachment400Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestPlanAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+]);
 
-export const CreateTestPlanAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestPlanAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestPlanAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestPlanAttachment413Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestPlanAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const CreateTestPlanAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestPlanAttachmentDefaultResponse = zod
   .object({
@@ -6979,19 +9746,69 @@ export const ListTestExecutions200Response = zod
   })
   .strict();
 
-export const ListTestExecutions401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestExecutions400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestExecutions401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const ListTestExecutions500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestExecutionsDefaultResponse = zod
   .object({
@@ -7112,19 +9929,186 @@ export const CreateTestExecution201Response = zod
   })
   .strict();
 
-export const CreateTestExecution401Response = zod
+export const CreateTestExecution400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A custom field name in the body does not exist for the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      'A custom field value has the wrong type for the field definition. The message names the field and the expected type, e.g. "requires a number value", "requires a string value", "requires a boolean value", "requires a string which is in the format yyyy-MM-dd", or "requires a list".\n',
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The statusName provided for creating a test execution does not exist in the project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The project has required custom fields but the request omitted them.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "Custom fields were provided but not all required ones are present.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required custom field was provided with a null or empty value.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A required multi-choice custom field was set to an empty collection.",
+    ),
+]);
+
+export const CreateTestExecution401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestExecution403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestExecution404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test case exists for the given testCaseKey."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test cycle exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The projectKey filter refers to a project that does not exist or is deactivated.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestExecution500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestExecutionDefaultResponse = zod
   .object({
@@ -7462,19 +10446,69 @@ export const ListTestExecutionsNextgen200Response = zod
   })
   .strict();
 
-export const ListTestExecutionsNextgen401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestExecutionsNextgen400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
+
+export const ListTestExecutionsNextgen401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const ListTestExecutionsNextgen500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestExecutionsNextgenDefaultResponse = zod
   .object({
@@ -7689,26 +10723,88 @@ export const GetTestExecution200Response = zod
   })
   .strict();
 
-export const GetTestExecution401Response = zod
+export const GetTestExecution400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestExecution404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecution401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestExecution404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestExecution500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestExecutionDefaultResponse = zod
   .object({
@@ -7785,26 +10881,137 @@ export const UpdateTestExecutionBody = zod
   })
   .strict();
 
-export const UpdateTestExecution401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UpdateTestExecution400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const UpdateTestExecution404Response = zod
+export const UpdateTestExecution401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const UpdateTestExecution403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const UpdateTestExecution404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
+
+export const UpdateTestExecution422Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The provided status name does not exist for the test execution's project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The provided environment name does not exist for the test execution's project.",
+    ),
+]);
 
 export const UpdateTestExecution500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const UpdateTestExecutionDefaultResponse = zod
   .object({
@@ -7963,21 +11170,108 @@ export const GetTestExecutionTestSteps200Response = zod
   .strict()
   .describe("Response body when retrieving test steps for a test execution");
 
-export const GetTestExecutionTestSteps401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionTestSteps400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("A numeric query parameter was sent with a non-numeric value."),
+]);
 
-export const GetTestExecutionTestSteps404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionTestSteps401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestExecutionTestSteps404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestExecutionTestSteps500Response = zod
+  .object({
+    errorCode: zod.number(),
+    message: zod.string(),
+  })
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
+
+export const GetTestExecutionTestStepsDefaultResponse = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
@@ -8027,19 +11321,108 @@ export const PutTestExecutionTestStepsBody = zod
   })
   .strict();
 
-export const PutTestExecutionTestSteps401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const PutTestExecutionTestSteps400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const PutTestExecutionTestSteps404Response = zod
+export const PutTestExecutionTestSteps401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const PutTestExecutionTestSteps403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const PutTestExecutionTestSteps404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const PutTestExecutionTestSteps409Response = zod
   .object({
@@ -8061,6 +11444,15 @@ export const PutTestExecutionTestSteps422Response = zod.union([
       message: zod.string(),
     })
     .strict(),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The provided status name does not exist for the test execution's project.",
+    ),
 ]);
 
 export const PutTestExecutionTestSteps500Response = zod
@@ -8068,7 +11460,8 @@ export const PutTestExecutionTestSteps500Response = zod
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const PutTestExecutionTestStepsDefaultResponse = zod
   .object({
@@ -8105,19 +11498,90 @@ export const SyncTestExecutionScript200Response = zod
   })
   .strict();
 
-export const SyncTestExecutionScript401Response = zod
+export const SyncTestExecutionScript400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const SyncTestExecutionScript404Response = zod
+export const SyncTestExecutionScript401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const SyncTestExecutionScript403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const SyncTestExecutionScript404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const SyncTestExecutionScript409Response = zod
   .object({
@@ -8131,7 +11595,8 @@ export const SyncTestExecutionScript500Response = zod
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const SyncTestExecutionScriptDefaultResponse = zod
   .object({
@@ -8191,42 +11656,55 @@ export const CreateTestExecutionTestStepAttachment400Response = zod
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+  );
 
-export const CreateTestExecutionTestStepAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestExecutionTestStepAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestExecutionTestStepAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const CreateTestExecutionTestStepAttachment413Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestExecutionTestStepAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const CreateTestExecutionTestStepAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestExecutionTestStepAttachmentDefaultResponse = zod
   .object({
@@ -8298,26 +11776,71 @@ export const ListTestExecutionLinks200Response = zod
   })
   .strict();
 
-export const ListTestExecutionLinks401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestExecutionLinks400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The test execution key is well-formed but not found in the database (returned as 400 by the links endpoint).",
+    ),
+]);
 
-export const ListTestExecutionLinks404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const ListTestExecutionLinks401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const ListTestExecutionLinks500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const ListTestExecutionLinksDefaultResponse = zod
   .object({
@@ -8350,26 +11873,125 @@ export const CreateTestExecutionIssueLinkBody = zod
   })
   .strict();
 
-export const CreateTestExecutionIssueLink401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const CreateTestExecutionIssueLink400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("The request body is not valid JSON."),
+]);
 
-export const CreateTestExecutionIssueLink404Response = zod
+export const CreateTestExecutionIssueLink401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const CreateTestExecutionIssueLink403Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "The caller lacks a required Zephyr permission (when the project's permission system is enabled).",
+  );
+
+export const CreateTestExecutionIssueLink404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A referenced Jira entity (e.g. jiraProjectVersion) does not exist or is not accessible.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const CreateTestExecutionIssueLink500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const CreateTestExecutionIssueLinkDefaultResponse = zod
   .object({
@@ -8427,26 +12049,108 @@ export const GetTestExecutionTestStepAttachmentsReference200Response = zod
   })
   .strict();
 
-export const GetTestExecutionTestStepAttachmentsReference401Response = zod
+export const GetTestExecutionTestStepAttachmentsReference400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestExecutionTestStepAttachmentsReference404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionTestStepAttachmentsReference401Response =
+  zod.union([
+    zod
+      .object({
+        error: zod.string(),
+      })
+      .strict()
+      .describe("The Authorization header is missing."),
+    zod
+      .object({
+        error: zod.string(),
+      })
+      .strict()
+      .describe(
+        "The bearer token does not have the three dot-separated parts of a JWT.",
+      ),
+    zod
+      .object({
+        error: zod.string(),
+      })
+      .strict()
+      .describe("A segment of the bearer token is not valid base64."),
+    zod
+      .object({
+        error: zod.string(),
+      })
+      .strict()
+      .describe("A decoded segment of the bearer token is not valid JSON."),
+    zod
+      .object({
+        error: zod.string(),
+      })
+      .strict()
+      .describe(
+        "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+      ),
+  ]);
+
+export const GetTestExecutionTestStepAttachmentsReference404Response =
+  zod.union([
+    zod
+      .object({
+        errorCode: zod.number(),
+        message: zod.string(),
+      })
+      .strict()
+      .describe("No test execution exists with the given id or key."),
+    zod
+      .object({
+        errorCode: zod.number(),
+        message: zod.string(),
+      })
+      .strict()
+      .describe(
+        "The test execution step with the given ID does not exist in the test execution.",
+      ),
+    zod
+      .object({
+        errorCode: zod.number(),
+        message: zod.string(),
+      })
+      .strict()
+      .describe(
+        "No attachment metadata was found for the given test execution step.",
+      ),
+    zod
+      .object({
+        errorCode: zod.number(),
+        message: zod.string(),
+      })
+      .strict()
+      .describe(
+        "The referenced resource does not exist, or the caller does not have access to its project.",
+      ),
+    zod
+      .object({
+        errorCode: zod.number(),
+        message: zod.string(),
+      })
+      .strict()
+      .describe(
+        "The referenced resource belongs to a disabled project, or a project that does not exist.",
+      ),
+  ]);
 
 export const GetTestExecutionTestStepAttachmentsReference500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestExecutionTestStepAttachmentsReferenceDefaultResponse = zod
   .object({
@@ -8494,26 +12198,95 @@ export const GetTestExecutionAttachmentsReference200Response = zod
   })
   .strict();
 
-export const GetTestExecutionAttachmentsReference401Response = zod
+export const GetTestExecutionAttachmentsReference400Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+  );
 
-export const GetTestExecutionAttachmentsReference404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionAttachmentsReference401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
+
+export const GetTestExecutionAttachmentsReference404Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No test execution exists with the given id or key."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe("No attachment metadata was found for the given test execution."),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource does not exist, or the caller does not have access to its project.",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The referenced resource belongs to a disabled project, or a project that does not exist.",
+    ),
+]);
 
 export const GetTestExecutionAttachmentsReference500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestExecutionAttachmentsReferenceDefaultResponse = zod
   .object({
@@ -8565,42 +12338,55 @@ export const UploadTestExecutionAttachment400Response = zod
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe(
+    "A request body field failed validation at the API layer (required field missing, pattern mismatch, size, or numeric bound).",
+  );
 
-export const UploadTestExecutionAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestExecutionAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestExecutionAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const UploadTestExecutionAttachment413Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const UploadTestExecutionAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const UploadTestExecutionAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const UploadTestExecutionAttachmentDefaultResponse = zod
   .object({
@@ -8635,33 +12421,71 @@ export const GetTestExecutionStepAttachmentParams = zod
   })
   .strict();
 
-export const GetTestExecutionStepAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionStepAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+]);
 
-export const GetTestExecutionStepAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const GetTestExecutionStepAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionStepAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const GetTestExecutionStepAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestExecutionStepAttachmentDefaultResponse = zod
   .object({
@@ -8692,33 +12516,71 @@ export const GetTestExecutionAttachmentParams = zod
   })
   .strict();
 
-export const GetTestExecutionAttachment401Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionAttachment400Response = zod.union([
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A path parameter failed validation at the API layer (for example a testCaseKey that does not match its required pattern).",
+    ),
+  zod
+    .object({
+      errorCode: zod.number(),
+      message: zod.string(),
+    })
+    .strict()
+    .describe(
+      "A query parameter failed validation at the API layer (projectKey pattern, or the numeric bounds maxResults >= 1, startAt 0..1000000, folderId >= 1, jiraProjectVersionId >= 1).",
+    ),
+]);
 
-export const GetTestExecutionAttachment403Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
-
-export const GetTestExecutionAttachment404Response = zod
-  .object({
-    errorCode: zod.number(),
-    message: zod.string(),
-  })
-  .strict();
+export const GetTestExecutionAttachment401Response = zod.union([
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("The Authorization header is missing."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The bearer token does not have the three dot-separated parts of a JWT.",
+    ),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A segment of the bearer token is not valid base64."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe("A decoded segment of the bearer token is not valid JSON."),
+  zod
+    .object({
+      error: zod.string(),
+    })
+    .strict()
+    .describe(
+      "The JWT is well-formed but its signature could not be verified (wrong secret, tampered, or unknown issuer).",
+    ),
+]);
 
 export const GetTestExecutionAttachment500Response = zod
   .object({
     errorCode: zod.number(),
     message: zod.string(),
   })
-  .strict();
+  .strict()
+  .describe("The backend service returned a 5xx or could not be reached.");
 
 export const GetTestExecutionAttachmentDefaultResponse = zod
   .object({

--- a/src/zephyr/common/utils.test.ts
+++ b/src/zephyr/common/utils.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { deepMerge } from "./utils";
+import { z } from "zod";
+import { deepMerge, deepStrip } from "./utils";
+
+// A permissive schema so these cases exercise merge behavior without stripping.
+const passthrough = z.any();
 
 describe("deepMerge", () => {
   it("should merge two simple objects", () => {
     const baseObject = { a: 1, b: 2 };
     const objectWithUpdates = { b: 3, c: 4 };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ a: 1, b: 3, c: 4 });
   });
@@ -18,7 +22,7 @@ describe("deepMerge", () => {
     const objectWithUpdates = {
       customFields: { field2: "updated", field3: "new" },
     };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({
       a: 1,
@@ -29,7 +33,7 @@ describe("deepMerge", () => {
   it("should skip undefined values", () => {
     const baseObject = { a: 1, b: 2 };
     const objectWithUpdates = { b: undefined, c: 3 };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ a: 1, b: 2, c: 3 });
   });
@@ -37,7 +41,7 @@ describe("deepMerge", () => {
   it("should overwrite with null values", () => {
     const baseObject = { a: 1, component: { id: 1 } };
     const objectWithUpdates = { component: null };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ a: 1, component: null });
   });
@@ -48,7 +52,7 @@ describe("deepMerge", () => {
       component: null,
     };
     const objectWithUpdates = { component: { id: 1 } };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ a: 1, component: { id: 1 } });
   });
@@ -58,7 +62,7 @@ describe("deepMerge", () => {
       a: 1,
     };
     const objectWithUpdates = { component: { id: 1 } };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ a: 1, component: { id: 1 } });
   });
@@ -66,8 +70,77 @@ describe("deepMerge", () => {
   it("should replace arrays rather than merge them", () => {
     const baseObject = { labels: ["old", "label"] };
     const objectWithUpdates = { labels: ["new", "labels"] };
-    const result = deepMerge(baseObject, objectWithUpdates);
+    const result = deepMerge(baseObject, objectWithUpdates, passthrough);
 
     expect(result).toEqual({ labels: ["new", "labels"] });
+  });
+
+  it("should replace non-plain objects (e.g. Date) wholesale", () => {
+    const baseObject = { when: new Date("2020-01-01T00:00:00Z") };
+    const updated = new Date("2024-06-01T00:00:00Z");
+    const result = deepMerge(baseObject, { when: updated }, passthrough);
+
+    expect(result.when).toBe(updated);
+  });
+
+  it("should strip keys not declared in the target schema", () => {
+    const schema = z.object({ a: z.number(), b: z.number() }).strict();
+    const baseObject = { a: 1, b: 2, extra: "drop me", createdOn: "x" };
+    const objectWithUpdates = { b: 3 };
+
+    const result = deepMerge(baseObject, objectWithUpdates, schema);
+
+    expect(result).toEqual({ a: 1, b: 3 });
+  });
+
+  it("should strip unknown keys nested inside strict sub-objects", () => {
+    const schema = z
+      .object({
+        id: z.number(),
+        nested: z.object({ id: z.number() }).strict(),
+      })
+      .strict();
+    const baseObject = {
+      id: 1,
+      nested: { id: 2, self: "url", extra: true },
+      links: ["remove"],
+    };
+
+    const result = deepMerge(baseObject, {}, schema);
+
+    expect(result).toEqual({ id: 1, nested: { id: 2 } });
+  });
+
+  it("should still enforce leaf validations after stripping", () => {
+    const schema = z.object({ name: z.string().min(1) }).strict();
+
+    expect(() => deepMerge({ name: "", extra: 1 }, {}, schema)).toThrow();
+  });
+});
+
+describe("deepStrip", () => {
+  it("loosens strict objects at every level while keeping known keys", () => {
+    const schema = z
+      .object({
+        id: z.number(),
+        child: z.object({ id: z.number() }).strict(),
+        list: z.array(z.object({ id: z.number() }).strict()),
+      })
+      .strict();
+
+    const parsed = deepStrip(schema).parse({
+      id: 1,
+      child: { id: 2, extra: 1 },
+      list: [{ id: 3, extra: 2 }],
+      topExtra: "x",
+    });
+
+    expect(parsed).toEqual({ id: 1, child: { id: 2 }, list: [{ id: 3 }] });
+  });
+
+  it("preserves leaf validation rules", () => {
+    const schema = z.object({ n: z.number().min(1) }).strict();
+
+    expect(() => deepStrip(schema).parse({ n: 0 })).toThrow();
   });
 });

--- a/src/zephyr/common/utils.test.ts
+++ b/src/zephyr/common/utils.test.ts
@@ -116,6 +116,13 @@ describe("deepMerge", () => {
 
     expect(() => deepMerge({ name: "", extra: 1 }, {}, schema)).toThrow();
   });
+
+  it("should return the base object unchanged when the updates argument itself is undefined", () => {
+    const baseObject = { a: 1, b: 2 };
+    const result = deepMerge(baseObject, undefined as any, passthrough);
+
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
 });
 
 describe("deepStrip", () => {
@@ -142,5 +149,25 @@ describe("deepStrip", () => {
     const schema = z.object({ n: z.number().min(1) }).strict();
 
     expect(() => deepStrip(schema).parse({ n: 0 })).toThrow();
+  });
+
+  it("applies the default value on a default()-wrapped field", () => {
+    const schema = z.object({ status: z.string().default("open") }).strict();
+
+    const parsed = deepStrip(schema).parse({ extra: "drop me" });
+
+    expect(parsed).toEqual({ status: "open" });
+  });
+
+  it("loosens strict objects nested inside a union", () => {
+    const branchA = z.object({ type: z.literal("a"), a: z.number() }).strict();
+    const branchB = z.object({ type: z.literal("b"), b: z.number() }).strict();
+    const schema = z.object({ payload: z.union([branchA, branchB]) }).strict();
+
+    const parsed = deepStrip(schema).parse({
+      payload: { type: "a", a: 1, extra: "drop me" },
+    });
+
+    expect(parsed).toEqual({ payload: { type: "a", a: 1 } });
   });
 });

--- a/src/zephyr/common/utils.test.ts
+++ b/src/zephyr/common/utils.test.ts
@@ -75,7 +75,7 @@ describe("deepMerge", () => {
     expect(result).toEqual({ labels: ["new", "labels"] });
   });
 
-  it("should replace non-plain objects (e.g. Date) wholesale", () => {
+  it("should replace non-plain objects (e.g. Date) completely", () => {
     const baseObject = { when: new Date("2020-01-01T00:00:00Z") };
     const updated = new Date("2024-06-01T00:00:00Z");
     const result = deepMerge(baseObject, { when: updated }, passthrough);

--- a/src/zephyr/common/utils.ts
+++ b/src/zephyr/common/utils.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
  * - `undefined` in `objectWithUpdates` is skipped (the base value is kept).
  * - `null` is treated as a real value and overwrites the base value.
  * - Plain objects are merged recursively; arrays and non-plain objects
- *   (e.g. Date, Map, class instances) are replaced wholesale.
+ *   (e.g. Date, Map, class instances) are replaced completely.
  *
  * The merged result is parsed through `targetSchema` so the output shape/type
  * is guaranteed. The schema is deep-stripped first (see {@link deepStrip}), so
@@ -49,7 +49,7 @@ function mergeValues(base: unknown, updated: unknown): unknown {
     return result;
   }
 
-  // Primitives, arrays, null, and non-plain objects: overwrite wholesale.
+  // Primitives, arrays, null, and non-plain objects: overwrite the whole value.
   return updated;
 }
 

--- a/src/zephyr/common/utils.ts
+++ b/src/zephyr/common/utils.ts
@@ -1,45 +1,111 @@
+import { z } from "zod";
+
 /**
- * Deep merge two objects, with properties from 'updates' taking precedence.
- * For nested objects, this merges rather than replaces them entirely.
+ * Deep merge two objects and coerce the result to a target Zod schema.
  *
- * @param baseObject - The base object to merge into
- * @param objectWithUpdates - The object with updates to apply
- * @returns The merged object
+ * Merge rules:
+ * - Values from `objectWithUpdates` take precedence over `baseObject`.
+ * - `undefined` in `objectWithUpdates` is skipped (the base value is kept).
+ * - `null` is treated as a real value and overwrites the base value.
+ * - Plain objects are merged recursively; arrays and non-plain objects
+ *   (e.g. Date, Map, class instances) are replaced wholesale.
+ *
+ * The merged result is parsed through `targetSchema` so the output shape/type
+ * is guaranteed. The schema is deep-stripped first (see {@link deepStrip}), so
+ * any key not declared in the schema - at any nesting level - is dropped rather
+ * than causing a validation error, even when the schema is `.strict()`. Leaf
+ * validations (min, regex, ...) still apply, and the return value is typed as
+ * `z.infer<typeof targetSchema>`.
+ *
+ * @param baseObject - The base object to merge into (fallback values)
+ * @param objectWithUpdates - The object with updates to apply (takes precedence)
+ * @param targetSchema - The Zod schema the merged result must conform to
+ * @returns The merged object, stripped to the schema shape and typed as `z.infer<typeof targetSchema>`
  */
-export function deepMerge<
-  T extends Record<string, any>,
-  U extends Record<string, any>,
->(baseObject: T, objectWithUpdates: U): T {
-  const result: Record<string, any> = { ...baseObject };
-
-  for (const key in objectWithUpdates) {
-    if (objectWithUpdates[key] === undefined) {
-      // Skip undefined values - don't include them in the merge
-      continue;
-    }
-
-    if (objectsCanBeMerged(baseObject, objectWithUpdates, key)) {
-      // Deep merge nested objects (like customFields)
-      result[key] = deepMerge(baseObject[key], objectWithUpdates[key]);
-    } else {
-      // For primitives, arrays, and null values, just overwrite
-      result[key] = objectWithUpdates[key];
-    }
-  }
-
-  return result as T;
+export function deepMerge<S extends z.ZodTypeAny>(
+  baseObject: Record<string, any>,
+  objectWithUpdates: Record<string, any>,
+  targetSchema: S,
+): z.infer<S> {
+  const merged = mergeValues(baseObject, objectWithUpdates);
+  return deepStrip(targetSchema).parse(merged);
 }
 
-function objectsCanBeMerged<
-  T extends Record<string, any>,
-  U extends Record<string, any>,
->(baseObject: T, objectWithUpdates: U, key: Extract<keyof U, string>): boolean {
-  return (
-    objectWithUpdates[key] &&
-    typeof objectWithUpdates[key] === "object" &&
-    !Array.isArray(objectWithUpdates[key]) &&
-    baseObject[key] &&
-    typeof baseObject[key] === "object" &&
-    !Array.isArray(baseObject[key])
-  );
+/** Recursively merge two arbitrary values, with `updated` taking precedence. */
+function mergeValues(base: unknown, updated: unknown): unknown {
+  // Skip undefined updates - don't include them in the merge.
+  if (updated === undefined) {
+    return base;
+  }
+
+  if (isPlainObject(base) && isPlainObject(updated)) {
+    const result: Record<string, unknown> = { ...base };
+    for (const key of Object.keys(updated)) {
+      if (updated[key] === undefined) {
+        continue;
+      }
+      result[key] = mergeValues(base[key], updated[key]);
+    }
+    return result;
+  }
+
+  // Primitives, arrays, null, and non-plain objects: overwrite wholesale.
+  return updated;
+}
+
+/** True only for plain object literals (not arrays, Dates, Maps, class instances, ...). */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively rebuild a Zod schema so every object level strips unknown keys
+ * instead of rejecting them. Only object strictness is loosened - leaf
+ * validations and the inferred type are preserved - so parsing a superset
+ * object yields exactly the schema's shape without throwing on extra keys.
+ *
+ * Handles the constructs used by the update-body schemas (object, array,
+ * optional, nullable, default, record, union). Any other node is returned
+ * unchanged, which means strict objects nested inside an unsupported wrapper
+ * would not be loosened - none exist in the current schemas.
+ */
+export function deepStrip<T extends z.ZodTypeAny>(schema: T): T {
+  return stripNode(schema) as unknown as T;
+}
+
+function stripNode(schema: z.ZodTypeAny): z.ZodTypeAny {
+  // biome-ignore lint/suspicious/noExplicitAny: traversing zod's internal defs
+  const def = schema.def as any;
+
+  switch (def.type) {
+    case "object": {
+      const shape = def.shape as Record<string, z.ZodTypeAny>;
+      const strippedShape: Record<string, z.ZodTypeAny> = {};
+      for (const key of Object.keys(shape)) {
+        strippedShape[key] = stripNode(shape[key]);
+      }
+      // z.object strips unknown keys by default in zod v4.
+      return z.object(strippedShape);
+    }
+    case "array":
+      return z.array(stripNode(def.element));
+    case "optional":
+      return z.optional(stripNode(def.innerType));
+    case "nullable":
+      return z.nullable(stripNode(def.innerType));
+    case "default":
+      return stripNode(def.innerType).default(def.defaultValue);
+    case "record":
+      return z.record(def.keyType, stripNode(def.valueType));
+    case "union":
+      return z.union(
+        def.options.map((option: z.ZodTypeAny) => stripNode(option)),
+      );
+    default:
+      return schema;
+  }
 }

--- a/src/zephyr/tool/test-case/update-test-case.test.ts
+++ b/src/zephyr/tool/test-case/update-test-case.test.ts
@@ -544,6 +544,68 @@ describe("UpdateTestCase", () => {
       expect(mergedBody.objective).toBe("Original objective"); // Preserved
     });
 
+    it("should expand a primitive folder ID into a folder object", async () => {
+      const args = {
+        testCaseKey: "SA-T10",
+        id: 12345,
+        key: "SA-T10",
+        name: "Original Test Case",
+        project: { id: 100 },
+        priority: { id: 1 },
+        status: { id: 1 },
+        folder: 456,
+      };
+
+      await instance.handle(args, EXTRA_REQUEST_HANDLER);
+
+      const putCall = mockClient.getApiClient().put.mock.calls[0];
+      const mergedBody = putCall[1];
+
+      expect(mergedBody.folder).toEqual({ id: 456 });
+    });
+
+    it("should expand a primitive owner accountId into an owner object", async () => {
+      const args = {
+        testCaseKey: "SA-T10",
+        id: 12345,
+        key: "SA-T10",
+        name: "Original Test Case",
+        project: { id: 100 },
+        priority: { id: 1 },
+        status: { id: 1 },
+        owner: "5b10a2844c20165700ede21g",
+      };
+
+      await instance.handle(args, EXTRA_REQUEST_HANDLER);
+
+      const putCall = mockClient.getApiClient().put.mock.calls[0];
+      const mergedBody = putCall[1];
+
+      expect(mergedBody.owner).toEqual({
+        accountId: "5b10a2844c20165700ede21g",
+      });
+    });
+
+    it("should expand a primitive component ID into a component object", async () => {
+      const args = {
+        testCaseKey: "SA-T10",
+        id: 12345,
+        key: "SA-T10",
+        name: "Original Test Case",
+        project: { id: 100 },
+        priority: { id: 1 },
+        status: { id: 1 },
+        component: 789,
+      };
+
+      await instance.handle(args, EXTRA_REQUEST_HANDLER);
+
+      const putCall = mockClient.getApiClient().put.mock.calls[0];
+      const mergedBody = putCall[1];
+
+      expect(mergedBody.component).toEqual({ id: 789 });
+    });
+
     it("Links and the createdOn field should not be included in the PUT request", async () => {
       const args = {
         testCaseKey: "SA-T10",

--- a/src/zephyr/tool/test-case/update-test-case.ts
+++ b/src/zephyr/tool/test-case/update-test-case.ts
@@ -32,7 +32,7 @@ const UpdateTestCaseBodyToolInput = UpdateTestCaseBody.extend({
     .regex(updateTestCaseBodyOwnerAccountIdRegExp)
     .nullish()
     .describe("Atlassian Account ID of the Jira user to set as owner."),
-});
+}).partial();
 
 export class UpdateTestCase extends Tool<ZephyrClient> {
   specification: ToolParams = {
@@ -42,9 +42,7 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
       'Update an existing Test Case in Zephyr. This operation fetches the current test case and merges your updates with it to prevent accidental property deletion. Properties which are not included in the tool call will be left unchanged. To remove a property, set it to null explicitly. For fields that accept multiple values, such as `labels`, if the field is provided, it will override the previous values. For example, if `labels` is provided with the values `["label1", "label2"]`, the Test Case will now only have those two labels, and any previous labels will be removed. If you want to add a label, you would need to specify in the prompt the intention to add a label.',
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCaseParams.and(
-      UpdateTestCaseBodyToolInput.partial(),
-    ),
+    inputSchema: UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput),
     examples: [
       {
         description:
@@ -117,9 +115,9 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
-    const parsed = UpdateTestCaseParams.and(
-      UpdateTestCaseBodyToolInput.partial(),
-    ).parse(args);
+    const parsed = UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput).parse(
+      args,
+    );
 
     const { testCaseKey, ...updatesFromToolInput } = parsed;
 
@@ -155,9 +153,7 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
   // expanding the primitive folder/component/owner IDs back into the `{ id }` /
   // `{ accountId }` objects the REST API's UpdateTestCaseBody shape expects.
   private toRestApiUpdates(
-    updatesFromToolInput: Partial<
-      zod.infer<typeof UpdateTestCaseBodyToolInput>
-    >,
+    updatesFromToolInput: zod.infer<typeof UpdateTestCaseBodyToolInput>,
   ) {
     const restApiCompatibleFields: Partial<
       zod.infer<typeof UpdateTestCaseBody>

--- a/src/zephyr/tool/test-case/update-test-case.ts
+++ b/src/zephyr/tool/test-case/update-test-case.ts
@@ -1,5 +1,6 @@
 import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape, z as zod } from "zod";
+import type { ZodRawShape } from "zod";
+import { z as zod } from "zod";
 import { Tool } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
@@ -7,8 +8,31 @@ import {
   type GetTestCase200Response,
   UpdateTestCaseBody,
   UpdateTestCaseParams,
+  updateTestCaseBodyOwnerAccountIdRegExp,
 } from "../../common/rest-api-schemas";
 import { deepMerge } from "../../common/utils";
+
+// The update API expects a folder/component/owner as `{ id }` / `{ accountId }`
+// optional objects, but that optional objects are not supported the same way by all LLMs.
+// Expose them as plain IDs here and expand them back into objects before merging into the
+// real UpdateTestCaseBody shape (i.e., the one required by the REST API).
+const UpdateTestCaseBodyToolInput = UpdateTestCaseBody.extend({
+  folder: zod
+    .number()
+    .min(1)
+    .nullish()
+    .describe("The ID of the folder to move the test case into."),
+  component: zod
+    .number()
+    .min(1)
+    .nullish()
+    .describe("The ID of the Jira component to associate."),
+  owner: zod
+    .string()
+    .regex(updateTestCaseBodyOwnerAccountIdRegExp)
+    .nullish()
+    .describe("Atlassian Account ID of the Jira user to set as owner."),
+});
 
 export class UpdateTestCase extends Tool<ZephyrClient> {
   specification: ToolParams = {
@@ -18,7 +42,9 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
       'Update an existing Test Case in Zephyr. This operation fetches the current test case and merges your updates with it to prevent accidental property deletion. Properties which are not included in the tool call will be left unchanged. To remove a property, set it to null explicitly. For fields that accept multiple values, such as `labels`, if the field is provided, it will override the previous values. For example, if `labels` is provided with the values `["label1", "label2"]`, the Test Case will now only have those two labels, and any previous labels will be removed. If you want to add a label, you would need to specify in the prompt the intention to add a label.',
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCaseParams.and(UpdateTestCaseBody.partial()),
+    inputSchema: UpdateTestCaseParams.and(
+      UpdateTestCaseBodyToolInput.partial(),
+    ),
     examples: [
       {
         description:
@@ -91,31 +117,13 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
   };
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
-    const parsed = UpdateTestCaseParams.and(UpdateTestCaseBody.partial()).parse(
-      args,
-    );
+    const parsed = UpdateTestCaseParams.and(
+      UpdateTestCaseBodyToolInput.partial(),
+    ).parse(args);
 
-    const { testCaseKey, ...rawUpdates } = parsed;
+    const { testCaseKey, ...updatesFromToolInput } = parsed;
 
-    const nullValuesObject: Record<string, any> = {};
-
-    if (rawUpdates.folder) {
-      //do nothing when null or undefined
-      nullValuesObject.folder = { id: rawUpdates.folder };
-    }
-    if (rawUpdates.owner) {
-      //do nothing when null or undefined
-      nullValuesObject.owner = { accountId: rawUpdates.owner };
-    }
-    if (rawUpdates.component) {
-      //do nothing when null or undefined
-      nullValuesObject.component = { id: rawUpdates.component };
-    }
-
-    const updates = {
-      ...rawUpdates,
-      ...nullValuesObject,
-    };
+    const updatesForRestApi = this.toRestApiUpdates(updatesFromToolInput);
 
     // Fetch the existing test case to ensure we have all properties
     // This is necessary because Zephyr's PUT endpoints requires the complete resource
@@ -123,11 +131,15 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
     const existingTestCase: zod.infer<typeof GetTestCase200Response> =
       await this.client.getApiClient().get(`/testcases/${testCaseKey}`);
 
-    // Deep merge the updates with the existing test case
-    // For nested objects like customFields, we merge instead of replacing
-    const mergedBody = deepMerge(existingTestCase, updates);
-    delete mergedBody.createdOn;
-    delete mergedBody.links;
+    // Deep merge the updatesForRestApi with the existing test case, then coerce to the
+    // update body schema. For nested objects like customFields we merge instead
+    // of replacing, and the schema strips fields the PUT endpoint rejects
+    // (e.g. createdOn, links).
+    const mergedBody = deepMerge(
+      existingTestCase,
+      updatesForRestApi,
+      UpdateTestCaseBody.partial(),
+    );
 
     await this.client
       .getApiClient()
@@ -138,4 +150,34 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
       content: [],
     };
   };
+
+  // Convert the tool input into updates compatible with the REST API by
+  // expanding the primitive folder/component/owner IDs back into the `{ id }` /
+  // `{ accountId }` objects the REST API's UpdateTestCaseBody shape expects.
+  private toRestApiUpdates(
+    updatesFromToolInput: Partial<
+      zod.infer<typeof UpdateTestCaseBodyToolInput>
+    >,
+  ) {
+    const restApiCompatibleFields: Partial<
+      zod.infer<typeof UpdateTestCaseBody>
+    > = {};
+
+    if (updatesFromToolInput.folder) {
+      restApiCompatibleFields.folder = { id: updatesFromToolInput.folder };
+    }
+    if (updatesFromToolInput.owner) {
+      restApiCompatibleFields.owner = { accountId: updatesFromToolInput.owner };
+    }
+    if (updatesFromToolInput.component) {
+      restApiCompatibleFields.component = {
+        id: updatesFromToolInput.component,
+      };
+    }
+
+    return {
+      ...updatesFromToolInput,
+      ...restApiCompatibleFields,
+    };
+  }
 }

--- a/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
@@ -295,7 +295,9 @@ describe("UpdateTestCycle", () => {
       expect(mergedBody.description).toBeNull();
     });
 
-    it("should NOT overwrite plannedStartDate when update provides null", async () => {
+    it("should pass plannedStartDate through as null when update provides null", async () => {
+      // The API treats a null plannedStartDate as "leave unchanged", so sending
+      // it through as-is is safe - no special-casing needed here.
       const args = {
         testCycleIdOrKey: "SA-R40",
         plannedStartDate: null as any,
@@ -304,10 +306,12 @@ describe("UpdateTestCycle", () => {
       await instance.handle(args, EXTRA_REQUEST_HANDLER);
 
       const mergedBody = mockClient.getApiClient().put.mock.calls[0][1];
-      expect(mergedBody.plannedStartDate).toBe("2018-05-19T13:15:13Z");
+      expect(mergedBody.plannedStartDate).toBeNull();
     });
 
-    it("should NOT overwrite plannedEndDate when update provides null", async () => {
+    it("should pass plannedEndDate through as null when update provides null", async () => {
+      // The API treats a null plannedEndDate as "leave unchanged", so sending
+      // it through as-is is safe - no special-casing needed here.
       const args = {
         testCycleIdOrKey: "SA-R40",
         plannedEndDate: null as any,
@@ -316,7 +320,7 @@ describe("UpdateTestCycle", () => {
       await instance.handle(args, EXTRA_REQUEST_HANDLER);
 
       const mergedBody = mockClient.getApiClient().put.mock.calls[0][1];
-      expect(mergedBody.plannedEndDate).toBe("2018-05-20T13:15:13Z");
+      expect(mergedBody.plannedEndDate).toBeNull();
     });
 
     it("should update plannedStartDate/plannedEndDate when values are provided", async () => {

--- a/src/zephyr/tool/test-cycle/update-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.ts
@@ -33,7 +33,7 @@ const UpdateTestCycleBodyToolInput = UpdateTestCycleBody.extend({
     .regex(updateTestCycleBodyOwnerAccountIdRegExp)
     .nullish()
     .describe("Atlassian Account ID of the Jira user to set as owner."),
-});
+}).partial();
 
 export class UpdateTestCycle extends Tool<ZephyrClient> {
   specification: ToolParams = {
@@ -43,9 +43,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
       "Update an existing Test Cycle in Zephyr. This operation fetches the current test cycle and merges your updates with it to prevent accidental property deletion. To remove a property, set it to null explicitly. The plannedStartDate and plannedEndDate fields cannot be cleared",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCycleParams.and(
-      UpdateTestCycleBodyToolInput.partial(),
-    ),
+    inputSchema: UpdateTestCycleParams.and(UpdateTestCycleBodyToolInput),
     examples: [
       {
         description:
@@ -120,7 +118,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
     const parsed = UpdateTestCycleParams.and(
-      UpdateTestCycleBodyToolInput.partial(),
+      UpdateTestCycleBodyToolInput,
     ).parse(args);
 
     const { testCycleIdOrKey, ...updatesFromToolInput } = parsed;
@@ -158,9 +156,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
   // API treats null on those fields as "leave unchanged", so no special handling
   // is needed here.
   private toRestApiUpdates(
-    updatesFromToolInput: Partial<
-      zod.infer<typeof UpdateTestCycleBodyToolInput>
-    >,
+    updatesFromToolInput: zod.infer<typeof UpdateTestCycleBodyToolInput>,
   ) {
     const restApiCompatibleFields: Partial<
       zod.infer<typeof UpdateTestCycleBody>

--- a/src/zephyr/tool/test-cycle/update-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.ts
@@ -1,5 +1,6 @@
 import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape, z as zod } from "zod";
+import type { ZodRawShape } from "zod";
+import { z as zod } from "zod";
 import { Tool } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
@@ -7,8 +8,32 @@ import {
   type GetTestCycle200Response,
   UpdateTestCycleBody,
   UpdateTestCycleParams,
+  updateTestCycleBodyOwnerAccountIdRegExp,
 } from "../../common/rest-api-schemas";
 import { deepMerge } from "../../common/utils";
+
+// The update API expects folder/jiraProjectVersion/owner as `{ id }` /
+// `{ accountId }` objects, but not all LLMs handle optional nested objects the
+// same way. Expose them as plain IDs here and expand them back into objects
+// before merging into the real UpdateTestCycleBody shape (i.e., the one
+// required by the REST API).
+const UpdateTestCycleBodyToolInput = UpdateTestCycleBody.extend({
+  folder: zod
+    .number()
+    .min(1)
+    .nullish()
+    .describe("The ID of the folder to move the test cycle into."),
+  jiraProjectVersion: zod
+    .number()
+    .min(1)
+    .nullish()
+    .describe("The ID of the Jira project version (release) to associate."),
+  owner: zod
+    .string()
+    .regex(updateTestCycleBodyOwnerAccountIdRegExp)
+    .nullish()
+    .describe("Atlassian Account ID of the Jira user to set as owner."),
+});
 
 export class UpdateTestCycle extends Tool<ZephyrClient> {
   specification: ToolParams = {
@@ -18,7 +43,9 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
       "Update an existing Test Cycle in Zephyr. This operation fetches the current test cycle and merges your updates with it to prevent accidental property deletion. To remove a property, set it to null explicitly. The plannedStartDate and plannedEndDate fields cannot be cleared",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCycleParams.and(UpdateTestCycleBody.partial()),
+    inputSchema: UpdateTestCycleParams.and(
+      UpdateTestCycleBodyToolInput.partial(),
+    ),
     examples: [
       {
         description:
@@ -47,7 +74,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
           "Change folder and status for test cycle 'SA-R40' by setting folder id and status id.",
         parameters: {
           testCycleIdOrKey: "SA-R40",
-          folder: { id: 100006 },
+          folder: 100006,
           status: { id: 10000 },
         },
         expectedOutput:
@@ -93,43 +120,26 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
 
   handle: ToolCallback<ZodRawShape> = async (args) => {
     const parsed = UpdateTestCycleParams.and(
-      UpdateTestCycleBody.partial(),
+      UpdateTestCycleBodyToolInput.partial(),
     ).parse(args);
 
-    const { testCycleIdOrKey, ...rawUpdates } = parsed;
-    const nullValuesObject: Record<string, any> = {};
+    const { testCycleIdOrKey, ...updatesFromToolInput } = parsed;
 
-    if (rawUpdates.folder) {
-      //do nothing when null or undefined
-      nullValuesObject.folder = { id: rawUpdates.folder };
-    }
-    if (rawUpdates.owner) {
-      //do nothing when null or undefined
-      nullValuesObject.owner = { accountId: rawUpdates.owner };
-    }
-    if (rawUpdates.jiraProjectVersion) {
-      //do nothing when null or undefined
-      nullValuesObject.jiraProjectVersion = {
-        id: rawUpdates.jiraProjectVersion,
-      };
-    }
-
-    const updates: Record<string, unknown> = {
-      ...rawUpdates,
-      ...nullValuesObject,
-    };
-
-    if (updates.plannedStartDate === null) delete updates.plannedStartDate;
-    if (updates.plannedEndDate === null) delete updates.plannedEndDate;
+    const updatesForRestApi = this.toRestApiUpdates(updatesFromToolInput);
 
     // Fetch the existing test cycle to ensure we have all properties.
     // Zephyr's PUT endpoints require the complete resource and clear unspecified fields.
     const existingTestCycle: zod.infer<typeof GetTestCycle200Response> =
       await this.client.getApiClient().get(`/testcycles/${testCycleIdOrKey}`);
 
-    // Merge updates into the existing resource so unspecified fields remain unchanged.
-    const mergedBody = deepMerge(existingTestCycle, updates);
-    delete mergedBody.links;
+    // Merge updates into the existing resource so unspecified fields remain
+    // unchanged, then coerce to the update body schema, which strips fields the
+    // PUT endpoint rejects (e.g. links).
+    const mergedBody = deepMerge(
+      existingTestCycle,
+      updatesForRestApi,
+      UpdateTestCycleBody.partial(),
+    );
 
     await this.client
       .getApiClient()
@@ -140,4 +150,37 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
       content: [],
     };
   };
+
+  // Convert the tool input into updates compatible with the REST API by
+  // expanding the primitive folder/jiraProjectVersion/owner IDs back into the
+  // `{ id }` / `{ accountId }` objects the REST API's UpdateTestCycleBody shape
+  // expects. A null plannedStartDate/plannedEndDate is passed through as-is: the
+  // API treats null on those fields as "leave unchanged", so no special handling
+  // is needed here.
+  private toRestApiUpdates(
+    updatesFromToolInput: Partial<
+      zod.infer<typeof UpdateTestCycleBodyToolInput>
+    >,
+  ) {
+    const restApiCompatibleFields: Partial<
+      zod.infer<typeof UpdateTestCycleBody>
+    > = {};
+
+    if (updatesFromToolInput.folder) {
+      restApiCompatibleFields.folder = { id: updatesFromToolInput.folder };
+    }
+    if (updatesFromToolInput.owner) {
+      restApiCompatibleFields.owner = { accountId: updatesFromToolInput.owner };
+    }
+    if (updatesFromToolInput.jiraProjectVersion) {
+      restApiCompatibleFields.jiraProjectVersion = {
+        id: updatesFromToolInput.jiraProjectVersion,
+      };
+    }
+
+    return {
+      ...updatesFromToolInput,
+      ...restApiCompatibleFields,
+    };
+  }
 }


### PR DESCRIPTION
**TL;DR:** `deepMerge` now coerces its output to a target Zod schema (dropping unknown keys at any depth), and the test-case/test-cycle update tools expose `folder`/`component`/`owner`/`jiraProjectVersion` as plain IDs instead of nested objects (just as before this change, but now in a different place).

## Goal

Update tools were manually deleting specific fields (`createdOn`, `links`, ...) after merging updates into the existing resource, which is brittle against new read-only API fields. Also, the REST API models `folder`/`component`/`owner`/`jiraProjectVersion` as `{ id }` / `{ accountId }` objects, which not all LLMs handle reliably as tool arguments.

## Design

- `deepMerge` takes a target Zod schema and parses the merged result through a deep-stripped version of it (new `deepStrip` helper), dropping any undeclared key at any nesting depth instead of relying on manual `delete` calls.
- `update-test-case.ts` / `update-test-cycle.ts` expose `folder`/`component`/`owner`/`jiraProjectVersion` as plain IDs in their tool input, expanding them back into the real `{ id }` / `{ accountId }` shape before merging/PUTing.
- Dropped now-unnecessary null special-casing for `plannedStartDate`/`plannedEndDate` (API already no-ops on null there).

## Changeset

- `src/zephyr/common/utils.ts` — schema-aware `deepMerge` + new `deepStrip`.
- `src/zephyr/common/rest-api-schemas.ts` — regenerated from the OpenAPI spec.
- `src/zephyr/tool/test-case/update-test-case.ts`, `.../test-cycle/update-test-cycle.ts` — primitive ID tool inputs, schema-aware merge.
- `src/common/__snapshots__/server-definitions.test.ts.snap` — regenerated for updated tool examples.

## Testing

- `vitest run` — full suite passing (153 files / 2384 tests).
- New tests for `deepMerge`/`deepStrip` (schema stripping at depth, leaf validation, `default()`/`union` cases, undefined-updates short-circuit) and for folder/owner/component ID expansion in the update tools.
- Tested manually by talking to ChatGPT to get test cases, create folders, and update test cases
- Tested manually with Remove MCP against Rovo (using Gemini model) with the same scenarios that I used with ChatGPT