### PR TITLE
Fix session isolation to prevent credential and base path leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Zephyr] Refactor to keep REST API schemas unmodified and ensure correct payload for update operations [#609](https://github.com/SmartBear/smartbear-mcp/pull/609)
 
+### Security
+
+- Fixed session isolation vulnerability (Base Path Injection / SSRF): `ClientRegistry.configure()` now calls `cloneClient()` to produce a fresh client instance per session, preventing per-session state (base-path URLs, auth tokens) stored on one session's client from leaking into concurrent sessions.
+- Fixed credential leakage vulnerability: because each session receives its own client clone, an unauthenticated session no longer inherits a previously authenticated session's `SwaggerClient` API instance or API key. An unauthenticated session has no Swagger tools available.
+- [Swagger] Changed `portal_base_path`, `registry_base_path`, `ui_base_path`, and `functional_testing_base_path` config fields from `z.string()` to `z.url()`, enabling allowlist enforcement via `MCP_ALLOWED_ENDPOINTS` and rejecting non-URL values at parse time.
+
 ## [0.32.0] - 2026-07-23
 
 ### Added

--- a/src/common/client-registry.test.ts
+++ b/src/common/client-registry.test.ts
@@ -4,6 +4,29 @@ import { clientRegistry } from "./client-registry";
 import type { SmartBearMcpServer } from "./server";
 import type { Client } from "./types";
 
+class StatefulClient implements Client {
+  name = "stateful";
+  capabilityPrefix = "stateful";
+  configPrefix = "Stateful";
+  config = z.object({ endpoint: z.url() });
+
+  endpoint?: string;
+  configured = false;
+
+  async configure(_server: SmartBearMcpServer, config: any): Promise<void> {
+    this.endpoint = config.endpoint;
+    this.configured = true;
+  }
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  registerTools(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 describe("ClientRegistry", () => {
   let mockServer: SmartBearMcpServer;
   let mockClient: Client;
@@ -585,6 +608,33 @@ describe("ClientRegistry", () => {
         // Invalid client should not be configured
         expect(invalidClient.configure).not.toHaveBeenCalled();
       });
+    });
+
+    it("clones class-based clients so each session gets its own state", async () => {
+      const original = new StatefulClient();
+      clientRegistry.register(original);
+
+      const getConfig = vi
+        .fn()
+        .mockReturnValueOnce("https://first.example.com")
+        .mockReturnValueOnce("https://second.example.com");
+
+      const firstCount = await clientRegistry.configure(mockServer, getConfig);
+      const secondCount = await clientRegistry.configure(mockServer, getConfig);
+
+      expect(firstCount).toBe(1);
+      expect(secondCount).toBe(1);
+
+      const added = vi
+        .mocked(mockServer.addClient)
+        .mock.calls.map((call) => call[0] as StatefulClient);
+      expect(added.length).toBe(2);
+      expect(added[0]).not.toBe(original);
+      expect(added[1]).not.toBe(original);
+      expect(added[0]).not.toBe(added[1]);
+      expect(added[0].endpoint).toBe("https://first.example.com");
+      expect(added[1].endpoint).toBe("https://second.example.com");
+      expect(original.endpoint).toBeUndefined();
     });
   });
 });

--- a/src/common/client-registry.ts
+++ b/src/common/client-registry.ts
@@ -4,6 +4,29 @@ import type { Client } from "./types";
 import { fullyUnwrapZodType, isOptionalType } from "./zod-utils";
 
 /**
+ * Create a fresh client instance for each configuration/session so that
+ * per-session state (base-path URLs, auth tokens) stored on the instance
+ * cannot leak between concurrent sessions.
+ *
+ * Lookup order:
+ *  1. client.clone()  — explicit opt-in for clients with constructor args
+ *  2. new ctor()      — zero-arg constructor (covers all current class clients)
+ *  3. entry itself    — plain-object mocks used in tests
+ */
+function cloneClient(entry: Client): Client {
+  const withClone = entry as unknown as { clone?: () => Client };
+  if (typeof withClone.clone === "function") {
+    return withClone.clone();
+  }
+  const ctor = (entry as unknown as { constructor?: new () => Client })
+    .constructor;
+  if (ctor && (ctor as any) !== Object && typeof ctor === "function") {
+    return new ctor();
+  }
+  return entry;
+}
+
+/**
  * Central registry for all MCP clients
  * Add new clients here to make them automatically available
  */
