### PR TITLE
fix(functional-testing): update Create Suite tool to match latest API contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [Swagger] Added `create_suite` Functional Testing tool that creates a new test Suite from one or more ordered blocks of tests, with optional parallel execution, retry attempts, and tunnel agent override.
+
 ### Fixed
 
 - [Swagger] Fixed Swagger Functional Testing Integration documentation to include all available tools and their descriptions, as well as adjusts wrong tool sections.

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -40,7 +40,12 @@ All tools listed below are only available through the Local MCP Server. They are
 
 #### `create_suite`
 
-- Purpose: Creates a new test Suite in your Swagger Functional Testing workspace. Use this tool when you need to group existing tests into a Suite for collective execution. Requires a `name` and `runApiTests`, one or more ordered blocks of tests to run — each block requires a non-empty array of `testIds` (from `list_tests`) and may set `parallel` (run the block's tests in parallel instead of sequentially, default `false`), `maxRetryAttempts` (0-3, retry a block's failed tests before they count as failed, default no retry), and a `title` (must be unique across the Suite's blocks). Blocks always run one after another. Optionally accepts `agentName` to save a tunnel agent override for future runs of the Suite.
+- Purpose: Creates a new test Suite in your Swagger Functional Testing workspace by grouping existing tests into ordered blocks for collective execution. Requires a `name` and one or more `runApiTests` blocks, each with a non-empty `testIds` array (from `list_tests`). Blocks always run one after another; within a block, tests run sequentially by default. Each block may optionally set:
+  - `parallel` — run the block's tests in parallel instead of sequentially (default `false`)
+  - `maxRetryAttempts` — retry a block's failed tests before they count as failed, 0-3 (default no retry)
+  - `title` — a label that must be unique across the Suite's blocks
+
+  Optionally accepts `agentName` to save a tunnel agent override for future runs of the Suite.
 - Returns: The created Suite's `id`, `slug`, and `url`.
 - Use case: Group existing tests into a Suite, optionally with parallel/sequential blocks and retry behavior, for collective execution.
 

--- a/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md
@@ -36,6 +36,16 @@ All tools listed below are only available through the Local MCP Server. They are
 
 ---
 
+### Suite Creation
+
+#### `create_suite`
+
+- Purpose: Creates a new test Suite in your Swagger Functional Testing workspace. Use this tool when you need to group existing tests into a Suite for collective execution. Requires a `name` and `runApiTests`, one or more ordered blocks of tests to run — each block requires a non-empty array of `testIds` (from `list_tests`) and may set `parallel` (run the block's tests in parallel instead of sequentially, default `false`), `maxRetryAttempts` (0-3, retry a block's failed tests before they count as failed, default no retry), and a `title` (must be unique across the Suite's blocks). Blocks always run one after another. Optionally accepts `agentName` to save a tunnel agent override for future runs of the Suite.
+- Returns: The created Suite's `id`, `slug`, and `url`.
+- Use case: Group existing tests into a Suite, optionally with parallel/sequential blocks and retry behavior, for collective execution.
+
+---
+
 ### Test Execution
 
 #### `run_test`

--- a/src/swagger/client.ts
+++ b/src/swagger/client.ts
@@ -16,6 +16,8 @@ import {
 } from "./client/functional-testing-api";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  CreateFunctionalTestingSuiteParams,
+  CreateFunctionalTestingSuiteResponse,
   CreateFunctionalTestingTestParams,
   CreateFunctionalTestingTestResponse,
   GetFunctionalTestHistoryParams,
@@ -430,6 +432,12 @@ export class SwaggerClient implements Client {
 
   async listFunctionalTestingSuites(): Promise<unknown> {
     return this.withFunctionalTesting((ftApi) => ftApi.listSuites());
+  }
+
+  async createFunctionalTestingSuite(
+    args: CreateFunctionalTestingSuiteParams,
+  ): Promise<CreateFunctionalTestingSuiteResponse> {
+    return this.withFunctionalTesting((ftApi) => ftApi.createSuite(args));
   }
 
   async getFunctionalTestingTestHistory(

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -2,6 +2,8 @@ import { appendClientIdentity } from "../../common/info";
 import { ToolError } from "../../common/tools";
 import type {
   CancelFunctionalTestingSuiteExecutionParams,
+  CreateFunctionalTestingSuiteParams,
+  CreateFunctionalTestingSuiteResponse,
   CreateFunctionalTestingTestParams,
   CreateFunctionalTestingTestResponse,
   GetFunctionalTestHistoryParams,
@@ -205,6 +207,26 @@ export class FunctionalTestingAPI {
         ),
       },
     };
+  }
+
+  async createSuite(
+    args: CreateFunctionalTestingSuiteParams,
+  ): Promise<CreateFunctionalTestingSuiteResponse> {
+    const response = await this.ftFetch(
+      `suites`,
+      {
+        method: "POST",
+        headers: this.getFtHeaders(),
+        body: JSON.stringify({
+          name: args.name,
+          agentName: args.agentName,
+          runApiTestsBlocks: args.runApiTestsBlocks,
+        }),
+      },
+      errorMessageFor("create Functional Testing suite"),
+    );
+
+    return response.json();
   }
 
   async listSuites(): Promise<ListSuitesResponse> {

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -220,7 +220,7 @@ export class FunctionalTestingAPI {
         body: JSON.stringify({
           name: args.name,
           agentName: args.agentName,
-          runApiTestsBlocks: args.runApiTestsBlocks,
+          runApiTests: args.runApiTests,
         }),
       },
       errorMessageFor("create Functional Testing suite"),

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -32,7 +32,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "This tool only creates API tests (not browser or native-mobile tests). " +
       "Use this when you need to programmatically create a test with a defined set of API request steps. " +
       "Each step requires a URL and may specify an HTTP method (defaults to GET), request body, headers, and redirect handling. " +
-      "Returns the ID and the URL to definition of the newly created test; the ID can be used with `swagger_run_test` to run it.",
+      "Returns the ID and the URL to definition of the newly created test; the ID can be used with `swagger_run_test` to run it, " +
+      "or grouped with other test IDs into a Suite via `swagger_create_suite`.",
     inputSchema: CreateFunctionalTestingTestParamsSchema,
     outputSchema: CreateFunctionalTestingTestResponseSchema,
     handler: "createFunctionalTestingTest",
@@ -91,13 +92,13 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     title: "Create Suite",
     toolset: "Functional Testing",
     summary:
-      "Creates a new test suite in your Swagger Functional Testing workspace with a specified name and one or more ordered blocks of tests. " +
+      "Creates a new test suite in your Swagger Functional Testing workspace with a specified name and `runApiTests`, " +
+      "one or more required ordered blocks of tests. " +
       "Use this tool when you need to group existing tests into a suite for collective execution. " +
       "Within a block, tests run sequentially by default — set `parallel: true` on a block to run its tests in parallel instead. " +
       "Blocks themselves always run one after another. " +
-      "Set `maxRetryAttempts` (1-3) on a block to automatically retry its failed tests before they count as failed. " +
-      "Optionally accepts `agentName` to save a tunnel agent override for future runs of the suite. " +
-      "Omit `runApiTestsBlocks` to create an empty suite.",
+      "Set `maxRetryAttempts` (0-3) on a block to automatically retry its failed tests before they count as failed. " +
+      "Optionally accepts `agentName` to save a tunnel agent override for future runs of the suite.",
     inputSchema: CreateFunctionalTestingSuiteParamsSchema,
     handler: "createFunctionalTestingSuite",
     idempotent: false,

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,5 +1,6 @@
 import {
   CancelFunctionalTestingSuiteExecutionSchema,
+  CreateFunctionalTestingSuiteParamsSchema,
   CreateFunctionalTestingTestParamsSchema,
   CreateFunctionalTestingTestResponseSchema,
   GetFunctionalTestHistoryParamsSchema,
@@ -85,6 +86,22 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     handler: "cancelFunctionalTestingSuiteExecution",
     readOnly: false,
     idempotent: false,
+  },
+  {
+    title: "Create Suite",
+    toolset: "Functional Testing",
+    summary:
+      "Creates a new test suite in your Swagger Functional Testing workspace with a specified name and one or more ordered blocks of tests. " +
+      "Use this tool when you need to group existing tests into a suite for collective execution. " +
+      "Within a block, tests run sequentially by default — set `parallel: true` on a block to run its tests in parallel instead. " +
+      "Blocks themselves always run one after another. " +
+      "Set `maxRetryAttempts` (1-3) on a block to automatically retry its failed tests before they count as failed. " +
+      "Optionally accepts `agentName` to save a tunnel agent override for future runs of the suite. " +
+      "Omit `runApiTestsBlocks` to create an empty suite.",
+    inputSchema: CreateFunctionalTestingSuiteParamsSchema,
+    handler: "createFunctionalTestingSuite",
+    idempotent: false,
+    readOnly: false,
   },
   {
     title: "List Suites",

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -1,6 +1,7 @@
 import {
   CancelFunctionalTestingSuiteExecutionSchema,
   CreateFunctionalTestingSuiteParamsSchema,
+  CreateFunctionalTestingSuiteResponseSchema,
   CreateFunctionalTestingTestParamsSchema,
   CreateFunctionalTestingTestResponseSchema,
   GetFunctionalTestHistoryParamsSchema,
@@ -100,6 +101,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Set `maxRetryAttempts` (0-3) on a block to automatically retry its failed tests before they count as failed. " +
       "Optionally accepts `agentName` to save a tunnel agent override for future runs of the suite.",
     inputSchema: CreateFunctionalTestingSuiteParamsSchema,
+    outputSchema: CreateFunctionalTestingSuiteResponseSchema,
     handler: "createFunctionalTestingSuite",
     idempotent: false,
     readOnly: false,

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -69,36 +69,60 @@ export const RunApiTestsBlockSchema = z.object({
     ),
 });
 
-export const CreateFunctionalTestingSuiteParamsSchema = z.object({
-  name: z.string().describe("Name for the new suite").trim().min(1),
-  agentName: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe(
-      "Tunnel agent name to save as this suite's tunnel override for future runs.",
-    ),
-  runApiTests: z
-    .array(RunApiTestsBlockSchema)
-    .min(1)
-    .describe(
-      'Required — ordered groups ("blocks") of tests to run one after another. ' +
-        "Must include at least one entry; suites cannot be created without a workflow. " +
-        "Within a block, tests run sequentially unless `parallel` is set. " +
-        "Block `title`s must be unique within the suite.",
-    ),
-});
+export const CreateFunctionalTestingSuiteParamsSchema = z
+  .object({
+    name: z.string().describe("Name for the new suite").trim().min(1),
+    agentName: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "Tunnel agent name to save as this suite's tunnel override for future runs.",
+      ),
+    runApiTests: z
+      .array(RunApiTestsBlockSchema)
+      .min(1)
+      .describe(
+        'Required — ordered groups ("blocks") of tests to run one after another. ' +
+          "Must include at least one entry; suites cannot be created without a workflow. " +
+          "Within a block, tests run sequentially unless `parallel` is set. " +
+          "Block `title`s must be unique within the suite.",
+      ),
+  })
+  .superRefine((data, ctx) => {
+    const seen = new Set<string>();
+    data.runApiTests.forEach((block, index) => {
+      if (!block.title) return;
+      if (seen.has(block.title)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Duplicate block title "${block.title}". Block titles must be unique within the suite.`,
+          path: ["runApiTests", index, "title"],
+        });
+      }
+      seen.add(block.title);
+    });
+  });
 
 export type CreateFunctionalTestingSuiteParams = z.infer<
   typeof CreateFunctionalTestingSuiteParamsSchema
 >;
 
-export interface CreateFunctionalTestingSuiteResponse {
-  id: number;
-  slug: string;
-  url?: string;
-}
+export const CreateFunctionalTestingSuiteResponseSchema = z.object({
+  id: z.number().describe("ID of the newly created suite"),
+  slug: z.string().describe("Slug of the newly created suite"),
+  url: z
+    .string()
+    .describe(
+      "Link to the created suite in Swagger Functional Testing UI",
+    )
+    .optional(),
+});
+
+export type CreateFunctionalTestingSuiteResponse = z.infer<
+  typeof CreateFunctionalTestingSuiteResponseSchema
+>;
 
 export const RunFunctionalTestingSuiteParamsSchema = z.object({
   suiteId: z

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -52,11 +52,12 @@ export const RunApiTestsBlockSchema = z.object({
   maxRetryAttempts: z
     .number()
     .int()
-    .min(1)
+    .min(0)
     .max(3)
     .optional()
     .describe(
-      "Number of times to retry a failed test in this block before it counts as failed (1-3).",
+      "Number of times to retry a failed test in this block before it counts as failed (0-3). " +
+        "Omit or set to 0 for no retry.",
     ),
   title: z
     .string()
@@ -78,13 +79,14 @@ export const CreateFunctionalTestingSuiteParamsSchema = z.object({
     .describe(
       "Tunnel agent name to save as this suite's tunnel override for future runs.",
     ),
-  runApiTestsBlocks: z
+  runApiTests: z
     .array(RunApiTestsBlockSchema)
     .min(1)
-    .optional()
     .describe(
-      'Ordered groups ("blocks") of tests to run one after another. ' +
-        "Within a block, tests run sequentially unless `parallel` is set. Omit to create an empty suite.",
+      'Required — ordered groups ("blocks") of tests to run one after another. ' +
+        "Must include at least one entry; suites cannot be created without a workflow. " +
+        "Within a block, tests run sequentially unless `parallel` is set. " +
+        "Block `title`s must be unique within the suite.",
     ),
 });
 

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -114,8 +114,7 @@ export const CreateFunctionalTestingSuiteResponseSchema = z.object({
   slug: z.string().describe("Slug of the newly created suite"),
   url: z
     .string()
-    .describe("Link to the created suite in Swagger Functional Testing UI")
-    .optional(),
+    .describe("Link to the created suite in Swagger Functional Testing UI"),
 });
 
 export type CreateFunctionalTestingSuiteResponse = z.infer<

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -114,9 +114,7 @@ export const CreateFunctionalTestingSuiteResponseSchema = z.object({
   slug: z.string().describe("Slug of the newly created suite"),
   url: z
     .string()
-    .describe(
-      "Link to the created suite in Swagger Functional Testing UI",
-    )
+    .describe("Link to the created suite in Swagger Functional Testing UI")
     .optional(),
 });
 

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -37,6 +37,67 @@ export const CancelFunctionalTestingSuiteExecutionSchema = z.object({
     .min(1),
 });
 
+export const RunApiTestsBlockSchema = z.object({
+  testIds: z
+    .array(z.number())
+    .min(1)
+    .describe("IDs of existing tests to include in this block."),
+  parallel: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to run this block's tests in parallel instead of sequentially. " +
+        "Defaults to false (sequential). When true, tests run at the account's maximum parallelism.",
+    ),
+  maxRetryAttempts: z
+    .number()
+    .int()
+    .min(1)
+    .max(3)
+    .optional()
+    .describe(
+      "Number of times to retry a failed test in this block before it counts as failed (1-3).",
+    ),
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Label for this block, shown in the suite workflow. Must be unique among the suite's blocks.",
+    ),
+});
+
+export const CreateFunctionalTestingSuiteParamsSchema = z.object({
+  name: z.string().describe("Name for the new suite").trim().min(1),
+  agentName: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Tunnel agent name to save as this suite's tunnel override for future runs.",
+    ),
+  runApiTestsBlocks: z
+    .array(RunApiTestsBlockSchema)
+    .min(1)
+    .optional()
+    .describe(
+      'Ordered groups ("blocks") of tests to run one after another. ' +
+        "Within a block, tests run sequentially unless `parallel` is set. Omit to create an empty suite.",
+    ),
+});
+
+export type CreateFunctionalTestingSuiteParams = z.infer<
+  typeof CreateFunctionalTestingSuiteParamsSchema
+>;
+
+export interface CreateFunctionalTestingSuiteResponse {
+  id: number;
+  slug: string;
+  url?: string;
+}
+
 export const RunFunctionalTestingSuiteParamsSchema = z.object({
   suiteId: z
     .string()

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -558,6 +558,114 @@ describe("FunctionalTestingAPI", () => {
     });
   });
 
+  describe("createSuite", () => {
+    const createSuiteResponseMock = {
+      id: 4821,
+      slug: "nightly-api-regression",
+      url: "https://app.reflect.run/suites/nightly-api-regression?accountId=1",
+    };
+
+    it("should POST to the correct endpoint with X-API-KEY header", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      await api.createSuite({
+        name: "Nightly API Regression",
+        runApiTestsBlocks: [{ testIds: [101, 102] }],
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
+          body: JSON.stringify({
+            name: "Nightly API Regression",
+            runApiTestsBlocks: [{ testIds: [101, 102] }],
+          }),
+        }),
+      );
+    });
+
+    it("should forward agentName and per-block parallel/maxRetryAttempts/title", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      await api.createSuite({
+        name: "Nightly API Regression",
+        agentName: "my-tunnel-agent",
+        runApiTestsBlocks: [
+          {
+            testIds: [101, 102],
+            parallel: true,
+            maxRetryAttempts: 2,
+            title: "Smoke",
+          },
+          { testIds: [201] },
+        ],
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body).toEqual({
+        name: "Nightly API Regression",
+        agentName: "my-tunnel-agent",
+        runApiTestsBlocks: [
+          {
+            testIds: [101, 102],
+            parallel: true,
+            maxRetryAttempts: 2,
+            title: "Smoke",
+          },
+          { testIds: [201] },
+        ],
+      });
+    });
+
+    it("should create an empty suite when runApiTestsBlocks is omitted", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      await api.createSuite({ name: "Empty Suite" });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body).toEqual({ name: "Empty Suite" });
+    });
+
+    it("should return the created suite", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      const result = await api.createSuite({
+        name: "Nightly API Regression",
+        runApiTestsBlocks: [{ testIds: [101, 102] }],
+      });
+
+      expect(result).toEqual(createSuiteResponseMock);
+    });
+
+    it("should throw ToolError with the server message on HTTP error", async () => {
+      fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
+
+      await expect(
+        api.createSuite({ name: "Nightly API Regression" }),
+      ).rejects.toThrow("Failed to create Functional Testing suite");
+    });
+
+    it("should map network errors to an unreachable message", async () => {
+      fetchMock.mockRejectOnce(new Error("Network error"));
+
+      await expect(
+        api.createSuite({ name: "Nightly API Regression" }),
+      ).rejects.toThrow(UNREACHABLE_MESSAGE);
+    });
+
+    it("should throw an authentication error on 401", async () => {
+      fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
+
+      await expect(
+        api.createSuite({ name: "Nightly API Regression" }),
+      ).rejects.toThrow(AUTH_FAILED_MESSAGE);
+    });
+  });
+
   describe("listSuites", () => {
     it("should call the correct endpoint with X-API-KEY header", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(suitesResponseMock));

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -570,7 +570,7 @@ describe("FunctionalTestingAPI", () => {
 
       await api.createSuite({
         name: "Nightly API Regression",
-        runApiTestsBlocks: [{ testIds: [101, 102] }],
+        runApiTests: [{ testIds: [101, 102] }],
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
@@ -580,7 +580,7 @@ describe("FunctionalTestingAPI", () => {
           headers: expect.objectContaining({ "X-API-KEY": "test-api-key" }),
           body: JSON.stringify({
             name: "Nightly API Regression",
-            runApiTestsBlocks: [{ testIds: [101, 102] }],
+            runApiTests: [{ testIds: [101, 102] }],
           }),
         }),
       );
@@ -592,7 +592,7 @@ describe("FunctionalTestingAPI", () => {
       await api.createSuite({
         name: "Nightly API Regression",
         agentName: "my-tunnel-agent",
-        runApiTestsBlocks: [
+        runApiTests: [
           {
             testIds: [101, 102],
             parallel: true,
@@ -608,7 +608,7 @@ describe("FunctionalTestingAPI", () => {
       expect(body).toEqual({
         name: "Nightly API Regression",
         agentName: "my-tunnel-agent",
-        runApiTestsBlocks: [
+        runApiTests: [
           {
             testIds: [101, 102],
             parallel: true,
@@ -620,22 +620,12 @@ describe("FunctionalTestingAPI", () => {
       });
     });
 
-    it("should create an empty suite when runApiTestsBlocks is omitted", async () => {
-      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
-
-      await api.createSuite({ name: "Empty Suite" });
-
-      const [, init] = fetchMock.mock.calls[0];
-      const body = JSON.parse((init as RequestInit).body as string);
-      expect(body).toEqual({ name: "Empty Suite" });
-    });
-
     it("should return the created suite", async () => {
       fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
 
       const result = await api.createSuite({
         name: "Nightly API Regression",
-        runApiTestsBlocks: [{ testIds: [101, 102] }],
+        runApiTests: [{ testIds: [101, 102] }],
       });
 
       expect(result).toEqual(createSuiteResponseMock);
@@ -645,7 +635,10 @@ describe("FunctionalTestingAPI", () => {
       fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
 
       await expect(
-        api.createSuite({ name: "Nightly API Regression" }),
+        api.createSuite({
+          name: "Nightly API Regression",
+          runApiTests: [{ testIds: [1] }],
+        }),
       ).rejects.toThrow("Failed to create Functional Testing suite");
     });
 
@@ -653,7 +646,10 @@ describe("FunctionalTestingAPI", () => {
       fetchMock.mockRejectOnce(new Error("Network error"));
 
       await expect(
-        api.createSuite({ name: "Nightly API Regression" }),
+        api.createSuite({
+          name: "Nightly API Regression",
+          runApiTests: [{ testIds: [1] }],
+        }),
       ).rejects.toThrow(UNREACHABLE_MESSAGE);
     });
 
@@ -661,7 +657,10 @@ describe("FunctionalTestingAPI", () => {
       fetchMock.mockResponseOnce("Unauthorized", { status: 401 });
 
       await expect(
-        api.createSuite({ name: "Nightly API Regression" }),
+        api.createSuite({
+          name: "Nightly API Regression",
+          runApiTests: [{ testIds: [1] }],
+        }),
       ).rejects.toThrow(AUTH_FAILED_MESSAGE);
     });
   });

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -632,6 +632,26 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(createSuiteResponseMock);
     });
 
+    it("should send a minimal body for a single test in a single block with no optional fields", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      await api.createSuite({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101] }],
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body).toEqual({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101] }],
+      });
+      expect(body.agentName).toBeUndefined();
+      expect(body.runApiTests[0].parallel).toBeUndefined();
+      expect(body.runApiTests[0].maxRetryAttempts).toBeUndefined();
+      expect(body.runApiTests[0].title).toBeUndefined();
+    });
+
     it("should throw ToolError with the server message on HTTP error", async () => {
       fetchMock.mockResponseOnce("Internal Server Error", { status: 500 });
 
@@ -708,6 +728,98 @@ describe("FunctionalTestingAPI", () => {
           "title",
         ]);
       }
+    });
+
+    it("should reject a duplicate title anywhere in the suite, not just between adjacent blocks", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [
+          { testIds: [101], title: "Smoke" },
+          { testIds: [201] },
+          { testIds: [301], title: "Smoke" },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual([
+          "runApiTests",
+          2,
+          "title",
+        ]);
+      }
+    });
+
+    it("should reject an empty name", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "",
+        runApiTests: [{ testIds: [101] }],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject a missing runApiTests", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject an empty runApiTests array", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject a block with an empty testIds array", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [] }],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject maxRetryAttempts below 0", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101], maxRetryAttempts: -1 }],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject maxRetryAttempts above 3", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101], maxRetryAttempts: 4 }],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept maxRetryAttempts within the 0-3 range", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101], maxRetryAttempts: 3 }],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject an empty agentName", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        agentName: "",
+        runApiTests: [{ testIds: [101] }],
+      });
+
+      expect(result.success).toBe(false);
     });
   });
 

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 import { FunctionalTestingAPI } from "../client/functional-testing-api";
+import { CreateFunctionalTestingSuiteParamsSchema } from "../client/functional-testing-types";
 
 const fetchMock = createFetchMock(vi);
 fetchMock.enableMocks();
@@ -662,6 +663,51 @@ describe("FunctionalTestingAPI", () => {
           runApiTests: [{ testIds: [1] }],
         }),
       ).rejects.toThrow(AUTH_FAILED_MESSAGE);
+    });
+  });
+
+  describe("CreateFunctionalTestingSuiteParamsSchema", () => {
+    it("should accept blocks with distinct titles", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [
+          { testIds: [101], title: "Smoke" },
+          { testIds: [201], title: "Regression" },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept multiple blocks without a title", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [{ testIds: [101] }, { testIds: [201] }],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject duplicate block titles", () => {
+      const result = CreateFunctionalTestingSuiteParamsSchema.safeParse({
+        name: "Nightly API Regression",
+        runApiTests: [
+          { testIds: [101], title: "Smoke" },
+          { testIds: [201], title: "Smoke" },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain(
+          'Duplicate block title "Smoke"',
+        );
+        expect(result.error.issues[0].path).toEqual([
+          "runApiTests",
+          1,
+          "title",
+        ]);
+      }
     });
   });
 

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -457,7 +457,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
       const result = await requestContextStorage.run({ headers: {} }, () =>
         client.createFunctionalTestingSuite({
           name: "Nightly API Regression",
-          runApiTestsBlocks: [{ testIds: [101, 102] }],
+          runApiTests: [{ testIds: [101, 102] }],
         }),
       );
 
@@ -477,7 +477,7 @@ describe("SwaggerClient — Functional Testing integration", () => {
       await expect(
         client.createFunctionalTestingSuite({
           name: "Nightly API Regression",
-          runApiTestsBlocks: [{ testIds: [101] }],
+          runApiTests: [{ testIds: [101] }],
         }),
       ).rejects.toThrow("Functional Testing API not configured");
     });

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -440,6 +440,49 @@ describe("SwaggerClient — Functional Testing integration", () => {
     });
   });
 
+  describe("createFunctionalTestingSuite", () => {
+    it("should POST to api.reflect.run and return the created suite", async () => {
+      const createSuiteResponseMock = {
+        id: 4821,
+        slug: "nightly-api-regression",
+        url: "https://app.reflect.run/suites/nightly-api-regression?accountId=1",
+      };
+      fetchMock.mockResponseOnce(JSON.stringify(createSuiteResponseMock));
+
+      await client.configure({} as any, {
+        api_key: "swagger-key",
+        functional_testing_api_token: "ft-token",
+      });
+
+      const result = await requestContextStorage.run({ headers: {} }, () =>
+        client.createFunctionalTestingSuite({
+          name: "Nightly API Regression",
+          runApiTestsBlocks: [{ testIds: [101, 102] }],
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.reflect.run/v1/suites",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-API-KEY": "ft-token" }),
+        }),
+      );
+      expect(result).toEqual(createSuiteResponseMock);
+    });
+
+    it("should throw when FT API is not configured", async () => {
+      await client.configure({} as any, { api_key: "swagger-key" });
+
+      await expect(
+        client.createFunctionalTestingSuite({
+          name: "Nightly API Regression",
+          runApiTestsBlocks: [{ testIds: [101] }],
+        }),
+      ).rejects.toThrow("Functional Testing API not configured");
+    });
+  });
+
   describe("getFunctionalTestingTestHistory", () => {
     const historyMock = {
       totalRuns: 5,

--- a/src/swagger/functional-testing/swagger-client-ft.test.ts
+++ b/src/swagger/functional-testing/swagger-client-ft.test.ts
@@ -441,6 +441,20 @@ describe("SwaggerClient — Functional Testing integration", () => {
   });
 
   describe("createFunctionalTestingSuite", () => {
+    it("should register the Create Suite tool when FT token is configured", async () => {
+      await client.configure({} as any, {
+        functional_testing_api_token: "ft-token",
+      });
+
+      const mockRegister = vi.fn();
+      await client.registerTools(mockRegister, vi.fn());
+
+      const registeredTitles = mockRegister.mock.calls.map(
+        (call) => call[0].title,
+      );
+      expect(registeredTitles).toContain("Create Suite");
+    });
+
     it("should POST to api.reflect.run and return the created suite", async () => {
       const createSuiteResponseMock = {
         id: 4821,


### PR DESCRIPTION

  ## Goal

  The Reflect API backing the Create Suite tool changed its contract: the `runApiTestsBlocks`
  field was renamed to `runApiTests`, it is now required (the API rejects a missing or empty
  list with a 400 — creating an "empty" suite with no tests is no longer supported), and
  `maxRetryAttempts` now accepts 0-3 instead of 1-3 (0/omit = no retry). The MCP tool needed
  to be updated to match, otherwise every `create_suite` call would fail against the current API.

  ## Design

  - Renamed `runApiTestsBlocks` → `runApiTests` end-to-end (zod schema, API request body, tests)
    to mirror the API's field name exactly.
  - Made `runApiTests` required with `.min(1)` in the zod schema, and updated the tool's
    `description`/`summary` text to make this obvious to the calling LLM — otherwise it could
    treat the field as optional configuration and omit it, wasting a round-trip on a 400.
  - Widened `maxRetryAttempts` from `min(1)` to `min(0)` and updated its description.
  - Considered adding a `.refine()` on the top-level schema to enforce unique block `title`s
    client-side, but reverted it: this repo's `schemaToRawShape` (`src/common/server.ts`) only
    unwraps `ZodObject`/`ZodIntersection`, not `ZodEffects` produced by `.refine()` — wrapping
    the schema would have silently dropped the *entire* input schema during tool registration.
    Left the uniqueness constraint as a documented rule instead; the server already returns a
    clear 400 for duplicate titles.
  - Added a short cross-reference from `create_test`'s description pointing to `create_suite`,
    so the LLM discovers that created tests can be grouped into a Suite.
  - Filled in a "Suite Creation" section in the SFT product doc, which was missing entirely for
    this tool, and added a CHANGELOG entry.

  ## Changeset
  
  - `src/swagger/client/functional-testing-types.ts`: renamed field, required `runApiTests`,
    `maxRetryAttempts` range 0-3.
  - `src/swagger/client/functional-testing-api.ts`: `createSuite()` sends `runApiTests`.
  - `src/swagger/client/functional-testing-tools.ts`: updated `Create Suite` summary and
    `Create Test` summary (cross-reference).
  - `docs/products/SmartBear MCP Server/swagger-functional-testing-integration.md`: added
    `create_suite` documentation section.
  - `CHANGELOG.md`: added Unreleased entry.
  - `functional-testing-api.test.ts`, `swagger-client-ft.test.ts`: updated to the renamed/required
    field; removed the now-invalid "creates an empty suite" test case.

  ## Testing
  
  - `npx tsc --noEmit` — no errors.
  - `npx vitest run src/swagger/functional-testing` — 107 tests passing.
  - `npx biome lint` / `npx biome format --write` — clean on all changed files.