### PR TITLE
fix(functional-testing): fix sft mcp doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Swagger] Fixed Swagger Functional Testing Integration documentation to include all available tools and their descriptions, as well as adjusts wrong tool sections.
+
 ## [0.33.0] - 2026-07-28
 
 ### Added

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -2,7 +2,7 @@
 
 The Swagger Functional Testing client provides tools for discovering and executing API tests and test Suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
-> **Availability:** The Swagger Functional Testing tools listed below are only available through the Local MCP Server. They are not available on the Remote MCP Servers.
+**Note**: All tools listed below are only available through the Local MCP Server. They are not available on the Remote MCP Server.
 
 ## Available Tools
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -2,6 +2,8 @@
 
 The Swagger Functional Testing client provides tools for discovering and executing API tests and test Suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
+> **Availability:** The Swagger Functional Testing tools listed below are only available through the Local MCP Server. They are not available on the Remote MCP Servers.
+
 ## Available Tools
 
 ### Test Discovery
@@ -12,11 +14,25 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Returns: Complete list of tests with their identifiers and names.
 - Use case: Discover available tests.
 
+---
+
+### Suite Discovery
+
 #### `list_suites`
 
 - Purpose: Lists all test Suites available in your Swagger Functional Testing workspace. Use this tool when you need to discover available Suites before running them or checking their execution history. Do not use this tool to retrieve individual tests or test Suite execution results.
 - Returns: An object with a `suites` array of the test Suites in the workspace, alongside aggregate `stats`. When no Suites exist, the `suites` array is empty (`{ "suites": [] }`).
 - Use case: Discover available test Suites.
+
+---
+
+### Test Creation
+
+#### `create_test`
+
+- Purpose: Creates a new API test in your Swagger Functional Testing workspace based on given API spec. Use this tool when you need to create an end-to-end test for a given API spec.
+- Returns: The created test ID and the URL to test definition; the ID can be used with `run_test` to run it.
+- Use case: Create an API test by providing an existing API spec.
 
 ---
 
@@ -34,17 +50,11 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Returns: Execution status and result details for the given execution.
 - Use case: Poll for the outcome of a test run after calling `run_test`.
 
-#### `list_suite_executions`
+#### `get_test_history`
 
-- Purpose: Lists all executions for a given test suite in your Swagger Functional Testing workspace. Use this tool when you need to review execution history and timings for a specific suite. Do not use this tool to retrieve the status of a single execution or individual test results. Requires a `suiteId`.
-- Returns: Complete list of executions for the given suite. An empty list is returned when no executions exist.
-- Use case: Review the execution history and timings of a test suite.
-
-#### `cancel_suite_execution`
-
-- Purpose: Cancels an ongoing test suite execution in your Swagger Functional Testing workspace. Use this tool when you need to stop a long-running or accidentally triggered suite run. Do not use this tool to cancel individual test runs. Requires a `suiteId` and an `executionId`.
-- Returns: Confirmation of the cancellation. The cancelled execution is persisted in run history with status `cancelled`.
-- Use case: Stop a long-running or accidentally triggered suite run.
+- Purpose: Retrieves the execution history for a given test in your Swagger Functional Testing workspace. Use this tool when you need to check past run results, identify failures, or assess test reliability over time. Do not use this tool to run a test or retrieve suite-level execution results. Requires a `testId`.
+- Returns: A list of past runs, each including pass/fail status, run time, creation timestamp, and — for failed runs — a per-step breakdown of failure details.
+- Use case: Review past run results and assess test reliability over time.
 
 ---
 
@@ -61,6 +71,18 @@ The Swagger Functional Testing client provides tools for discovering and executi
 - Purpose: Retrieves the status and per-test result of triggered Suite execution. Requires the `suiteId` of your test Suite and the `executionId` returned by `run_suite`.
 - Returns: Execution details including `suiteId`, `executionId`, overall status (pending, canceled, passed, or failed), whether run finished, and a per-test breakdown. The per-test results include status (pending, canceled, passed, or failed), runtime and number of steps.
 - Use case: Poll for the outcome of a Suite run after calling `run_suite`.
+
+#### `list_suite_executions`
+
+- Purpose: Lists all executions for a given test Suite in your Swagger Functional Testing workspace. Use this tool when you need to review execution history and timings for a specific Suite. Do not use this tool to retrieve the status of a single execution or individual test results. Requires a `suiteId`.
+- Returns: Complete list of executions for the given Suite. An empty list is returned when no executions exist.
+- Use case: Review the execution history and timings of a test Suite.
+
+#### `cancel_suite_execution`
+
+- Purpose: Cancels an ongoing test Suite execution in your Swagger Functional Testing workspace. Use this tool when you need to stop a long-running or accidentally triggered Suite run. Do not use this tool to cancel individual test runs. Requires a `suiteId` and an `executionId`.
+- Returns: Confirmation of the cancellation. The cancelled execution is persisted in run history with status `cancelled`.
+- Use case: Stop a long-running or accidentally triggered Suite run.
 
 ---
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -2,9 +2,9 @@
 
 The Swagger Functional Testing client provides tools for discovering and executing API tests and test Suites. Tools for Swagger Functional Testing require a `SWAGGER_FUNCTIONAL_TESTING_API_TOKEN`.
 
-**Note**: All tools listed below are only available through the Local MCP Server. They are not available on the Remote MCP Server.
-
 ## Available Tools
+
+All tools listed below are only available through the Local MCP Server. They are not available on the Remote MCP Server.
 
 ### Test Discovery
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -30,9 +30,9 @@ The Swagger Functional Testing client provides tools for discovering and executi
 
 #### `create_test`
 
-- Purpose: Creates a new API test in your Swagger Functional Testing workspace based on given API spec. Use this tool when you need to create an end-to-end test for a given API spec.
+- Purpose: Creates a new API test in your Swagger Functional Testing workspace. Use this tool when you need to create an end-to-end API test, either from an existing API spec or by directly providing the request steps (URL, HTTP method, headers, body, redirect handling).
 - Returns: The created test ID and the URL to test definition; the ID can be used with `run_test` to run it.
-- Use case: Create an API test by providing an existing API spec.
+- Use case: Create an API test from an existing API spec or from directly supplied endpoint data.
 
 ---
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
This PR fixes SFT MCP documentation blueprint to include all tools we released + to adjust the tool sections there to be correct.

## Design

<!-- Why was this approach used? -->
This is done to correct our documentation that lives under https://developer.smartbear.com/smartbear-mcp/docs/swagger-functional-testing-integration.
Should be a 1 time fix, in the future we will try to remember to keep this doc up-to-date with each change.

## Changeset

-

## Testing

-
