### PR TITLE
feat: added url in standardize-api tool when new version is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Swagger] `standardize_api` tool: returns a `url` only when the server confirms the fix was saved (`savedVersion`).
 - [Swagger] `resolve_organization_portal` tool: the generated subdomain now follows the Portal UI convention - slugified organization name plus a random 3-character suffix (e.g. `acmecorp-k7p`), appended even without a collision.
 - [Swagger] `create_portal` tool: the `subdomain` parameter description now recommends the same convention, while the client still picks the value.
 

--- a/docs/products/SmartBear MCP Server/swagger-studio-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-studio-integration.md
@@ -93,7 +93,7 @@ The Swagger Studio client provides comprehensive API and Domain management capab
 #### `standardize_api`
 
 -   Purpose: Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. If errors are found, they will be sent to SmartBear AI to generate a corrected definition, which is then saved back to the registry.
--   Returns: Standardization result including a message, the number of errors found, and the fixed definition if successful. Also includes details about each error (description, line number, severity).
+ -   Returns: Standardization result including a message, the number of errors found, and the fixed definition if successful. Also includes details about each error (description, line number, severity). If the fixed definition was saved, the response includes a `url` to view the API in SwaggerHub (server returns `savedVersion`); otherwise `url` is omitted.
 -   Use case: Automatically fix API definitions that fail standardization scans, ensure governance compliance in existing APIs, or clean up imported/legacy API definitions to meet current organization standards.
 -   Parameters:
 

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -12076,7 +12076,7 @@ None",
       "readOnlyHint": false,
       "title": "Swagger: Standardize API",
     },
-    "description": "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found and the fixed definition if successful. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.
+    "description": "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API (URL is environment-specific and determined by the server configuration). Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.
 
 **Toolset:** Registry API
 
@@ -12096,6 +12096,7 @@ None",
       "fixedDefinition",
       "message",
       "savedVersion",
+      "url",
     ],
     "title": "Swagger: Standardize API",
   },

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -12076,7 +12076,7 @@ None",
       "readOnlyHint": false,
       "title": "Swagger: Standardize API",
     },
-    "description": "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API (URL is environment-specific and determined by the server configuration). Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.
+    "description": "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.
 
 **Toolset:** Registry API
 

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1508,7 +1508,7 @@ export class SwaggerAPI {
       );
     }
 
-    // Attach `url` only when the server returned a non-empty `savedVersion`. 
+    // Attach `url` only when the server returned a non-empty `savedVersion`.
     // Always ensure `errorsFound` exists (default 0) so callers don't have to guard.
     const updated: StandardizeApiResponse = {
       ...result,

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -105,6 +105,18 @@ function hasErrorsFound(
 }
 
 /**
+ * Type guard to check if a value has a 'savedVersion' property
+ */
+function hasSavedVersion(
+  value: unknown,
+): value is { savedVersion: string } & Record<string, unknown> {
+  // Ensure the value is an object and the savedVersion is a non-empty string.
+  if (typeof value !== "object" || value === null) return false;
+  const sv = (value as { savedVersion?: unknown }).savedVersion;
+  return typeof sv === "string" && sv.length > 0;
+}
+
+/**
  * Type guard to check if a value is a StandardizationScanApiResponse
  */
 function isStandardizationResult(
@@ -1463,7 +1475,7 @@ export class SwaggerAPI {
   /**
    * Standardize and fix an API definition using AI
    * @param params Parameters including owner, API name, version, and optional newVersion
-   * @returns Standardization response with status and fixed definition
+   * @returns Standardization response with status, fixed definition, and URL to the API
    */
   async standardizeApi(
     params: StandardizeApiParams,
@@ -1496,10 +1508,17 @@ export class SwaggerAPI {
       );
     }
 
-    if (!hasErrorsFound(result)) {
-      return { ...result, errorsFound: 0 } as StandardizeApiResponse;
+    // Attach `url` only when the server returned a non-empty `savedVersion`. 
+    // Always ensure `errorsFound` exists (default 0) so callers don't have to guard.
+    const updated: StandardizeApiResponse = {
+      ...result,
+      errorsFound: hasErrorsFound(result) ? (result as any).errorsFound : 0,
+    } as StandardizeApiResponse;
+
+    if (hasSavedVersion(result)) {
+      updated.url = `${this.config.uiBasePath}/apis/${params.owner}/${params.api}/${result.savedVersion}`;
     }
 
-    return result as StandardizeApiResponse;
+    return updated;
   }
 }

--- a/src/swagger/client/registry-types.ts
+++ b/src/swagger/client/registry-types.ts
@@ -245,6 +245,7 @@ export interface StandardizeApiResponse {
   errorsFound: number;
   fixedDefinition?: string;
   savedVersion?: string;
+  url?: string;
   errors?: Array<{
     description: string;
     line?: number;
@@ -294,6 +295,7 @@ export const StandardizeOutputSchema = z.looseObject({
   errorsFound: z.number().optional(),
   fixedDefinition: z.string().optional(),
   savedVersion: z.string().optional(),
+  url: z.string().optional(),
 });
 
 export const ApiDefinitionOutputSchema = z.object({

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -323,7 +323,7 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "Standardize API",
     toolset: "Registry API",
     summary:
-      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API (URL is environment-specific and determined by the server configuration). Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
+      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
     inputSchema: StandardizeApiParamsSchema,
     outputSchema: StandardizeOutputSchema,
     handler: "standardizeApi",

--- a/src/swagger/client/tools.ts
+++ b/src/swagger/client/tools.ts
@@ -323,7 +323,7 @@ export const TOOLS: SwaggerToolParams[] = [
     title: "Standardize API",
     toolset: "Registry API",
     summary:
-      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found and the fixed definition if successful. Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
+      "Standardize and fix an API definition using AI to ensure compliance with governance policies. Scans the API definition for standardization errors and automatically fixes them using SmartBear AI. Optionally provide 'newVersion' (e.g. patch bump '1.0.0' → '1.0.1') to save the fixed definition as a new version — omitting it will overwrite the current version. Returns the number of errors found, the fixed definition, and a URL to view the standardized API (URL is environment-specific and determined by the server configuration). Use this tool when users ask to standardize, fix, govern, or ensure governance compliance of APIs.",
     inputSchema: StandardizeApiParamsSchema,
     outputSchema: StandardizeOutputSchema,
     handler: "standardizeApi",


### PR DESCRIPTION
## Goal
SWG-21072:
We want to url should be return by tool so Agent will not hallucinate it or we  don't need to hardcode it in skill base on env.

## Design

to avoid hallucination and env specific url generation

## Changeset
If the fixed definition was saved, the response includes a `url` to view the API in SwaggerHub (server returns `savedVersion`); otherwise `url` is omitted

## Testing

standardize api tool call if url present in response or not.
