### PR TITLE
refactor(common): isolate client state per session

### DIFF
--- a/src/common/client-registry.test.ts
+++ b/src/common/client-registry.test.ts
@@ -4,6 +4,29 @@ import { clientRegistry } from "./client-registry";
 import type { SmartBearMcpServer } from "./server";
 import type { Client } from "./types";
 
+class StatefulClient implements Client {
+  name = "stateful";
+  capabilityPrefix = "stateful";
+  configPrefix = "Stateful";
+  config = z.object({ endpoint: z.url() });
+
+  endpoint?: string;
+  configured = false;
+
+  async configure(_server: SmartBearMcpServer, config: any): Promise<void> {
+    this.endpoint = config.endpoint;
+    this.configured = true;
+  }
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  registerTools(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 describe("ClientRegistry", () => {
   let mockServer: SmartBearMcpServer;
   let mockClient: Client;
@@ -585,6 +608,33 @@ describe("ClientRegistry", () => {
         // Invalid client should not be configured
         expect(invalidClient.configure).not.toHaveBeenCalled();
       });
+    });
+
+    it("clones class-based clients so each session gets its own state", async () => {
+      const original = new StatefulClient();
+      clientRegistry.register(original);
+
+      const getConfig = vi
+        .fn()
+        .mockReturnValueOnce("https://first.example.com")
+        .mockReturnValueOnce("https://second.example.com");
+
+      const firstCount = await clientRegistry.configure(mockServer, getConfig);
+      const secondCount = await clientRegistry.configure(mockServer, getConfig);
+
+      expect(firstCount).toBe(1);
+      expect(secondCount).toBe(1);
+
+      const added = vi
+        .mocked(mockServer.addClient)
+        .mock.calls.map((call) => call[0] as StatefulClient);
+      expect(added.length).toBe(2);
+      expect(added[0]).not.toBe(original);
+      expect(added[1]).not.toBe(original);
+      expect(added[0]).not.toBe(added[1]);
+      expect(added[0].endpoint).toBe("https://first.example.com");
+      expect(added[1].endpoint).toBe("https://second.example.com");
+      expect(original.endpoint).toBeUndefined();
     });
   });
 });

--- a/src/common/client-registry.ts
+++ b/src/common/client-registry.ts
@@ -4,6 +4,24 @@ import type { Client } from "./types";
 import { fullyUnwrapZodType, isOptionalType } from "./zod-utils";
 
 /**
+ * Create a fresh client instance for each configuration/session.
+ * Real clients are class instances and are cloned via their constructor.
+ * Plain object mocks used in tests are returned as-is.
+ */
+function cloneClient(entry: Client): Client {
+  const withClone = entry as unknown as { clone?: () => Client };
+  if (typeof withClone.clone === "function") {
+    return withClone.clone();
+  }
+  const ctor = (entry as unknown as { constructor?: new () => Client })
+    .constructor;
+  if (ctor && (ctor as any) !== Object && typeof ctor === "function") {
+    return new ctor();
+  }
+  return entry;
+}
+
+/**
  * Central registry for all MCP clients
  * Add new clients here to make them automatically available
  */
@@ -121,23 +139,24 @@ class ClientRegistry {
   ): Promise<number> {
     let configuredCount = 0;
     entryLoop: for (const entry of this.getAll()) {
+      const client = cloneClient(entry);
       const config: Record<string, string> = {};
-      for (const configKey of Object.keys(entry.config.shape)) {
-        const value = getConfigValue(entry, configKey);
+      for (const configKey of Object.keys(client.config.shape)) {
+        const value = getConfigValue(client, configKey);
         if (value !== null) {
           // validate if a config option is an Allowed Endpoint URL
-          this.validateAllowedEndpoint(entry.config.shape[configKey], value);
+          this.validateAllowedEndpoint(client.config.shape[configKey], value);
           config[configKey] = value;
         } else if (
           !ignoreMissingRequiredConfigs &&
-          !isOptionalType(entry.config.shape[configKey])
+          !isOptionalType(client.config.shape[configKey])
         ) {
           continue entryLoop; // Skip configuring this client - missing required config
         }
       }
-      await entry.configure(server, config);
-      if (entry.isConfigured()) {
-        await server.addClient(entry);
+      await client.configure(server, config);
+      if (client.isConfigured()) {
+        await server.addClient(client);
         configuredCount++;
       }
     }

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -78,15 +78,15 @@ import type {
 const ConfigurationSchema = z.object({
   api_key: z.string().optional().describe("Swagger API key for authentication"),
   portal_base_path: z
-    .string()
+    .url()
     .optional()
     .describe("Base path for Portal API requests (optional)"),
   registry_base_path: z
-    .string()
+    .url()
     .optional()
     .describe("Base path for Registry API requests (optional)"),
   ui_base_path: z
-    .string()
+    .url()
     .optional()
     .describe("Base URL for the SwaggerHub UI (optional)"),
   functional_testing_api_token: z
@@ -96,7 +96,7 @@ const ConfigurationSchema = z.object({
       "Swagger Functional Testing API token. Leave empty to disable Functional Testing tools.",
     ),
   functional_testing_base_path: z
-    .string()
+    .url()
     .optional()
     .describe(
       "Base URL for Swagger Functional Testing API requests (optional)",


### PR DESCRIPTION
Swagger base paths are now z.url() for MCP_ALLOWED_ENDPOINTS support.

## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? -->
