### PR TITLE
feat: add kiro section in remote swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Swagger] Adjusted some of the Swagger Functional Testing tools responses to return `url` of test or test Suite execution.
+- [Swagger] Added Kiro (AWS) setup instructions and one-click install badge for the Swagger Remote MCP Server.
 
 ## [0.32.0] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ For BugSnag, Swagger, and Zephyr, SmartBear hosts Remote MCP Servers that you ca
 
 See the [Remote MCP Servers guide](https://developer.smartbear.com/smartbear-mcp/docs/remote-mcp-servers) for per-client setup instructions. You can connect to multiple remote servers at the same time.
 
+### Kiro (AWS)
+
+Add the Swagger remote MCP server to Kiro with one click:
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=smartbear-swagger&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fswagger.mcp.smartbear.com%2Fmcp%22%2C%22oauth%22%3A%7B%22redirectUri%22%3A%22127.0.0.1%3A8080%22%2C%22oauthScopes%22%3A%5B%5D%7D%2C%22disabled%22%3Afalse%7D)
+
 > **Need BearQ, Reflect, QMetry, QTM4J, PactFlow, Collaborator, or Functional Testing?** These products are only available via the local npm package below, which bundles all products into a single MCP server.
 
 ## Prerequisites

--- a/docs/custom-words.txt
+++ b/docs/custom-words.txt
@@ -64,3 +64,5 @@ Watchos
 Webapi
 Wsgi
 teststep
+Kiro
+kiro

--- a/docs/products/SmartBear MCP Server/remote-swagger.md
+++ b/docs/products/SmartBear MCP Server/remote-swagger.md
@@ -66,3 +66,27 @@ Edit your `claude_desktop_config.json` file:
 ```
 claude mcp add --transport http smartbear-swagger https://swagger.mcp.smartbear.com/mcp
 ```
+
+### Kiro (AWS)
+
+Add to your `~/.kiro/settings/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "smartbear-swagger": {
+      "type": "http",
+      "url": "https://swagger.mcp.smartbear.com/mcp",
+      "oauth": {
+        "redirectUri": "127.0.0.1:8080",
+        "oauthScopes": []
+      },
+      "disabled": false
+    }
+  }
+}
+```
+
+Or install with one click:
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=smartbear-swagger&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fswagger.mcp.smartbear.com%2Fmcp%22%2C%22oauth%22%3A%7B%22redirectUri%22%3A%22127.0.0.1%3A8080%22%2C%22oauthScopes%22%3A%5B%5D%7D%2C%22disabled%22%3Afalse%7D)


### PR DESCRIPTION
## Goal

Add Kiro (AWS) as a supported MCP client for the Swagger Remote MCP Server. Kiro is an agentic IDE by AWS that supports remote MCP servers over HTTP with OAuth — the existing Swagger server at https://swagger.mcp.smartbear.com/mcp works without any server-side changes.

## Design

Added a ### Kiro (AWS) section to the docs following the same pattern as VS Code, Cursor, Claude Desktop, and Claude Code. The config uses Kiro's native type: http format with an oauth block (no explicit redirectUri required — Kiro handles the loopback redirect internally).

## Changeset

  - docs/products/SmartBear MCP Server/remote-swagger.md — added ### Kiro (AWS) section with JSON config and install badge

## Testing

Tested end-to-end in Kiro IDE: OAuth flow triggered on first connection, browser login completed successfully, Swagger tools available in Kiro agent.
