### PR TITLE
QTM4J: Add API quota details to QTM4J integration documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] `resolve_organization_portal` tool: the generated subdomain now follows the Portal UI convention - slugified organization name plus a random 3-character suffix (e.g. `acmecorp-k7p`), appended even without a collision.
 - [Swagger] `create_portal` tool: the `subdomain` parameter description now recommends the same convention, while the client still picks the value.
 - [PactFlow] Added `pageNumber`/`pageSize` pagination (default page size 5) across list and Bi-Directional Contract Testing tools, with tool-layer caching for PactFlow endpoints that don't paginate natively. [#623](https://github.com/SmartBear/smartbear-mcp/pull/623)
-- [QTM4J] Added API quota information to the QTM4J integration documentation.
+- [QTM4J] Added API quota information to the QTM4J integration documentation. [#638](https://github.com/SmartBear/smartbear-mcp/pull/638)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Swagger] `resolve_organization_portal` tool: the generated subdomain now follows the Portal UI convention - slugified organization name plus a random 3-character suffix (e.g. `acmecorp-k7p`), appended even without a collision.
 - [Swagger] `create_portal` tool: the `subdomain` parameter description now recommends the same convention, while the client still picks the value.
 - [PactFlow] Added `pageNumber`/`pageSize` pagination (default page size 5) across list and Bi-Directional Contract Testing tools, with tool-layer caching for PactFlow endpoints that don't paginate natively. [#623](https://github.com/SmartBear/smartbear-mcp/pull/623)
+- [QTM4J] Added API quota information to the QTM4J integration documentation.
 
 ### Fixed
 

--- a/docs/products/SmartBear MCP Server/qtm4j-integration.md
+++ b/docs/products/SmartBear MCP Server/qtm4j-integration.md
@@ -21,6 +21,10 @@ The following environment variables configure the QTM4J integration:
 
 **Most tools require an active project context.** Call `qtm4j_set_project_context` to set the active project before performing any project-specific operation. Automation tools (`qtm4j_upload_automation_result` and `qtm4j_get_automation_history`) are the exception — they work independently without any project context.
 
+## API Quota
+
+**MCP tools use the QMetry Open API, and their usage counts toward your per-customer quota limit.** Monitor your MCP tool usage to ensure you do not exceed your allocation. Refer to [QMetry Open API Call Limit](https://support.smartbear.com/qmetry-test-management-for-jira-cloud/docs/en/user-guide/qmetry-open-api/api-call-limit-for-qtm4j-cloud.html) for more details.
+
 # Available Tools
 
 ## Project Context


### PR DESCRIPTION
## Goal

Inform customers that MCP tool usage counts toward their QMetry Open API quota, so they can plan AI assistant workflows accordingly.

---

## Changes

### Documentation

- `docs/products/SmartBear MCP Server/qtm4j-integration.md`
  - Added `## API Quota` section under Setup noting that MCP tool usage counts toward the customer's QMetry Open API quota limit, with a link to the QMetry Open API Call Limit documentation.

- `CHANGELOG.md` — added entry under `Unreleased → Changed`.

---

## Testing

- No code changes. Verify the rendered documentation displays the quota section correctly.