### PR TITLE
[Zephyr] TM4J-18202 add Get Test Plans (NextGen) tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Swagger] Added `create_test` Functional Testing tool that creates a new API test with set of steps.
+- [Zephyr] Added `Get Test Plans` tool that retrieves Test Plans using the cursor-paginated NextGen endpoint.
 
 ## [0.32.0] - 2026-07-23
 

--- a/docs/products/SmartBear MCP Server/zephyr-integration.md
+++ b/docs/products/SmartBear MCP Server/zephyr-integration.md
@@ -420,6 +420,21 @@ The following environment variables configure the Zephyr integration:
 - **Returns**: A list of links associated with the specified Test Execution, including their details.
 - **Use case**: Retrieve links associated with a specific Test Execution.
 
+## Test Plans
+
+### Retrieval Operations
+
+#### Get Test Plans
+
+- **Purpose**: Retrieve Test Plans available within your Zephyr account.
+- **Parameters**:
+  - optional Project key (`projectKey`)
+  - optional max results to return (`limit`)
+  - optional starting cursor position for pagination (`startAtId`)
+  - optional filter for entities updated after a given time (`updatedAfter`)
+- **Returns**: A list of Test Plans along with their properties.
+- **Use case**: Retrieve the Test Plans, it can be filtered by Project Key and update time.
+
 ## Statuses
 
 ### Retrieval Operations

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -13972,6 +13972,85 @@ Expected Output: The List of test executions linked to Jira issue PROJ-123 with 
     "outputSchema": undefined,
     "title": "Zephyr: Get test executions linked to a Jira issue",
   },
