### PR TITLE
Migration to sdk-v2/codemod v1-to-v2 changes applied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/node": "^2.0.0-beta.5",
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
+        "@modelcontextprotocol/server-legacy": "^2.0.0-beta.5",
         "js-yaml": "^4.2.0",
         "node-cache": "^5.1.2",
         "swagger-client": "^3.37.1",
@@ -33,6 +35,9 @@
         "typescript": "^5.9.3",
         "vitest": "^3.2.4",
         "vitest-fetch-mock": "^0.4.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -782,42 +787,76 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
+        "hono": {
           "optional": true
-        },
-        "zod": {
-          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-legacy/-/server-legacy-2.0.0.tgz",
+      "integrity": "sha512-LnffC1BSqFMHtMQxEz92lqDpHWma+ErV3ghdHDgdkCyYzVcCYKcUT5loq4kflty+Bf9C9qjJqbnphyBWyCqo8Q==",
+      "deprecated": "This package is a frozen copy of v1's SSE transport and OAuth Authorization Server helpers for migration purposes only. Use StreamableHTTP from @modelcontextprotocol/server and a dedicated OAuth server in production. Will not receive new features.",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "express-rate-limit": "^8.2.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
         }
       }
     },
@@ -2187,37 +2226,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -2571,6 +2579,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2839,25 +2848,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2934,11 +2924,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
@@ -2950,22 +2935,6 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3279,6 +3248,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3431,7 +3401,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3498,14 +3469,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3550,16 +3513,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "node_modules/lodash": {
       "version": "4.18.1",
@@ -3911,6 +3864,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4230,14 +4184,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4429,6 +4375,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4440,6 +4387,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5321,6 +5269,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5470,14 +5419,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@smartbear/mcp",
   "version": "0.33.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "MCP server for interacting SmartBear Products",
   "keywords": [
     "smartbear",
@@ -51,13 +54,15 @@
   },
   "dependencies": {
     "@bugsnag/js": "^8.8.1",
-    "@modelcontextprotocol/sdk": "^1.27.1",
     "js-yaml": "^4.2.0",
     "node-cache": "^5.1.2",
     "swagger-client": "^3.37.1",
     "vite": "^7.3.1",
     "ws": "^8.19.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@modelcontextprotocol/server": "^2.0.0-beta.5",
+    "@modelcontextprotocol/node": "^2.0.0-beta.5",
+    "@modelcontextprotocol/server-legacy": "^2.0.0-beta.5"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/src/bearq/tool/environments/list-environments.ts
+++ b/src/bearq/tool/environments/list-environments.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -17,7 +15,7 @@ export class ListEnvironments extends Tool<BearQClient> {
     readOnly: true,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (_args) => {
+  handle: ToolHandler = async (_args) => {
     const res = await fetch(`${this.client.getBaseUrl()}/environments`, {
       method: "GET",
       headers: this.client.getHeaders(),

--- a/src/bearq/tool/tasks/chat-with-qa-lead.ts
+++ b/src/bearq/tool/tasks/chat-with-qa-lead.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -23,7 +21,7 @@ export class ChatWithQaLead extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { instruction } = inputSchema.parse(args);
     const res = await fetch(`${this.client.getBaseUrl()}/tasks`, {
       method: "POST",

--- a/src/bearq/tool/tasks/delete-test-cases.ts
+++ b/src/bearq/tool/tasks/delete-test-cases.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -23,7 +21,7 @@ export class DeleteTestCases extends Tool<BearQClient> {
     destructive: true,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseIds } = inputSchema.parse(args);
     const deleted: number[] = [];
     const failed: { testCaseId: number; error: string }[] = [];

--- a/src/bearq/tool/tasks/expand-application-model.ts
+++ b/src/bearq/tool/tasks/expand-application-model.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -23,7 +21,7 @@ export class ExpandApplicationModel extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { functionalArea } = inputSchema.parse(args);
     const body: Record<string, unknown> = { agent: "explorer" };
     if (functionalArea !== undefined) body.functionalArea = functionalArea;

--- a/src/bearq/tool/tasks/get-task-status.ts
+++ b/src/bearq/tool/tasks/get-task-status.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -18,7 +16,7 @@ export class GetTaskStatus extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { taskId } = inputSchema.parse(args);
     const res = await fetch(
       `${this.client.getBaseUrl()}/tasks/${taskId}/status`,

--- a/src/bearq/tool/tasks/get-task.ts
+++ b/src/bearq/tool/tasks/get-task.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -18,7 +16,7 @@ export class GetTask extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { taskId } = inputSchema.parse(args);
     const res = await fetch(`${this.client.getBaseUrl()}/tasks/${taskId}`, {
       method: "GET",

--- a/src/bearq/tool/tasks/run-regression-tests.ts
+++ b/src/bearq/tool/tasks/run-regression-tests.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -24,7 +22,7 @@ export class RunRegressionTests extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { environment } = inputSchema.parse(args);
     const body: Record<string, unknown> = { agent: "tester", mode: "run" };
     if (environment !== undefined) body.environment = environment;

--- a/src/bearq/tool/tasks/run-test-cases.ts
+++ b/src/bearq/tool/tasks/run-test-cases.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -28,7 +26,7 @@ export class RunTestCases extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseIds, environment } = inputSchema.parse(args);
     const body: Record<string, unknown> = {
       agent: "tester",

--- a/src/bearq/tool/tasks/run-tests-in-functional-areas.ts
+++ b/src/bearq/tool/tasks/run-tests-in-functional-areas.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -28,7 +26,7 @@ export class RunTestsInFunctionalAreas extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { functionalAreas, environment } = inputSchema.parse(args);
     const body: Record<string, unknown> = {
       agent: "tester",

--- a/src/bearq/tool/tasks/stop-task.ts
+++ b/src/bearq/tool/tasks/stop-task.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -17,7 +15,7 @@ export class StopTask extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { taskId } = inputSchema.parse(args);
     const res = await fetch(`${this.client.getBaseUrl()}/tasks/${taskId}`, {
       method: "DELETE",

--- a/src/bearq/tool/tasks/wait-for-task.test.ts
+++ b/src/bearq/tool/tasks/wait-for-task.test.ts
@@ -59,7 +59,7 @@ describe("WaitForTask", () => {
       ),
     );
 
-    const result = await instance.handle({ taskId: 1 }, {} as any);
+    const result = await instance.handle({ taskId: 1 }, { mcpReq: {} } as any);
     const parsed = JSON.parse((result.content[0] as any).text);
 
     expect(parsed.events).toEqual([
@@ -83,7 +83,7 @@ describe("WaitForTask", () => {
       new Response(makeStream(allAtOnce), { status: 200 }),
     );
 
-    const result = await instance.handle({ taskId: 5 }, {} as any);
+    const result = await instance.handle({ taskId: 5 }, { mcpReq: {} } as any);
     const parsed = JSON.parse((result.content[0] as any).text);
 
     expect(parsed.events).toEqual([
@@ -111,7 +111,7 @@ describe("WaitForTask", () => {
         ),
       );
 
-    const result = await instance.handle({ taskId: 2 }, {} as any);
+    const result = await instance.handle({ taskId: 2 }, { mcpReq: {} } as any);
     const parsed = JSON.parse((result.content[0] as any).text);
 
     expect(parsed.events).toEqual([
@@ -132,9 +132,9 @@ describe("WaitForTask", () => {
       ),
     );
 
-    await expect(instance.handle({ taskId: 4 }, {} as any)).rejects.toThrow(
-      "closed without a done or timeout event",
-    );
+    await expect(
+      instance.handle({ taskId: 4 }, { mcpReq: {} } as any),
+    ).rejects.toThrow("closed without a done or timeout event");
   });
 
   it("should throw ToolError on non-2xx response", async () => {
@@ -142,9 +142,9 @@ describe("WaitForTask", () => {
       new Response("Unauthorized", { status: 401, statusText: "Unauthorized" }),
     );
 
-    await expect(instance.handle({ taskId: 3 }, {} as any)).rejects.toThrow(
-      "GET /tasks/3/stream failed: 401",
-    );
+    await expect(
+      instance.handle({ taskId: 3 }, { mcpReq: {} } as any),
+    ).rejects.toThrow("GET /tasks/3/stream failed: 401");
   });
 
   it("should ignore ping comment lines", async () => {
@@ -159,7 +159,7 @@ describe("WaitForTask", () => {
       ),
     );
 
-    const result = await instance.handle({ taskId: 6 }, {} as any);
+    const result = await instance.handle({ taskId: 6 }, { mcpReq: {} } as any);
     const parsed = JSON.parse((result.content[0] as any).text);
     expect(parsed.events.at(-1)).toEqual({
       event: "done",
@@ -184,14 +184,16 @@ describe("WaitForTask", () => {
     );
 
     const notifications: any[] = [];
-    const extra = {
-      _meta: { progressToken: "tok-1" },
-      sendNotification: vi.fn(async (n) => {
-        notifications.push(n);
-      }),
+    const ctx = {
+      mcpReq: {
+        _meta: { progressToken: "tok-1" },
+        notify: vi.fn(async (n) => {
+          notifications.push(n);
+        }),
+      },
     };
 
-    await instance.handle({ taskId: 9 }, extra as any);
+    await instance.handle({ taskId: 9 }, ctx as any);
 
     expect(notifications.map((n) => n.params.progress)).toEqual([1, 2, 3, 4]);
     expect(notifications.map((n) => JSON.parse(n.params.message))).toEqual([
@@ -217,12 +219,14 @@ describe("WaitForTask", () => {
       ),
     );
 
-    const sendNotification = vi.fn();
+    const notify = vi.fn();
     await instance.handle({ taskId: 10 }, {
-      _meta: {},
-      sendNotification,
+      mcpReq: {
+        _meta: {},
+        notify,
+      },
     } as any);
 
-    expect(sendNotification).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
   });
 });

--- a/src/bearq/tool/tasks/wait-for-task.ts
+++ b/src/bearq/tool/tasks/wait-for-task.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BearQClient } from "../../client";
 
@@ -30,7 +28,7 @@ export class WaitForTask extends Tool<BearQClient> {
     inputSchema,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, extra) => {
+  handle: ToolHandler = async (args, ctx) => {
     const { taskId } = inputSchema.parse(args);
     const url = `${this.client.getBaseUrl()}/tasks/${taskId}/stream`;
     const res = await fetch(url, {
@@ -43,11 +41,11 @@ export class WaitForTask extends Tool<BearQClient> {
     if (!res.body)
       throw new ToolError(`GET /tasks/${taskId}/stream: no response body`);
 
-    const progressToken = extra?._meta?.progressToken;
+    const progressToken = ctx?.mcpReq._meta?.progressToken;
     let progress = 0;
     const notify = async (event: string, data: unknown) => {
       if (progressToken === undefined) return;
-      await extra.sendNotification({
+      await ctx.mcpReq.notify({
         method: "notifications/progress",
         params: {
           progressToken,

--- a/src/bugsnag/tool/error/get-error.ts
+++ b/src/bugsnag/tool/error/get-error.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { type FilterObject, toUrlSearchParams } from "../../client/filters";
@@ -59,7 +57,7 @@ export class GetError extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const errorDetails = (

--- a/src/bugsnag/tool/error/list-project-errors.ts
+++ b/src/bugsnag/tool/error/list-project-errors.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import type { FilterObject } from "../../client/filters";
@@ -87,7 +85,7 @@ export class ListProjectErrors extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
 

--- a/src/bugsnag/tool/error/update-error.ts
+++ b/src/bugsnag/tool/error/update-error.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { GetInputFunction, ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { ErrorUpdateRequest } from "../../client/api/index";
@@ -193,7 +191,7 @@ export class UpdateError extends Tool<BugsnagClient> {
     this.getInput = getInput;
   }
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
 

--- a/src/bugsnag/tool/event/get-event-details-from-dashboard-url.ts
+++ b/src/bugsnag/tool/event/get-event-details-from-dashboard-url.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 
@@ -44,7 +42,7 @@ export class GetEventDetailsFromDashboardUrl extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const url = new URL(params.link);
     const eventId = url.searchParams.get("event_id");

--- a/src/bugsnag/tool/event/get-event.ts
+++ b/src/bugsnag/tool/event/get-event.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -34,7 +32,7 @@ export class GetEvent extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const response = await this.client.getEvent(params.eventId, project.id);

--- a/src/bugsnag/tool/event/list-error-events.ts
+++ b/src/bugsnag/tool/event/list-error-events.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -43,7 +41,7 @@ export class ListErrorEvents extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const response = await this.client.errorsApi.listErrorEvents(

--- a/src/bugsnag/tool/performance/get-network-endpoint-groupings.ts
+++ b/src/bugsnag/tool/performance/get-network-endpoint-groupings.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -40,7 +38,7 @@ export class GetNetworkEndpointGroupings extends Tool<BugsnagClient> {
     idempotent: true,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const result =

--- a/src/bugsnag/tool/performance/get-span-group.ts
+++ b/src/bugsnag/tool/performance/get-span-group.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -49,7 +47,7 @@ export class GetSpanGroup extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
 

--- a/src/bugsnag/tool/performance/get-trace.ts
+++ b/src/bugsnag/tool/performance/get-trace.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -63,7 +61,7 @@ export class GetTrace extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     if (!params.traceId || !params.from || !params.to) {

--- a/src/bugsnag/tool/performance/list-span-groups.ts
+++ b/src/bugsnag/tool/performance/list-span-groups.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -92,7 +90,7 @@ export class ListSpanGroups extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const result = await this.client.projectApi.listProjectSpanGroups(

--- a/src/bugsnag/tool/performance/list-spans.ts
+++ b/src/bugsnag/tool/performance/list-spans.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -79,7 +77,7 @@ export class ListSpans extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const result = await this.client.projectApi.listSpansBySpanGroupId(

--- a/src/bugsnag/tool/performance/list-trace-fields.ts
+++ b/src/bugsnag/tool/performance/list-trace-fields.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -37,7 +35,7 @@ export class ListTraceFields extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const traceFields = await this.client.getProjectTraceFields(project);

--- a/src/bugsnag/tool/performance/set-network-endpoint-groupings.ts
+++ b/src/bugsnag/tool/performance/set-network-endpoint-groupings.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -81,7 +79,7 @@ export class SetNetworkEndpointGroupings extends Tool<BugsnagClient> {
     idempotent: true,
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const result =

--- a/src/bugsnag/tool/project/get-current-project.ts
+++ b/src/bugsnag/tool/project/get-current-project.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -28,7 +26,7 @@ export class GetCurrentProject extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (_args, _extra) => {
+  handle: ToolHandler = async (_args, _extra) => {
     const project = await this.client.getCurrentProject();
     if (!project) {
       throw new ToolError(

--- a/src/bugsnag/tool/project/list-project-event-filters.ts
+++ b/src/bugsnag/tool/project/list-project-event-filters.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -38,7 +36,7 @@ export class ListProjectEventFilters extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const eventFilters = await this.client.getProjectEventFields(
       await this.client.getInputProject(params.projectId),

--- a/src/bugsnag/tool/project/list-projects.ts
+++ b/src/bugsnag/tool/project/list-projects.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import type { Project } from "../../client/api/index";
@@ -32,7 +30,7 @@ export class ListProjects extends Tool<BugsnagClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     let projects = await this.client.getProjects();
     if (!projects || projects.length === 0) {

--- a/src/bugsnag/tool/release/get-build.ts
+++ b/src/bugsnag/tool/release/get-build.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import { toolInputParameters } from "../../input-schemas";
@@ -42,7 +40,7 @@ export class GetBuild extends Tool<BugsnagClient> {
       "JSON object containing build details along with stability metrics such as user and session stability, and whether it meets project targets",
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const response = await this.client.projectApi.getProjectReleaseById(

--- a/src/bugsnag/tool/release/get-release.ts
+++ b/src/bugsnag/tool/release/get-release.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import type { Build } from "../../client/api/index";
@@ -54,7 +52,7 @@ export class GetRelease extends Tool<BugsnagClient> {
       "JSON object containing release details along with stability metrics such as user and session stability, and whether it meets project targets",
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const releaseResponse = await this.client.projectApi.getReleaseGroup(

--- a/src/bugsnag/tool/release/list-releases.ts
+++ b/src/bugsnag/tool/release/list-releases.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { BugsnagClient } from "../../client";
 import type { Release } from "../../client/api/index";
@@ -77,7 +75,7 @@ export class ListReleases extends Tool<BugsnagClient> {
       "JSON array of release summary objects with metadata, with a URL to the next page if more results are available",
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, _extra) => {
+  handle: ToolHandler = async (args, _extra) => {
     const params = inputSchema.parse(args);
     const project = await this.client.getInputProject(params.projectId);
     const response = await this.client.projectApi.listProjectReleaseGroups(

--- a/src/collaborator/client.test.ts
+++ b/src/collaborator/client.test.ts
@@ -1,7 +1,6 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
-import type { ZodRawShape } from "zod";
+import type { ToolHandler } from "../common/tools";
 import { CollaboratorClient } from "./client";
 
 const fetchMock = createFetchMock(vi);
@@ -307,7 +306,7 @@ describe("CollaboratorClient", () => {
   });
 
   describe("tool handler direct invocation", () => {
-    let handlers: Record<string, ToolCallback<ZodRawShape>> = {};
+    let handlers: Record<string, ToolHandler> = {};
     const mockGetInput = vi.fn();
     beforeEach(() => {
       handlers = {};

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -12394,6 +12394,10 @@ Expected Output: The newly created Test Case with its details and key",
 
 **Toolset:** Test Cases
 
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+- issueId (number): The Jira issue ID
+
 **Examples:**
 1. Create a link between the test case SA-T1 and the Jira Issue ID 10100
 \`\`\`json
@@ -12424,6 +12428,12 @@ Expected Output: The newly created Issue Link with its ID and self link",
     "description": "Create steps for a Test Case in Zephyr. Supports inline step definitions or delegating execution to another test case (also known as 'call to test' via UI). Requires a mode: \`APPEND\` adds steps to the end of the existing list, \`OVERWRITE\` deletes all existing steps and replaces them with the provided ones. Always ask the user to choose between OVERWRITE or APPEND before calling this tool.
 
 **Toolset:** Test Cases
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+- mode (string) *required*: Valid values: \`"APPEND"\`, \`"OVERWRITE"\`. <br> \`OVERWRITE\` deletes and recreates the test steps and associated custom field values using the provided input. Attachments for existing steps are kept, but those for missing steps are deleted permanently <br> \`APPEND\` only adds extra steps to your test steps.
+
+- items (array) *required*: The list of test steps. Each step should be an object containing \`inline\` or \`testCase\`. **They should only include one of these fields at a time**.
 
 **Examples:**
 1. To the Test Case SA-T1, add steps that will test a login page.
@@ -12655,6 +12665,10 @@ Expected Output: The newly created Test Cycle with its details and key",
 
 **Toolset:** Test Cycles
 
+**Parameters:**
+- testCycleIdOrKey (string) *required*: The ID or key of the test cycle.
+- issueId (number) *required*: The Jira issue ID
+
 **Examples:**
 1. Create a link between the test cycle with key SA-R1 and the Jira Issue ID 10100
 \`\`\`json
@@ -12691,6 +12705,11 @@ Expected Output: The link between Test Cycle and Jira issue should be created, b
     "description": "Create a new Web Link for a Test Cycle in Zephyr
 
 **Toolset:** Test Cycles
+
+**Parameters:**
+- testCycleIdOrKey (string) *required*: The ID or key of the test cycle.
+- description (string): The web link description
+- url (string): The web link URL
 
 **Examples:**
 1. Create a link between the specified test cycle by Id '100001' and generic URL 'https://www.atlassian.com' with description 'Atlassian homepage'
@@ -12835,6 +12854,10 @@ Expected Output: The newly created Test Execution including custom field values"
 
 **Toolset:** Test Executions
 
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+- issueId (number) *required*: The Jira issue ID
+
 **Examples:**
 1. Create a link between the test execution with key SA-E40 and the Jira Issue ID 10100
 \`\`\`json
@@ -12871,6 +12894,22 @@ Expected Output: The link between Test Execution and Jira issue should be create
     "description": "Create a new Test Script of the types Plain Text or BDD in a Zephyr Test Case.
 
 **Toolset:** Test Cases
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+- type (enum): Test scripts can be written in plain text or BDD format. The BDD type supports
+remote execution on a build system via API plugin.
+
+Supported Keywords for BDD:
+Given, When, Then, And, But.
+
+For more information about BDD and Gherkin syntax, see:
+https://support.smartbear.com/zephyr/docs/en/test-cases/gherkin-behavior-driven-development--bdd-.html
+
+For Plain Text scripts, we support HTML fragments.
+To create a step-by-step test script, you should use the POST /testcases/{testCaseKey}/teststeps endpoint.
+
+- text (string)
 
 **Examples:**
 1. Create a plain text test script for test case SA-T1 to verify that the axial pump can be enabled
@@ -13022,7 +13061,11 @@ Expected Output: The List of test cases linked to Jira issue PROJ-123 with their
     "inputSchema": [
       "issueKey",
     ],
-    "outputSchema": undefined,
+    "outputSchema": [
+      "key",
+      "self",
+      "version",
+    ],
     "title": "Zephyr: Get Issue Link Test Cases",
   },
   "zephyr_get_priorities": {
@@ -13347,6 +13390,14 @@ Expected Output: The links (issue links and web links) associated with the test 
     "description": "Get details of test case steps in Zephyr
 
 **Toolset:** Test Cases
+
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
 
 **Examples:**
 1. Get the first 10 test case steps for test case with key 'SA-T1'
@@ -13684,7 +13735,10 @@ Expected Output: The List of test cycles linked to Jira issue PROJ-123 with thei
     "inputSchema": [
       "issueKey",
     ],
-    "outputSchema": undefined,
+    "outputSchema": [
+      "id",
+      "self",
+    ],
     "title": "Zephyr: Get Test Cycles linked to a Jira issue",
   },
   "zephyr_get_test_execution": {
@@ -13793,6 +13847,15 @@ Expected Output: The test execution links with its details",
     "description": "Get details of test execution steps in Zephyr
 
 **Toolset:** Test Executions
+
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+- maxResults (number): Specifies the maximum number of results to return in a single call. The default value is 10, and the maximum value that can be requested is 1000.
+
+Note that the server may enforce a lower limit than requested, depending on resource availability or other internal constraints. If this happens, the result set may be truncated. Always check the maxResults value in the response to confirm how many results were actually returned.
+ (default: 10)
+- startAt (number): Zero-indexed starting position. Should be a multiple of maxResults. (default: 0)
+- testDataRowNumber (number): The id of the test data row to retrieve.
 
 **Examples:**
 1. Get the first 10 test execution steps for test execution with ID 1
@@ -13969,7 +14032,10 @@ Expected Output: The List of test executions linked to Jira issue PROJ-123 with 
     "inputSchema": [
       "issueKey",
     ],
-    "outputSchema": undefined,
+    "outputSchema": [
+      "id",
+      "self",
+    ],
     "title": "Zephyr: Get test executions linked to a Jira issue",
   },
   "zephyr_get_test_plans": {
@@ -14112,6 +14178,26 @@ Expected Output: The test script with its type (plain or bdd), text content, and
 
 **Toolset:** Test Cases
 
+**Parameters:**
+- testCaseKey (string) *required*: The key of the test case. Test case keys are of the format [A-Z]+-T[0-9]+
+- id (number): The ID of the entity
+- key (string): The test case key
+- name (string)
+- project (object): ID and link relative to Zephyr project.
+- objective (string): A description of the objective.
+- precondition (string): Any conditions that need to be met.
+- estimatedTime (number): Estimated duration in milliseconds.
+- labels (array): Array of labels associated to this entity.
+- component (number): The ID of the Jira component to associate.
+- priority (object): ID and link to the priority resource.
+- status (object): ID and link to the status resource.
+- folder (number): The ID of the folder to move the test case into.
+- owner (string): Atlassian Account ID of the Jira user to set as owner.
+- customFields (record<string, any>): Multi-line text fields support HTML and should denote new lines with the \\<br\\> tag.
+Dates should be in the format 'yyyy-MM-dd'.
+Users should have values of Jira User Account IDs.
+
+
 **Examples:**
 1. Update the name of the test case 'SA-T10' to 'Check axial pump' and objective to 'To ensure the axial pump can be enabled'
 \`\`\`json
@@ -14213,6 +14299,24 @@ Expected Output: The test case should be updated, but no output is expected.",
 
 **Toolset:** Test Cycles
 
+**Parameters:**
+- testCycleIdOrKey (string) *required*: The ID or key of the test cycle.
+- id (number): The ID of the entity
+- key (string): Unique key of the test cycle
+- name (string)
+- project (object): ID and link relative to Zephyr project.
+- jiraProjectVersion (number): The ID of the Jira project version (release) to associate.
+- status (object): ID and link to the status resource.
+- folder (number): The ID of the folder to move the test cycle into.
+- description (string): Description outlining the scope.
+- plannedStartDate (string): Planned start date of the test cycle. This field cannot be blank. Setting it as null or excluding it from the request will leave the field values unchanged. ISO 8601 Format (i.e., yyyy-MM-dd'T'HH:mm:ss'Z')
+- plannedEndDate (string): The planned end date of the test cycle. This field cannot be blank. Setting it as null or excluding it from the request will leave the field values unchanged. ISO 8601 Format (i.e., yyyy-MM-dd'T'HH:mm:ss'Z')
+- owner (string): Atlassian Account ID of the Jira user to set as owner.
+- customFields (record<string, any>): Multi-line text fields support HTML and should denote new lines with the \\<br\\> tag.
+Dates should be in the format 'yyyy-MM-dd'.
+Users should have values of Jira User Account IDs.
+
+
 **Examples:**
 1. Update the name of the test cycle 'SA-R40' to 'Sprint 1 Regression - Updated' and set description.
 \`\`\`json
@@ -14308,6 +14412,16 @@ Expected Output: The test cycle should be updated, but no output is expected.",
 
 **Toolset:** Test Executions
 
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+- statusName (string): The status name.
+- environmentName (string): Environment assigned to the test case.
+- actualEndDate (string): The actual end date of the test cycle. Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+- executionTime (number): Actual test execution time in milliseconds.
+- executedById (string): Atlassian Account ID of the Jira user.
+- assignedToId (string): Atlassian Account ID of the Jira user.
+- comment (string): Comment added against overall test case execution.
+
 **Examples:**
 1. Update the status name to 'PASS' and the environment name to 'ENV-1' in the test execution 'SA-E40'.
 \`\`\`json
@@ -14380,6 +14494,10 @@ Expected Output: The test execution should be updated, but no output is expected
     "description": "Update test steps for a given Test Execution in Zephyr. This operation updates the provided steps with their execution status and actual results. Only the fields included in the request will be modified.
 
 **Toolset:** Test Executions
+
+**Parameters:**
+- testExecutionIdOrKey (string) *required*: The ID or key of the test execution. Test execution keys are of the format [A-Z]+-E[0-9]+
+- steps (array)
 
 **Examples:**
 1. Mark the status of all steps in the test execution 'SA-E1' as 'Pass'. Set the actual result of step 1 to 'Dashboard widgets loaded correctly' and step 2 to 'Navigation menu responded correctly to user interactions'.

--- a/src/common/pollyfills.ts
+++ b/src/common/pollyfills.ts
@@ -1,8 +1,4 @@
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ElicitRequest,
-  ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { RequestOptions, ElicitRequest, ElicitResult } from "@modelcontextprotocol/server";
 import type { SmartBearMcpServer } from "./server";
 import { ToolError } from "./tools";
 

--- a/src/common/prompts.ts
+++ b/src/common/prompts.ts
@@ -1,6 +1,18 @@
-import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
+import type {
+  GetPromptResult,
+  ServerContext,
+} from "@modelcontextprotocol/server";
 import type { Client, PromptParams } from "./types";
+
+/**
+ * Handler signature for a prompt's callback. In SDK v2 the request context is a
+ * single {@link ServerContext} argument (replacing the v1 `extra`); `args` is
+ * loosely typed because each prompt validates against its own `argsSchema`.
+ */
+export type PromptHandler = (
+  args: any,
+  ctx: ServerContext,
+) => GetPromptResult | Promise<GetPromptResult>;
 
 /**
  * Base class encapsulating a prompt's configuration and callback, with reference to its client.
@@ -11,5 +23,5 @@ export abstract class Prompt<T extends Client> {
     this.client = client;
   }
   abstract specification: PromptParams;
-  abstract callback: PromptCallback<ZodRawShape>;
+  abstract callback: PromptHandler;
 }

--- a/src/common/server-definitions.test.ts
+++ b/src/common/server-definitions.test.ts
@@ -2,16 +2,26 @@ import { describe, expect, it, vi } from "vitest";
 import { SmartBearMcpServer } from "./server";
 
 import "./register-clients";
-import type { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ResourceTemplate } from "@modelcontextprotocol/server";
 import { clientRegistry } from "./client-registry";
 
-// outputSchema/inputSchema may be a raw shape (plain object of Zod fields) or a
-// full Zod object schema (e.g. z.looseObject) — normalize to a sorted list of
-// field names either way so the snapshot reflects the schema's shape, not its
-// runtime representation.
+// outputSchema/inputSchema may be a raw shape (plain object of Zod fields), a
+// full Zod object schema (e.g. z.looseObject), a ZodIntersection (from
+// `.and(...)`), or a ZodArray (from `z.array(...)`) — normalize to a sorted
+// list of field names in every case so the snapshot reflects the schema's
+// shape, not its runtime representation.
 function schemaFieldNames(schema: any): string[] | undefined {
   if (!schema) {
     return undefined;
+  }
+  if (schema.def?.left && schema.def?.right) {
+    return [
+      ...(schemaFieldNames(schema.def.left) ?? []),
+      ...(schemaFieldNames(schema.def.right) ?? []),
+    ].sort();
+  }
+  if (schema.def?.element) {
+    return schemaFieldNames(schema.def.element);
   }
   const shape = schema.shape ?? schema;
   return Object.keys(shape).sort();
@@ -59,9 +69,7 @@ describe("server definitions are not changed unexpectedly", () => {
     ).mockImplementation(((promptName: string, config: any) => {
       registeredPrompts[promptName] = {
         ...config,
-        argsSchema: config.argsSchema
-          ? Object.keys(config.argsSchema).sort()
-          : undefined,
+        argsSchema: schemaFieldNames(config.argsSchema),
       };
     }) as any);
 

--- a/src/common/server.test.ts
+++ b/src/common/server.test.ts
@@ -1,4 +1,4 @@
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import z from "zod";
 import Bugsnag from "./bugsnag";
@@ -115,7 +115,7 @@ describe("SmartBearMcpServer", () => {
           "**Parameters:**\n" +
           "- p1 (string) *required*: The input for the tool",
       );
-      expect(registerToolParams[1].inputSchema.p1.toString()).toBe(
+      expect(registerToolParams[1].inputSchema.shape.p1.toString()).toBe(
         z.string().describe("The input for the tool").toString(),
       );
       expect(registerToolParams[1].annotations).toEqual({
@@ -252,7 +252,7 @@ describe("SmartBearMcpServer", () => {
           "```\n\n" +
           "**Hints:** 1. First hint 2. Second hint",
       );
-      expect(registerToolParams[1].inputSchema.p1.toString()).toBe(
+      expect(registerToolParams[1].inputSchema.shape.p1.toString()).toBe(
         z.string().describe("The input for the tool").toString(),
       );
       expect(registerToolParams[1].annotations).toEqual({
@@ -524,7 +524,9 @@ describe("SmartBearMcpServer", () => {
           "- p4 (boolean): param-defaulted-bool-described-after (default: false)",
       );
 
-      expect(Object.keys(registerToolParams[1].inputSchema).length).toBe(4);
+      expect(Object.keys(registerToolParams[1].inputSchema.shape).length).toBe(
+        4,
+      );
 
       // Output schema should be passed through as the full Zod schema (not a raw
       // shape) so that additionalProperties handling (e.g. looseObject) is preserved
@@ -858,30 +860,6 @@ describe("SmartBearMcpServer", () => {
       );
 
       expect(result).not.toBeNull();
-    });
-  });
-
-  describe("schemaToRawShape", () => {
-    it("should convert Zod schema to raw shape", () => {
-      const schema = z.object({
-        name: z.string().describe("The name of the person"),
-        age: z.number().min(0).describe("The age of the person"),
-        isActive: z.boolean().describe("Is the person active?"),
-      });
-      // biome-ignore lint/complexity/useLiteralKeys: accessing internal method for test
-      const result = server["schemaToRawShape"](schema);
-      expect(result).toEqual(schema.shape);
-    });
-    it("returns an empty object if it's not a ZodObject", () => {
-      const schema = z.array(z.string());
-      // biome-ignore lint/complexity/useLiteralKeys: accessing internal method for test
-      const rawShape = server["schemaToRawShape"](schema);
-      expect(rawShape).toBeUndefined();
-    });
-    it("returns an empty object if the schema is undefined", () => {
-      // biome-ignore lint/complexity/useLiteralKeys: accessing internal method for test
-      const rawShape = server["schemaToRawShape"](undefined);
-      expect(rawShape).toBeUndefined();
     });
   });
 

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,17 +1,9 @@
-import {
-  McpServer,
-  ResourceTemplate,
-} from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   CallToolResult,
   ToolAnnotations,
-} from "@modelcontextprotocol/sdk/types.js";
-import {
-  ZodIntersection,
-  ZodObject,
-  type ZodRawShape,
-  type ZodType,
-} from "zod";
+} from "@modelcontextprotocol/server";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
+import { ZodObject, z } from "zod";
 import Bugsnag, { type BugsnagEvent } from "../common/bugsnag";
 import { CacheService } from "./cache";
 import { type McpClientIdentity, toClientIdentity } from "./client-identity";
@@ -144,32 +136,28 @@ export class SmartBearMcpServer extends McpServer {
             `The tool name "${toolName}" is too long. Tool names must be 64 characters or fewer for client compatibility. https://github.com/anthropics/claude-code/issues/34960`,
           );
         }
+        // In SDK v2, registerTool accepts Standard Schema objects directly.
+        // Passing the Zod schemas through as-is (rather than extracting a raw
+        // `.shape`) preserves z.looseObject()'s additionalProperties:true in the
+        // JSON schema sent to clients — otherwise real API responses would fail
+        // "additional properties" validation.
         return super.registerTool(
           toolName,
           {
             title: toolTitle,
             description: this.getDescription(params),
-            inputSchema: params.inputSchema
-              ? this.schemaToRawShape(params.inputSchema)
-              : {},
-            // Pass ZodObject-based schemas through as-is (rather than via schemaToRawShape)
-            // so that z.looseObject()'s additionalProperties:true is preserved in the JSON
-            // schema sent to clients — extracting `.shape` would rebuild a strict object and
-            // cause "additional properties" validation errors on real API responses.
-            outputSchema:
-              params.outputSchema instanceof ZodObject
-                ? params.outputSchema
-                : this.schemaToRawShape(params.outputSchema),
+            inputSchema: params.inputSchema ?? z.object({}),
+            outputSchema: params.outputSchema,
             annotations: this.getAnnotations(toolTitle, params),
           },
-          async (args: any, extra: any) => {
+          async (args: any, ctx: any) => {
             try {
               if (!client.isConfigured()) {
                 throw new ToolError(
                   `The tool is not configured - configuration options for ${client.name} are missing or invalid.`,
                 );
               }
-              const result = await cb(args, extra);
+              const result = await cb(args, ctx);
               if (result) {
                 this.validateCallbackResult(result, params);
                 this.addStructuredContentAsText(result);
@@ -234,9 +222,9 @@ export class SmartBearMcpServer extends McpServer {
             title: this.getCapabilityTitle(client, params.title),
             description: params.description,
           },
-          async (url: any, variables: any, extra: any) => {
+          async (url: any, variables: any, ctx: any) => {
             try {
-              return await cb(url, variables, extra);
+              return await cb(url, variables, ctx);
             } catch (e) {
               Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
                 event.addMetadata("app", {
@@ -260,11 +248,11 @@ export class SmartBearMcpServer extends McpServer {
           {
             title: this.getCapabilityTitle(client, params.title),
             description: params.description,
-            argsSchema: this.schemaToRawShape(params.argsSchema) || {},
+            argsSchema: params.argsSchema,
           },
-          async (args: any, extra: any) => {
+          async (args: any, ctx: any) => {
             try {
-              return await cb(args, extra);
+              return await cb(args, ctx);
             } catch (e) {
               Bugsnag.notify(e as unknown as Error, (event: BugsnagEvent) => {
                 event.addMetadata("app", {
@@ -315,26 +303,6 @@ export class SmartBearMcpServer extends McpServer {
       openWorldHint: params.openWorld ?? false,
     };
     return annotations;
-  }
-
-  private schemaToRawShape(
-    schema: ZodType | undefined,
-  ): ZodRawShape | undefined {
-    if (schema) {
-      if (schema instanceof ZodObject) {
-        return schema.shape;
-      }
-      if (schema instanceof ZodIntersection) {
-        const leftShape = this.schemaToRawShape(
-          (schema as ZodIntersection<ZodType, ZodType>).def.left,
-        );
-        const rightShape = this.schemaToRawShape(
-          (schema as ZodIntersection<ZodType, ZodType>).def.right,
-        );
-        return { ...leftShape, ...rightShape };
-      }
-    }
-    return undefined;
   }
 
   private getCapabilityTitle(client: Client, title: string): string {

--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -1,6 +1,18 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
+import type {
+  CallToolResult,
+  ServerContext,
+} from "@modelcontextprotocol/server";
 import type { Client, ToolParams } from "./types";
+
+/**
+ * Handler signature for a tool's action. In SDK v2 the request context is a
+ * single {@link ServerContext} argument (replacing the v1 `extra`); `args` is
+ * loosely typed because each tool validates against its own `inputSchema`.
+ */
+export type ToolHandler = (
+  args: any,
+  ctx: ServerContext,
+) => CallToolResult | Promise<CallToolResult>;
 
 /**
  * Error class for tool-specific errors – these result in a response to the LLM with `isError: true`
@@ -30,5 +42,5 @@ export abstract class Tool<T extends Client> {
     this.client = client;
   }
   abstract specification: ToolParams;
-  abstract handle: ToolCallback<ZodRawShape>;
+  abstract handle: ToolHandler;
 }

--- a/src/common/transport-http.test.ts
+++ b/src/common/transport-http.test.ts
@@ -698,8 +698,8 @@ describe("handleStreamableHttpRequest (session routing)", () => {
     // initialize flow against an incomplete fakeResponse stub. The point of
     // this test is to verify dispatch *into* createNewTransport, not to
     // exercise the SDK internals.
-    const { StreamableHTTPServerTransport } = await import(
-      "@modelcontextprotocol/sdk/server/streamableHttp.js"
+    const { NodeStreamableHTTPServerTransport: StreamableHTTPServerTransport } = await import(
+      "@modelcontextprotocol/node"
     );
     const handleRequestSpy = vi
       .spyOn(StreamableHTTPServerTransport.prototype, "handleRequest")
@@ -725,8 +725,8 @@ describe("handleStreamableHttpRequest (session routing)", () => {
     const handleRequest = vi.fn().mockResolvedValue(undefined);
     // Construct a stand-in for StreamableHTTPServerTransport that satisfies the
     // instanceof check inside getExistingTransport without spinning up a real one.
-    const { StreamableHTTPServerTransport } = await import(
-      "@modelcontextprotocol/sdk/server/streamableHttp.js"
+    const { NodeStreamableHTTPServerTransport: StreamableHTTPServerTransport } = await import(
+      "@modelcontextprotocol/node"
     );
     const fakeTransport = Object.create(
       StreamableHTTPServerTransport.prototype,

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -2,10 +2,9 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import querystring from "node:querystring";
-
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { isInitializeRequest } from "@modelcontextprotocol/server";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { SSEServerTransport } from "@modelcontextprotocol/server-legacy/sse";
 import { clientRegistry } from "./client-registry";
 import { handleInitializeMessage } from "./initialize";
 import { setRequestMcpClient, withRequestContext } from "./request-context";
@@ -16,7 +15,7 @@ import { getTypeDescription, isOptionalType } from "./zod-utils";
 
 type SessionEntry = {
   server: SmartBearMcpServer;
-  transport: StreamableHTTPServerTransport | SSEServerTransport;
+  transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
 };
 
 /**
@@ -298,13 +297,13 @@ function getExistingTransport(
     string,
     {
       server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
+      transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
     }
   >,
   res: ServerResponse,
-): StreamableHTTPServerTransport | null {
+): NodeStreamableHTTPServerTransport | null {
   const existing = transports.get(sessionId);
-  if (existing && existing.transport instanceof StreamableHTTPServerTransport) {
+  if (existing && existing.transport instanceof NodeStreamableHTTPServerTransport) {
     return existing.transport;
   }
 
@@ -337,10 +336,10 @@ async function createNewTransport(
     string,
     {
       server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
+      transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
     }
   >,
-): Promise<StreamableHTTPServerTransport | null> {
+): Promise<NodeStreamableHTTPServerTransport | null> {
   // Create and configure server with headers from the request
   const server = await newServer(req, res);
   if (!server) {
@@ -348,7 +347,7 @@ async function createNewTransport(
   }
 
   // Create transport with session management
-  const transport = new StreamableHTTPServerTransport({
+  const transport = new NodeStreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
     onsessioninitialized: (newSessionId) => {
       console.log(`[MCP] New session initialized: ${newSessionId}`);
@@ -392,7 +391,7 @@ export async function handleStreamableHttpRequest(
     string,
     {
       server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
+      transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
     }
   >,
 ) {
@@ -423,7 +422,7 @@ export async function handleStreamableHttpRequest(
 
     const parsedBody = await parseRequestBody(req);
 
-    let transport: StreamableHTTPServerTransport;
+    let transport: NodeStreamableHTTPServerTransport;
 
     // Case 2: Existing session - route to existing transport
     if (sessionId) {
@@ -497,7 +496,7 @@ async function handleLegacySseRequest(
     string,
     {
       server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
+      transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
     }
   >,
 ) {
@@ -546,7 +545,7 @@ async function handleLegacyMessageRequest(
     string,
     {
       server: SmartBearMcpServer;
-      transport: StreamableHTTPServerTransport | SSEServerTransport;
+      transport: NodeStreamableHTTPServerTransport | SSEServerTransport;
     }
   >,
 ) {

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -1,6 +1,5 @@
 import { enableCompileCache } from "node:module";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { clientRegistry } from "./client-registry";
 import { USER_AGENT } from "./info";
 import { handleInitializeMessage } from "./initialize";

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,18 +1,16 @@
 import type {
-  PromptCallback,
+  ElicitRequest,
+  ElicitResult,
   ReadResourceTemplateCallback,
   RegisteredPrompt,
   RegisteredResourceTemplate,
   RegisteredTool,
-  ToolCallback,
-} from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ElicitRequest,
-  ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { ZodObject, ZodRawShape, ZodType } from "zod";
+  RequestOptions,
+} from "@modelcontextprotocol/server";
+import type { ZodObject, ZodType } from "zod";
+import type { PromptHandler } from "./prompts";
 import type { SmartBearMcpServer } from "./server";
+import type { ToolHandler } from "./tools";
 
 export interface ToolParams {
   title: string;
@@ -54,9 +52,9 @@ export interface ResourceParams {
   path: string;
 }
 
-export type RegisterToolsFunction = <InputArgs extends ZodRawShape>(
+export type RegisterToolsFunction = (
   params: ToolParams,
-  cb: ToolCallback<InputArgs>,
+  cb: ToolHandler,
 ) => RegisteredTool | null;
 
 export type RegisterResourceFunction = (
@@ -64,9 +62,9 @@ export type RegisterResourceFunction = (
   cb: ReadResourceTemplateCallback,
 ) => RegisteredResourceTemplate;
 
-export type RegisterPromptFunction = <Args extends ZodRawShape>(
+export type RegisterPromptFunction = (
   params: PromptParams,
-  cb: PromptCallback<Args>,
+  cb: PromptHandler,
 ) => RegisteredPrompt;
 
 export type GetInputFunction = (

--- a/src/pactflow/client/prompts.ts
+++ b/src/pactflow/client/prompts.ts
@@ -1,11 +1,11 @@
-import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
-import { type ZodRawShape, z } from "zod";
+import type { GetPromptResult } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import type { PromptHandler } from "../../common/prompts";
 import type { PromptParams } from "../../common/types";
 import { EndpointMatcherSchema } from "./ai";
 
 export interface PactflowPromptParams extends PromptParams {
-  callback: PromptCallback<ZodRawShape>;
+  callback: PromptHandler;
 }
 
 const OADMatcherPromptOpenAPIDocExample = {

--- a/src/qtm4j/tool/project/get-projects.ts
+++ b/src/qtm4j/tool/project/get-projects.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { Qtm4jClient } from "../../client";
 import {
@@ -115,7 +113,7 @@ export class GetProjects extends Tool<Qtm4jClient> {
       "JSON object containing paginated list of projects with IDs, keys, names, and QMetry status, along with pagination metadata",
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const input = GetProjectsBody.parse(args);
 
     // Build request body with pagination and optional filters

--- a/src/qtm4j/tool/project/set-project-context.test.ts
+++ b/src/qtm4j/tool/project/set-project-context.test.ts
@@ -122,7 +122,7 @@ describe("SetProjectContext", () => {
         projectKey: "SCRUM",
         projectName: "Scrum Project",
       });
-      expect(result.structuredContent?.projectKey).toBe("SCRUM");
+      expect((result.structuredContent as any)?.projectKey).toBe("SCRUM");
     });
 
     it("should clear previous project cache when switching projects", async () => {

--- a/src/qtm4j/tool/project/set-project-context.ts
+++ b/src/qtm4j/tool/project/set-project-context.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { Qtm4jClient } from "../../client";
 import {
@@ -89,7 +87,7 @@ export class SetProjectContext extends Tool<Qtm4jClient> {
       "availableFields contains priority and status options for NLP mapping in subsequent tool calls.",
   };
 
-  handle: ToolCallback<ZodRawShape> = async (rawArgs) => {
+  handle: ToolHandler = async (rawArgs) => {
     const { projectKey } = SetProjectContextBody.parse(rawArgs);
     const apiClient = this.client.getApiClient();
 

--- a/src/reflect/prompt/sap-test.ts
+++ b/src/reflect/prompt/sap-test.ts
@@ -1,6 +1,5 @@
-import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type ZodRawShape, z } from "zod";
-import { Prompt } from "../../common/prompts";
+import { z } from "zod";
+import { Prompt, type PromptHandler } from "../../common/prompts";
 import type { ReflectClient } from "../client";
 
 export class SapTest extends Prompt<ReflectClient> {
@@ -11,7 +10,7 @@ export class SapTest extends Prompt<ReflectClient> {
     argsSchema: z.object({}),
   };
 
-  callback: PromptCallback<ZodRawShape> = (_args) => ({
+  callback: PromptHandler = (_args) => ({
     messages: [
       {
         role: "user",

--- a/src/reflect/tool/recording/add-prompt-step.ts
+++ b/src/reflect/tool/recording/add-prompt-step.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import type { MCPAddPromptStepSuccessResponse } from "../../types/mcp";
@@ -25,7 +23,7 @@ export class AddPromptStep extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { sessionId, prompt } = args as {
       sessionId: string;
       prompt: string;

--- a/src/reflect/tool/recording/add-segment.ts
+++ b/src/reflect/tool/recording/add-segment.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 
@@ -20,7 +18,7 @@ export class AddSegment extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { sessionId, segmentId } = args as {
       sessionId: string;
       segmentId: number;

--- a/src/reflect/tool/recording/connect-to-session.ts
+++ b/src/reflect/tool/recording/connect-to-session.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import type { MCPConnectToSessionSuccessResponse } from "../../types/mcp";
@@ -30,7 +28,7 @@ export class ConnectToSession extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args, extra) => {
+  handle: ToolHandler = async (args, ctx) => {
     const { sessionId } = args as { sessionId: string };
     if (!sessionId) throw new ToolError("sessionId argument is required");
 
@@ -80,7 +78,7 @@ export class ConnectToSession extends Tool<ReflectClient> {
 
     // This identifies the MCP session, rather than the Reflect recording session.
     // There can be multiple MCP sessions if we're running in HTTP mode.
-    const mcpSessionId = extra?.sessionId;
+    const mcpSessionId = ctx?.sessionId;
     const { platform, test } = connectResponse;
     this.client.registerConnection(
       sessionId,

--- a/src/reflect/tool/recording/delete-previous-step.ts
+++ b/src/reflect/tool/recording/delete-previous-step.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 
@@ -20,7 +18,7 @@ export class DeletePreviousStep extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { sessionId } = args as { sessionId: string };
     if (!sessionId) throw new ToolError("sessionId argument is required");
 

--- a/src/reflect/tool/recording/get-screenshot.ts
+++ b/src/reflect/tool/recording/get-screenshot.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import type { MCPGetScreenshotSuccessResponse } from "../../types/mcp";
@@ -24,7 +22,7 @@ export class GetScreenshot extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { sessionId, format } = args as {
       sessionId: string;
       format?: "png" | "jpeg";

--- a/src/reflect/tool/suites/cancel-suite-execution.ts
+++ b/src/reflect/tool/suites/cancel-suite-execution.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -21,7 +19,7 @@ export class CancelSuiteExecution extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { suiteId, executionId } = args as {
       suiteId: string;
       executionId: string;

--- a/src/reflect/tool/suites/execute-suite.ts
+++ b/src/reflect/tool/suites/execute-suite.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -16,7 +14,7 @@ export class ExecuteSuite extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { suiteId } = args as { suiteId: string };
     if (!suiteId) throw new ToolError("suiteId argument is required");
 

--- a/src/reflect/tool/suites/get-suite-execution-status.ts
+++ b/src/reflect/tool/suites/get-suite-execution-status.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -21,7 +19,7 @@ export class GetSuiteExecutionStatus extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { suiteId, executionId } = args as {
       suiteId: string;
       executionId: string;

--- a/src/reflect/tool/suites/list-suite-executions.ts
+++ b/src/reflect/tool/suites/list-suite-executions.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -18,7 +16,7 @@ export class ListSuiteExecutions extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { suiteId } = args as { suiteId: string };
     if (!suiteId) throw new ToolError("suiteId argument is required");
 

--- a/src/reflect/tool/suites/list-suites.ts
+++ b/src/reflect/tool/suites/list-suites.ts
@@ -1,6 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type ZodRawShape, z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { z } from "zod";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -13,7 +12,7 @@ export class ListSuites extends Tool<ReflectClient> {
     inputSchema: z.object({}),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (_args) => {
+  handle: ToolHandler = async (_args) => {
     const response = await fetch(`https://${API_HOSTNAME}/v1/suites`, {
       method: "GET",
       headers: this.client.getHeaders(),

--- a/src/reflect/tool/tests/create-segment.ts
+++ b/src/reflect/tool/tests/create-segment.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import {
@@ -20,7 +18,7 @@ export class CreateSegment extends Tool<ReflectClient> {
     inputSchema: buildCreateDefinitionSchema({ isSegment: true }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     return createReflectDefinition(this.client, "segments", "segment", args);
   };
 }

--- a/src/reflect/tool/tests/create-test.ts
+++ b/src/reflect/tool/tests/create-test.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import {
@@ -19,7 +17,7 @@ export class CreateTest extends Tool<ReflectClient> {
     inputSchema: buildCreateDefinitionSchema({ isSegment: false }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     return createReflectDefinition(this.client, "tests", "test", args);
   };
 }

--- a/src/reflect/tool/tests/get-test-detail.ts
+++ b/src/reflect/tool/tests/get-test-detail.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -19,7 +17,7 @@ export class GetTestDetail extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testId } = args as { testId: string };
     if (!testId || !testId.trim())
       throw new ToolError("testId argument is required");

--- a/src/reflect/tool/tests/get-test-status.ts
+++ b/src/reflect/tool/tests/get-test-status.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -18,7 +16,7 @@ export class GetTestStatus extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { executionId } = args as {
       executionId: string;
     };

--- a/src/reflect/tool/tests/list-segments.ts
+++ b/src/reflect/tool/tests/list-segments.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME, WEB_APP_HOSTNAME } from "../../config/constants";
@@ -27,7 +25,7 @@ export class ListSegments extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const {
       platform,
       offset = 0,

--- a/src/reflect/tool/tests/list-tests.ts
+++ b/src/reflect/tool/tests/list-tests.ts
@@ -1,6 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type ZodRawShape, z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { z } from "zod";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -13,7 +12,7 @@ export class ListTests extends Tool<ReflectClient> {
     inputSchema: z.object({}),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (_args) => {
+  handle: ToolHandler = async (_args) => {
     const response = await fetch(`https://${API_HOSTNAME}/v1/tests`, {
       method: "GET",
       headers: this.client.getHeaders(),

--- a/src/reflect/tool/tests/run-test.ts
+++ b/src/reflect/tool/tests/run-test.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z } from "zod";
-import { Tool, ToolError } from "../../../common/tools";
+import { Tool, ToolError, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ReflectClient } from "../../client";
 import { API_HOSTNAME } from "../../config/constants";
@@ -16,7 +14,7 @@ export class RunTest extends Tool<ReflectClient> {
     }),
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testId } = args as { testId: string };
     if (!testId) throw new ToolError("testId argument is required");
 

--- a/src/zephyr/tool/environment/get-environments.ts
+++ b/src/zephyr/tool/environment/get-environments.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -73,7 +71,7 @@ export class GetEnvironments extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getEnvironmentsInput = ListEnvironmentsQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/folder/create-folder.test.ts
+++ b/src/zephyr/tool/folder/create-folder.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateFolderBody,
@@ -14,17 +10,27 @@ describe("CreateFolder", () => {
   let mockClient: any;
   let instance: CreateFolder;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/folder/create-folder.ts
+++ b/src/zephyr/tool/folder/create-folder.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -55,7 +53,7 @@ export class CreateFolder extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateFolderBody.parse(args);
     const response = await this.client.getApiClient().post(`/folders`, body);
     return {

--- a/src/zephyr/tool/issue-link/get-test-cases.ts
+++ b/src/zephyr/tool/issue-link/get-test-cases.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -29,7 +27,7 @@ export class GetTestCases extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestCasesPathParam.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/issue-link/get-test-cycles.ts
+++ b/src/zephyr/tool/issue-link/get-test-cycles.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -30,7 +28,7 @@ export class GetTestCycles extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestCyclesPathParam.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/issue-link/get-test-executions.ts
+++ b/src/zephyr/tool/issue-link/get-test-executions.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -30,7 +28,7 @@ export class GetTestExecutions extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestExecutionsParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/priority/get-priorities.ts
+++ b/src/zephyr/tool/priority/get-priorities.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -38,7 +36,7 @@ export class GetPriorities extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getPrioritiesInput = ListPrioritiesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/project/get-project.ts
+++ b/src/zephyr/tool/project/get-project.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetProject extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { projectIdOrKey } = GetProjectParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/project/get-projects.ts
+++ b/src/zephyr/tool/project/get-projects.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -45,7 +43,7 @@ export class GetProjects extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListProjectsQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/status/get-statuses.ts
+++ b/src/zephyr/tool/status/get-statuses.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -48,7 +46,7 @@ export class GetStatuses extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getStatusesInput = ListStatusesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-case/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseIssueLink201Response as createTestCaseIssueLinkResponse } from "../../common/rest-api-schemas";
 import { CreateTestCaseIssueLink } from "./create-issue-link";
@@ -11,17 +7,27 @@ describe("CreateTestCaseIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestCaseIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-issue-link.ts
+++ b/src/zephyr/tool/test-case/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestCaseIssueLink extends Tool<ZephyrClient> {
       "Create a new link between an issue in Jira and a Test Case in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCaseIssueLinkParams.and(
-      CreateTestCaseIssueLinkBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseIssueLinkParams.extend(
+      CreateTestCaseIssueLinkBody.partial().shape,
     ),
     outputSchema: createTestCaseIssueLinkResponse,
     examples: [
@@ -33,7 +33,7 @@ export class CreateTestCaseIssueLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseIssueLinkParams.and(
       CreateTestCaseIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-test-case.test.ts
+++ b/src/zephyr/tool/test-case/create-test-case.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestCaseBody,
@@ -13,17 +9,27 @@ import { CreateTestCase } from "./create-test-case";
 describe("CreateTestCase", () => {
   let mockClient: any;
   let instance: CreateTestCase;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-case.ts
+++ b/src/zephyr/tool/test-case/create-test-case.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -70,7 +68,7 @@ export class CreateTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestCaseBody.parse(args);
     const response = await this.client.getApiClient().post(`/testcases/`, body);
     return {

--- a/src/zephyr/tool/test-case/create-test-script.test.ts
+++ b/src/zephyr/tool/test-case/create-test-script.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseTestScript201Response as createTestCaseScriptResponse } from "../../common/rest-api-schemas";
 import { CreateTestScript } from "./create-test-script";
@@ -11,17 +7,27 @@ describe("CreateTestScript", () => {
   let mockClient: any;
   let instance: CreateTestScript;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-script.ts
+++ b/src/zephyr/tool/test-case/create-test-script.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -17,8 +15,10 @@ export class CreateTestScript extends Tool<ZephyrClient> {
       "Create a new Test Script of the types Plain Text or BDD in a Zephyr Test Case.",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCaseTestScriptParams.and(
-      CreateTestCaseTestScriptBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseTestScriptParams.extend(
+      CreateTestCaseTestScriptBody.partial().shape,
     ),
     outputSchema: createTestCaseScriptResponse,
     examples: [
@@ -58,7 +58,7 @@ export class CreateTestScript extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseTestScriptParams.and(
       CreateTestCaseTestScriptBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-test-steps.test.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseTestSteps201Response as createTestCaseTestStepsResponse } from "../../common/rest-api-schemas";
 import { CreateTestSteps } from "./create-test-steps";
@@ -11,17 +7,27 @@ describe("CreateTestSteps", () => {
   let mockClient: any;
   let instance: CreateTestSteps;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-steps.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -17,7 +15,11 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
     readOnly: false,
     destructive: true,
     idempotent: false,
-    inputSchema: CreateTestCaseTestStepsParams.and(CreateTestCaseTestStepsBody),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseTestStepsParams.extend(
+      CreateTestCaseTestStepsBody.shape,
+    ),
     outputSchema: createTestCaseTestStepsResponse,
     examples: [
       {
@@ -90,7 +92,7 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseTestStepsParams.and(
       CreateTestCaseTestStepsBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-web-link.test.ts
+++ b/src/zephyr/tool/test-case/create-web-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseWebLink201Response as CreateTestCaseWebLinkResponse } from "../../common/rest-api-schemas";
 import { CreateTestCaseWebLink } from "./create-web-link";
@@ -11,17 +7,27 @@ describe("CreateTestCaseWebLink", () => {
   let mockClient: any;
   let instance: CreateTestCaseWebLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-web-link.ts
+++ b/src/zephyr/tool/test-case/create-web-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -42,7 +40,7 @@ export class CreateTestCaseWebLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const fullInputSchema = CreateTestCaseWebLinkBody.extend({
       testCaseKey: CreateTestCaseWebLinkParams.shape.testCaseKey,
     });

--- a/src/zephyr/tool/test-case/get-links.test.ts
+++ b/src/zephyr/tool/test-case/get-links.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GetTestCaseLinksParams,
@@ -14,17 +10,27 @@ describe("GetTestCaseLinks", () => {
   let mockClient: any;
   let instance: GetTestCaseLinks;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 
@@ -216,14 +222,14 @@ describe("GetTestCaseLinks", () => {
       "/testcases/SA-T10/links",
     );
     expect(result.structuredContent).toBe(responseMock);
-    expect(result.structuredContent?.webLinks).toHaveLength(3);
-    expect((result.structuredContent?.webLinks as any)[0].url).toBe(
+    expect((result.structuredContent as any)?.webLinks).toHaveLength(3);
+    expect((result.structuredContent as any)?.webLinks[0].url).toBe(
       "not-a-valid-url",
     );
-    expect((result.structuredContent?.webLinks as any)[1].url).toBe(
+    expect((result.structuredContent as any)?.webLinks[1].url).toBe(
       "//incomplete",
     );
-    expect((result.structuredContent?.webLinks as any)[2].url).toBe(
+    expect((result.structuredContent as any)?.webLinks[2].url).toBe(
       "http://example.com/path with spaces",
     );
   });

--- a/src/zephyr/tool/test-case/get-links.ts
+++ b/src/zephyr/tool/test-case/get-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -31,7 +29,7 @@ export class GetTestCaseLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-case.ts
+++ b/src/zephyr/tool/test-case/get-test-case.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-cases.ts
+++ b/src/zephyr/tool/test-case/get-test-cases.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -62,7 +60,7 @@ export class GetTestCases extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestCasesCursorPaginatedQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-script.test.ts
+++ b/src/zephyr/tool/test-case/get-test-script.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GetTestCaseTestScript200Response as GetTestScriptResponse } from "../../common/rest-api-schemas";
 import { GetTestScript } from "./get-test-script";
@@ -11,17 +7,27 @@ describe("GetTestScript", () => {
   let mockClient: any;
   let instance: GetTestScript;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/get-test-script.ts
+++ b/src/zephyr/tool/test-case/get-test-script.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -48,7 +46,7 @@ export class GetTestScript extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseTestScriptParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-steps.ts
+++ b/src/zephyr/tool/test-case/get-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class GetTestCaseSteps extends Tool<ZephyrClient> {
     summary: "Get details of test case steps in Zephyr",
     readOnly: true,
     idempotent: true,
-    inputSchema: GetTestCaseTestStepsParams.and(
-      GetTestCaseTestStepsQueryParams.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: GetTestCaseTestStepsParams.extend(
+      GetTestCaseTestStepsQueryParams.partial().shape,
     ),
     outputSchema: getTestCaseStepsResponse,
     examples: [
@@ -53,7 +53,7 @@ export class GetTestCaseSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = GetTestCaseTestStepsParams.and(
       GetTestCaseTestStepsQueryParams,
     ).parse(args);

--- a/src/zephyr/tool/test-case/update-test-case.test.ts
+++ b/src/zephyr/tool/test-case/update-test-case.test.ts
@@ -1,25 +1,31 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestCase } from "./update-test-case";
 
 describe("UpdateTestCase", () => {
   let mockClient: any;
   let instance: UpdateTestCase;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/update-test-case.ts
+++ b/src/zephyr/tool/test-case/update-test-case.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z as zod } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -42,7 +40,9 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
       'Update an existing Test Case in Zephyr. This operation fetches the current test case and merges your updates with it to prevent accidental property deletion. Properties which are not included in the tool call will be left unchanged. To remove a property, set it to null explicitly. For fields that accept multiple values, such as `labels`, if the field is provided, it will override the previous values. For example, if `labels` is provided with the values `["label1", "label2"]`, the Test Case will now only have those two labels, and any previous labels will be removed. If you want to add a label, you would need to specify in the prompt the intention to add a label.',
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestCaseParams.extend(UpdateTestCaseBodyToolInput.shape),
     examples: [
       {
         description:
@@ -114,7 +114,7 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput).parse(
       args,
     );

--- a/src/zephyr/tool/test-cycle/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-cycle/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCycleIssueLink } from "./create-issue-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestCycleIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestCycleIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-issue-link.ts
+++ b/src/zephyr/tool/test-cycle/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestCycleIssueLink extends Tool<ZephyrClient> {
       "Create a new link between an issue in Jira and a Test Cycle in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCycleIssueLinkParams.and(
-      CreateTestCycleIssueLinkBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCycleIssueLinkParams.extend(
+      CreateTestCycleIssueLinkBody.shape,
     ),
     examples: [
       {
@@ -42,7 +42,7 @@ export class CreateTestCycleIssueLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCycleIssueLinkParams.and(
       CreateTestCycleIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-cycle/create-test-cycle.test.ts
+++ b/src/zephyr/tool/test-cycle/create-test-cycle.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestCycleBody,
@@ -13,17 +9,27 @@ import { CreateTestCycle } from "./create-test-cycle";
 describe("CreateTestCyCle", () => {
   let mockClient: any;
   let instance: CreateTestCycle;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/create-test-cycle.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -72,7 +70,7 @@ export class CreateTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestCycleBody.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/create-web-link.test.ts
+++ b/src/zephyr/tool/test-cycle/create-web-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCycleWebLink } from "./create-web-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestCycleWebLink", () => {
   let mockClient: any;
   let instance: CreateTestCycleWebLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-web-link.ts
+++ b/src/zephyr/tool/test-cycle/create-web-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -14,8 +12,10 @@ export class CreateTestCycleWebLink extends Tool<ZephyrClient> {
     summary: "Create a new Web Link for a Test Cycle in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCycleWebLinkParams.and(
-      CreateTestCycleWebLinkBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCycleWebLinkParams.extend(
+      CreateTestCycleWebLinkBody.partial().shape,
     ),
     examples: [
       {
@@ -50,7 +50,7 @@ export class CreateTestCycleWebLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCycleWebLinkParams.and(
       CreateTestCycleWebLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-cycle/get-links.test.ts
+++ b/src/zephyr/tool/test-cycle/get-links.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GetTestCycleLinksParams,
@@ -14,17 +10,27 @@ describe("GetTestCycleLinks", () => {
   let mockClient: any;
   let instance: GetTestCycleLinks;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/get-links.ts
+++ b/src/zephyr/tool/test-cycle/get-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -38,7 +36,7 @@ export class GetTestCycleLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCycleIdOrKey } = GetTestCycleLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/get-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/get-test-cycle.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCycleIdOrKey } = GetTestCycleParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/get-test-cycles.ts
+++ b/src/zephyr/tool/test-cycle/get-test-cycles.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -70,7 +68,7 @@ export class GetTestCycles extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestCyclesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestCycle } from "./update-test-cycle";
 
@@ -10,17 +6,27 @@ describe("UpdateTestCycle", () => {
   let mockClient: any;
   let instance: UpdateTestCycle;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/update-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z as zod } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -43,7 +41,11 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
       "Update an existing Test Cycle in Zephyr. This operation fetches the current test cycle and merges your updates with it to prevent accidental property deletion. To remove a property, set it to null explicitly. The plannedStartDate and plannedEndDate fields cannot be cleared",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCycleParams.and(UpdateTestCycleBodyToolInput),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestCycleParams.extend(
+      UpdateTestCycleBodyToolInput.shape,
+    ),
     examples: [
       {
         description:
@@ -116,7 +118,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = UpdateTestCycleParams.and(
       UpdateTestCycleBodyToolInput,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-execution/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestExecutionIssueLink } from "./create-issue-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestExecutionIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestExecutionIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/create-issue-link.ts
+++ b/src/zephyr/tool/test-execution/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestExecutionIssueLink extends Tool<ZephyrClient> {
       "Create a new link between a Jira issue and a Test Execution in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestExecutionIssueLinkParams.and(
-      CreateTestExecutionIssueLinkBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestExecutionIssueLinkParams.extend(
+      CreateTestExecutionIssueLinkBody.shape,
     ),
     examples: [
       {
@@ -43,7 +43,7 @@ export class CreateTestExecutionIssueLink extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestExecutionIssueLinkParams.and(
       CreateTestExecutionIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/create-test-execution.test.ts
+++ b/src/zephyr/tool/test-execution/create-test-execution.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestExecutionBody,
@@ -14,17 +10,27 @@ describe("CreateTestExecution", () => {
   let mockClient: any;
   let instance: CreateTestExecution;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/create-test-execution.ts
+++ b/src/zephyr/tool/test-execution/create-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -68,7 +66,7 @@ export class CreateTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestExecutionBody.parse(args);
 
     const response = await this.client

--- a/src/zephyr/tool/test-execution/get-test-execution-links.ts
+++ b/src/zephyr/tool/test-execution/get-test-execution-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestExecutionLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testExecutionIdOrKey } = ListTestExecutionLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-execution.ts
+++ b/src/zephyr/tool/test-execution/get-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testExecutionIdOrKey } = GetTestExecutionParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-executions.ts
+++ b/src/zephyr/tool/test-execution/get-test-executions.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -41,7 +39,7 @@ export class GetTestExecutions extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestExecutionsNextgenQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-steps.ts
+++ b/src/zephyr/tool/test-execution/get-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class GetTestExecutionSteps extends Tool<ZephyrClient> {
     summary: "Get details of test execution steps in Zephyr",
     readOnly: true,
     idempotent: true,
-    inputSchema: GetTestExecutionTestStepsParams.and(
-      GetTestExecutionTestStepsQueryParams.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: GetTestExecutionTestStepsParams.extend(
+      GetTestExecutionTestStepsQueryParams.partial().shape,
     ),
     outputSchema: getTestExecutionStepsResponse,
     examples: [
@@ -75,7 +75,7 @@ export class GetTestExecutionSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = GetTestExecutionTestStepsParams.and(
       GetTestExecutionTestStepsQueryParams,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/update-test-execution.test.ts
+++ b/src/zephyr/tool/test-execution/update-test-execution.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestExecution } from "./update-test-execution";
 
@@ -10,17 +6,27 @@ describe("UpdateTestExecution", () => {
   let mockClient: any;
   let instance: UpdateTestExecution;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: () => {
-      throw new Error("Not implemented");
-    },
-    sendRequest: () => {
-      throw new Error("Not implemented");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Not implemented");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Not implemented");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Not implemented");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/update-test-execution.ts
+++ b/src/zephyr/tool/test-execution/update-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class UpdateTestExecution extends Tool<ZephyrClient> {
       "Update an existing Test Execution in Zephyr. This operation only updates specified fields in the payload and ignores `null` or `undefined` values.",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestExecutionParams.and(
-      UpdateTestExecutionBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestExecutionParams.extend(
+      UpdateTestExecutionBody.partial().shape,
     ),
     examples: [
       {
@@ -75,7 +75,7 @@ export class UpdateTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const fullInputSchema = UpdateTestExecutionParams.and(
       UpdateTestExecutionBody.partial(),
     );

--- a/src/zephyr/tool/test-execution/update-test-steps.test.ts
+++ b/src/zephyr/tool/test-execution/update-test-steps.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestExecutionSteps } from "./update-test-steps";
 
@@ -10,17 +6,27 @@ describe("UpdateTestExecutionSteps", () => {
   let mockClient: any;
   let instance: UpdateTestExecutionSteps;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: () => {
-      throw new Error("Not implemented");
-    },
-    sendRequest: () => {
-      throw new Error("Not implemented");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Not implemented");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Not implemented");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Not implemented");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/update-test-steps.ts
+++ b/src/zephyr/tool/test-execution/update-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class UpdateTestExecutionSteps extends Tool<ZephyrClient> {
       "Update test steps for a given Test Execution in Zephyr. This operation updates the provided steps with their execution status and actual results. Only the fields included in the request will be modified.",
     readOnly: false,
     idempotent: true,
-    inputSchema: PutTestExecutionTestStepsParams.and(
-      PutTestExecutionTestStepsBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: PutTestExecutionTestStepsParams.extend(
+      PutTestExecutionTestStepsBody.shape,
     ),
     examples: [
       {
@@ -75,7 +75,7 @@ export class UpdateTestExecutionSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = PutTestExecutionTestStepsParams.and(
       PutTestExecutionTestStepsBody.required(),
     ).parse(args);

--- a/src/zephyr/tool/test-plan/get-test-plans.ts
+++ b/src/zephyr/tool/test-plan/get-test-plans.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -62,7 +60,7 @@ export class GetTestPlans extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestPlansCursorPaginatedQueryParams.parse(args);
     const response = await this.client
       .getApiClient()


### PR DESCRIPTION
Migrating to sdkv2 modelcontext protocol.

Goal
Migrate the MCP server from the old SDK (@modelcontextprotocol/sdk, v1) to the new v2 beta SDK, since v1 is being deprecated.

Design
The codemod did the bulk of the mechanical rewrite but left ~85 files broken (wrong handler types) and a handful of spots it flagged for manual review (context object shape changed in v2). Fixed those directly and kept scope tight — deferred the bigger transport rewrite (createMcpHandler) to a separate task.

Changeset
Swapped SDK dependency to the v2 packages.
Fixed handler/prompt types across all tool and prompt files.
Updated common/server.ts to match v2's schema and context handling.
Fixed the couple of spots needing manual context-object renames (extra → ctx).
Updated tests to match.
Rebased onto latest main, resolving conflicts with unrelated changes that landed there in the meantime.