@@ -121,23 +144,24 @@ class ClientRegistry {
   ): Promise<number> {
     let configuredCount = 0;
     entryLoop: for (const entry of this.getAll()) {
+      const client = cloneClient(entry);
       const config: Record<string, string> = {};
-      for (const configKey of Object.keys(entry.config.shape)) {
-        const value = getConfigValue(entry, configKey);
+      for (const configKey of Object.keys(client.config.shape)) {
+        const value = getConfigValue(client, configKey);
         if (value !== null) {
           // validate if a config option is an Allowed Endpoint URL
-          this.validateAllowedEndpoint(entry.config.shape[configKey], value);
+          this.validateAllowedEndpoint(client.config.shape[configKey], value);
           config[configKey] = value;
         } else if (
           !ignoreMissingRequiredConfigs &&
-          !isOptionalType(entry.config.shape[configKey])
+          !isOptionalType(client.config.shape[configKey])
         ) {
           continue entryLoop; // Skip configuring this client - missing required config
         }
       }
-      await entry.configure(server, config);
-      if (entry.isConfigured()) {
-        await server.addClient(entry);
+      await client.configure(server, config);
+      if (client.isConfigured()) {
+        await server.addClient(client);
         configuredCount++;
       }
     }

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -78,15 +78,15 @@ import type {
 const ConfigurationSchema = z.object({
   api_key: z.string().optional().describe("Swagger API key for authentication"),
   portal_base_path: z
-    .string()
+    .url()
     .optional()
-    .describe("Base path for Portal API requests (optional)"),
+    .describe("Base URL for Portal API requests (optional)"),
   registry_base_path: z
-    .string()
+    .url()
     .optional()
     .describe("Base path for Registry API requests (optional)"),
   ui_base_path: z
-    .string()
+    .url()
     .optional()
     .describe("Base URL for the SwaggerHub UI (optional)"),
   functional_testing_api_token: z
@@ -96,7 +96,7 @@ const ConfigurationSchema = z.object({
       "Swagger Functional Testing API token. Leave empty to disable Functional Testing tools.",
     ),
   functional_testing_base_path: z
-    .string()
+    .url()
     .optional()
     .describe(
       "Base URL for Swagger Functional Testing API requests (optional)",


### PR DESCRIPTION
Fixes [AIA-473](https://smartbear.atlassian.net/browse/AIA-473), [AIA-472](https://smartbear.atlassian.net/browse/AIA-472) two security vulnerabilities where shared singleton client state could leak between concurrent sessions:

1. **Base Path Injection / SSRF**: a malicious session could inject a custom `Swagger-Portal-Base-Path` into the shared `SwaggerClient` singleton, causing a victim's subsequent API calls to be sent to an attacker-controlled host.

2. **Credential Leakage**: an unauthenticated session initialized after an authenticated one would reuse the singleton's `this.api` and `this._apiKey`, giving the attacker access to the victim's Swagger tools and credentials.

`ClientRegistry.configure()` now calls `cloneClient()` to produce a fresh client instance per session. Each session's state is fully isolated — base paths and tokens set during one session cannot affect any other.

Changed Swagger base-path config fields from `z.string()` to `z.url()` so non-URL values are rejected at parse time and `MCP_ALLOWED_ENDPOINTS` allowlist enforcement applies to them.

**Tested**
- Unauthenticated session has zero Swagger tools (no credential reuse)
- Two concurrent sessions receive independent client clones with separate state (verified by unit test and live curl tests)


[AIA-473]: https://smartbear.atlassian.net/browse/AIA-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIA-472]: https://smartbear.atlassian.net/browse/AIA-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