+  "zephyr_get_test_plans": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Zephyr: Get Test Plans",
+    },
+    "description": "Get details of Test Plans in Zephyr
+
+**Toolset:** Test Plans
+
+**Parameters:**
+- projectKey (string): Jira project key filter
+- limit (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the limit value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAtId (number): Zero-indexed starting position for ID-based pagination. (default: 0)
+- updatedAfter (string): Filter only entities updated after the given time. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+
+**Examples:**
+1. Get the first 10 Test Plans
+\`\`\`json
+{
+  "limit": 10,
+  "startAtId": 0
+}
+\`\`\`
+Expected Output: The first 10 Test Plans with their details
+
+2. Get any Test Plan
+\`\`\`json
+{
+  "limit": 1
+}
+\`\`\`
+Expected Output: One Test Plan with its details
+
+3. Get five Test Plans starting from the ID 123
+\`\`\`json
+{
+  "limit": 5,
+  "startAtId": 123
+}
+\`\`\`
+Expected Output: Five Test Plans starting from the ID 123 with their details
+
+4. Get one Test Plan from the project PROJ
+\`\`\`json
+{
+  "projectKey": "PROJ",
+  "limit": 1
+}
+\`\`\`
+Expected Output: One Test Plan from project PROJ with its details
+
+5. Get Test Plans updated after a given time
+\`\`\`json
+{
+  "updatedAfter": "2024-01-01T00:00:00Z",
+  "limit": 10
+}
+\`\`\`
+Expected Output: Up to 10 Test Plans updated after 2024-01-01 with their details",
+    "inputSchema": [
+      "limit",
+      "projectKey",
+      "startAtId",
+      "updatedAfter",
+    ],
+    "outputSchema": [
+      "limit",
+      "next",
+      "nextStartAtId",
+      "values",
+    ],
+    "title": "Zephyr: Get Test Plans",
+  },
   "zephyr_get_test_script": {
     "annotations": {
       "destructiveHint": false,

--- a/src/zephyr/client.ts
+++ b/src/zephyr/client.ts
@@ -42,6 +42,7 @@ import { GetTestExecutions } from "./tool/test-execution/get-test-executions";
 import { GetTestExecutionSteps } from "./tool/test-execution/get-test-steps.ts";
 import { UpdateTestExecution } from "./tool/test-execution/update-test-execution";
 import { UpdateTestExecutionSteps } from "./tool/test-execution/update-test-steps.ts";
+import { GetTestPlans } from "./tool/test-plan/get-test-plans";
 
 const BASE_URL_DEFAULT = "https://api.zephyrscale.smartbear.com/v2";
 
@@ -146,6 +147,7 @@ export class ZephyrClient implements Client {
       new GetTestExecutionSteps(this),
       new GetTestExecutionLinks(this),
       new GetIssueLinkTestExecutions(this),
+      new GetTestPlans(this),
     ];
 
     for (const tool of tools) {

--- a/src/zephyr/tool/test-plan/get-test-plans.test.ts
+++ b/src/zephyr/tool/test-plan/get-test-plans.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ListTestPlansCursorPaginatedQueryParams,
+  ListTestPlansCursorPaginated200Response as ListTestPlansCursorPaginatedResponse,
+} from "../../common/rest-api-schemas";
+import { GetTestPlans } from "./get-test-plans";
+
+describe("GetTestPlans", () => {
+  let mockClient: any;
+  let instance: GetTestPlans;
+
+  beforeEach(() => {
+    mockClient = {
+      getApiClient: vi.fn().mockReturnValue({
+        get: vi.fn(),
+      }),
+    };
+    instance = new GetTestPlans(mockClient as any);
+  });
+
+  it("should set specification correctly", () => {
+    expect(instance.specification.title).toBe("Get Test Plans");
+    expect(instance.specification.summary).toBe(
+      "Get details of Test Plans in Zephyr",
+    );
+    expect(instance.specification.readOnly).toBe(true);
+    expect(instance.specification.idempotent).toBe(true);
+    expect(instance.specification.inputSchema).toBe(
+      ListTestPlansCursorPaginatedQueryParams,
+    );
+    expect(instance.specification.outputSchema).toBe(
+      ListTestPlansCursorPaginatedResponse,
+    );
+  });
+
+  it("should call apiClient.get with correct params and return formatted content", async () => {
+    const responseMock = {
+      next: null,
+      nextStartAtId: null,
+      limit: 10,
+      values: [
+        {
+          id: 1,
+          key: "PROJ-P1",
+          name: "Test Plan 1",
+          objective: "Validate release readiness",
+          project: {
+            id: 10000,
+            self: "https://api.example.com/projects/10000",
+          },
+          status: {
+            id: 10001,
+            self: "https://api.example.com/statuses/10001",
+          },
+          folder: {
+            id: 10002,
+            self: "https://api.example.com/folders/10002",
+          },
+          owner: {
+            accountId: "5b10a2844c20165700ede21g",
+            self: "https://jira.example.com/rest/api/2/user?accountId=5b10a2844c20165700ede21g",
+          },
+          labels: ["Regression", "Release"],
+          customFields: {
+            "Build Number": 20,
+            "Release Date": "2020-01-01",
+          },
+          links: {
+            webLinks: [
+              {
+                description: "A link to atlassian.com",
+                url: "https://atlassian.com",
+                self: "http://example.com",
+                id: 1,
+                type: "RELATED",
+              },
+            ],
+            issues: [
+              {
+                issueId: 10100,
+                self: "http://example.com",
+                id: 1,
+                target:
+                  "https://jira.example.com.atlassian.net/rest/api/2/issue/10100",
+                type: "COVERAGE",
+              },
+            ],
+            testCycles: [
+              {
+                id: 1,
+                self: "https://api.example.com/testcycles/1",
+                testCycleId: 5,
+                type: "RELATED",
+                target: "https://api.example.com/testcycles/5",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
+    const args = { limit: 10, startAtId: 0 };
+    const result = await instance.handle(args, {} as any);
+    expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
+      "/testplans/nextgen",
+      args,
+    );
+    expect(result.structuredContent).toBe(responseMock);
+  });
+
+  it("should handle empty args and call apiClient.get with default param values", async () => {
+    const responseMock = {
+      next: null,
+      nextStartAtId: null,
+      limit: 10,
+      values: [
+        {
+          id: 1,
+          key: "PROJ-P1",
+          name: "Test Plan 1",
+          project: {
+            id: 10000,
+          },
+          status: {
+            id: 10001,
+          },
+        },
+      ],
+    };
+    mockClient.getApiClient().get.mockResolvedValueOnce(responseMock);
+    const result = await instance.handle({}, {} as any);
+    expect(mockClient.getApiClient().get).toHaveBeenCalledWith(
+      "/testplans/nextgen",
+      { limit: 10, startAtId: 0 },
+    );
+    expect(result.structuredContent).toBe(responseMock);
+  });
+});

--- a/src/zephyr/tool/test-plan/get-test-plans.ts
+++ b/src/zephyr/tool/test-plan/get-test-plans.ts
@@ -1,0 +1,75 @@
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+import { Tool } from "../../../common/tools";
+import type { ToolParams } from "../../../common/types";
+import type { ZephyrClient } from "../../client";
+import {
+  ListTestPlansCursorPaginatedQueryParams,
+  ListTestPlansCursorPaginated200Response as ListTestPlansCursorPaginatedResponse,
+} from "../../common/rest-api-schemas";
+
+export class GetTestPlans extends Tool<ZephyrClient> {
+  specification: ToolParams = {
+    title: "Get Test Plans",
+    toolset: "Test Plans",
+    summary: "Get details of Test Plans in Zephyr",
+    readOnly: true,
+    idempotent: true,
+    inputSchema: ListTestPlansCursorPaginatedQueryParams,
+    outputSchema: ListTestPlansCursorPaginatedResponse,
+    examples: [
+      {
+        description: "Get the first 10 Test Plans",
+        parameters: {
+          limit: 10,
+          startAtId: 0,
+        },
+        expectedOutput: "The first 10 Test Plans with their details",
+      },
+      {
+        description: "Get any Test Plan",
+        parameters: {
+          limit: 1,
+        },
+        expectedOutput: "One Test Plan with its details",
+      },
+      {
+        description: "Get five Test Plans starting from the ID 123",
+        parameters: {
+          limit: 5,
+          startAtId: 123,
+        },
+        expectedOutput:
+          "Five Test Plans starting from the ID 123 with their details",
+      },
+      {
+        description: "Get one Test Plan from the project PROJ",
+        parameters: {
+          projectKey: "PROJ",
+          limit: 1,
+        },
+        expectedOutput: "One Test Plan from project PROJ with its details",
+      },
+      {
+        description: "Get Test Plans updated after a given time",
+        parameters: {
+          updatedAfter: "2024-01-01T00:00:00Z",
+          limit: 10,
+        },
+        expectedOutput:
+          "Up to 10 Test Plans updated after 2024-01-01 with their details",
+      },
+    ],
+  };
+
+  handle: ToolCallback<ZodRawShape> = async (args) => {
+    const parsedArgs = ListTestPlansCursorPaginatedQueryParams.parse(args);
+    const response = await this.client
+      .getApiClient()
+      .get("/testplans/nextgen", parsedArgs);
+    return {
+      structuredContent: response,
+      content: [],
+    };
+  };
+}


### PR DESCRIPTION
## Goal

Add a new MCP tool to retrieve Test Plans in Zephyr Scale using the cursor-paginated NextGen endpoint (`listTestPlansCursorPaginated`).

## Design

Follows the existing read-only tool pattern (mirrors `GetTestExecutions`): optional query-param inputs (`projectKey`, `limit`, `startAtId`, `updatedAfter`), GET to `/testplans/nextgen`, structured content from the API response. Marked `readOnly` and `idempotent`. Schemas reused from auto-generated `rest-api-schemas.ts`. Includes LLM-oriented examples covering pagination, project filtering, and time-based filtering.

## Changeset

- `get-test-plans.ts` - new GetTestPlans tool
- `get-test-plans.test.ts` - unit tests
- `client.ts` - register tool
- `zephyr-integration.md` - documentation
- `CHANGELOG.md` - changelog entry

## Testing

- spec validation (title, summary, readOnly, idempotent, input/output schemas)
- retrieval with explicit params (limit, startAtId)
- retrieval with empty args applying default param values (limit: 10, startAtId: 0)