### PR TITLE
fix(qtm4j): honour caller-supplied folderId when creating test cases …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [QTM4J] `create_test_case` and `create_test_cycle` no longer discard the caller's `folderId`: a numeric folder ID is now sent to the API as given, so test cases and cycles can be created in a specific folder. Both tools still fall back to the `MCP Generated` folder when `folderId` is omitted, and `create_test_cycle` accepts `folderId` for the first time.
+
 ## [0.34.0] - 2026-08-06
 
 ### Changed

--- a/docs/products/SmartBear MCP Server/qtm4j-integration.md
+++ b/docs/products/SmartBear MCP Server/qtm4j-integration.md
@@ -119,7 +119,7 @@ The following environment variables configure the QTM4J integration:
   - optional estimated time in HH:MM:SS format (`estimatedTime`) — e.g., `"01:30:00"`
   - optional label names to attach (`labels`) — e.g., `["Release_1", "Sprint 1"]`
   - optional component names to attach (`components`) — e.g., `["UI", "Backend"]`
-  - optional folder ID to place the test case in (`folderId`) — defaults to the `MCP Generated` folder if not provided
+  - optional numeric folder ID to place the test case in (`folderId`) — right-click the folder in QTM4J and choose `Copy Folder Id`; defaults to the `MCP Generated` folder if not provided
 - **Returns**: The created test case key (e.g., `SCRUM-TC-146`) and ID.
 - **Use case**: Adding new test cases with metadata, associating them with labels and components, organizing them into folders.
 
@@ -258,9 +258,9 @@ The following environment variables configure the QTM4J integration:
   - optional component names to attach (`components`) — e.g., `["UI", "Cloud"]`
   - optional planned start date (`plannedStartDate`) — format: `dd/MMM/yyyy HH:mm` e.g., `"10/May/2026 00:00"`
   - optional planned end date (`plannedEndDate`) — format: `dd/MMM/yyyy HH:mm`
+  - optional numeric folder ID to place the test cycle in (`folderId`) — right-click the folder in QTM4J and choose `Copy Folder Id`; defaults to the `MCP Generated` folder if not provided
 - **Returns**: The created test cycle key (e.g., `SCRUM-TR-218`) and ID.
 - **Use case**: Creating sprint cycles, release cycles, or environment-specific cycles; organizing test cases for a planned execution window.
-- **Note**: All cycles are placed in the `MCP Generated` folder automatically.
 
 ### Update Operations
 

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -8356,7 +8356,7 @@ Expected Output: description updated only. Field IDs auto-resolved from project 
 **Parameters:**
 - summary (string) *required*: Test case summary/title
 - description (string): Test case description
-- folderId (number): Folder ID to place the test case in
+- folderId (number): Numeric ID of the folder to place the test case in — never a folder name. Get it from the user (right-click the folder in QTM4J → 'Copy Folder Id'). Defaults to the 'MCP Generated' folder when omitted.
 - priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID.
 - status (string): Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID.
 - assignee (string): Assignee account ID
@@ -8367,7 +8367,7 @@ Expected Output: description updated only. Field IDs auto-resolved from project 
 
 **Output Description:** JSON object with test case ID, key, version number, and summary. Warnings included if any fields were skipped.
 
-**Use Cases:** 1. Create a basic test case with just a summary 2. Create a test case with priority and status using names from set_project_context response 3. Create a test case with labels and components by exact name 4. Add detailed test steps with step descriptions, test data, and expected results 5. Create a test case in a specific folder using folderId 6. Set assignee and reporter using Jira account IDs 7. Create test cases for manual testing with step-by-step instructions 8. Create test cases with all metadata fields for comprehensive test management
+**Use Cases:** 1. Create a basic test case with just a summary 2. Create a test case with priority and status using names from set_project_context response 3. Create a test case with labels and components by exact name 4. Add detailed test steps with step descriptions, test data, and expected results 5. Create a test case in a specific folder using its numeric folderId 6. Set assignee and reporter using Jira account IDs 7. Create test cases for manual testing with step-by-step instructions 8. Create test cases with all metadata fields for comprehensive test management
 
 **Examples:**
 1. Create a simple test case (project must be set via set_project_context first)
@@ -8425,7 +8425,16 @@ Expected Output: Test case created with resolved priority and status IDs
 \`\`\`
 Expected Output: Test case created with resolved labels/components/priority/status and 3 steps
 
-**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. Priority and status values were returned by set_project_context. Use NLP to map user input (e.g., 'Major' → 'High', 'Critical' → 'Blocker'). 3. If priority or status name is not found, the operation proceeds without that field and a warning is returned. 4. Labels and components are resolved on demand. If a name is not found, it is skipped with a warning. 5. Steps: ALWAYS include all three fields — stepDetails, testData, and expectedResult. Generate reasonable values if not provided. 6. folderId is optional. assignee and reporter accept Jira account IDs.",
+4. Create a test case in a specific folder
+\`\`\`json
+{
+  "summary": "Login with SSO",
+  "folderId": 109987
+}
+\`\`\`
+Expected Output: Test case created inside folder 109987
+
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. Priority and status values were returned by set_project_context. Use NLP to map user input (e.g., 'Major' → 'High', 'Critical' → 'Blocker'). 3. If priority or status name is not found, the operation proceeds without that field and a warning is returned. 4. Labels and components are resolved on demand. If a name is not found, it is skipped with a warning. 5. Steps: ALWAYS include all three fields — stepDetails, testData, and expectedResult. Generate reasonable values if not provided. 6. folderId is optional and must be the numeric folder ID — never a folder name. Ask the user for the ID directly (right-click the target folder in QTM4J → 'Copy Folder Id'); never guess it. When omitted, the test case is created in the 'MCP Generated' folder. 7. assignee and reporter accept Jira account IDs.",
     "inputSchema": [
       "assignee",
       "components",
@@ -8454,13 +8463,14 @@ Expected Output: Test case created with resolved labels/components/priority/stat
       "readOnlyHint": false,
       "title": "QTM4J: Create Test Cycle",
     },
-    "description": "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Always creates in the 'MCP Generated' folder. projectId is injected automatically from the active project context.
+    "description": "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Creates it in the folder given by the numeric folderId, or in the 'MCP Generated' folder when folderId is omitted. projectId is injected automatically from the active project context.
 
 **Toolset:** Test Cycles
 
 **Parameters:**
 - summary (string) *required*: Short title of the test cycle. Must not be blank. Max 255 chars.
 - description (string): Detailed description of the test cycle. Max 65 535 characters.
+- folderId (number): Numeric ID of the folder to place the test cycle in — never a folder name. Get it from the user (right-click the folder in QTM4J → 'Copy Folder Id'). Defaults to the 'MCP Generated' folder when omitted.
 - priority (string): Priority name (e.g., 'High', 'Medium', 'Low'). Auto-resolved to ID.
 - status (string): Status name (e.g., 'To Do', 'In Progress', 'Done'). Auto-resolved to ID.
 - assignee (string): Assignee account ID
@@ -8472,7 +8482,7 @@ Expected Output: Test case created with resolved labels/components/priority/stat
 
 **Output Description:** JSON object with the new test cycle's id and key (e.g. 'TRWT-TR-218'). Warnings included if any fields were skipped.
 
-**Use Cases:** 1. Create a test cycle with summary, priority, status, labels, or components 2. Set planned start and end dates on a new test cycle
+**Use Cases:** 1. Create a test cycle with summary, priority, status, labels, or components 2. Set planned start and end dates on a new test cycle 3. Create a test cycle in a specific folder using its numeric folderId
 
 **Examples:**
 1. Create a simple test cycle (project must be set via set_project_context first)
@@ -8504,11 +8514,21 @@ Expected Output: Test cycle created with key 'SCRUM-TR-xxx'
 \`\`\`
 Expected Output: Test cycle created with resolved priority, status, labels, and components
 
-**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. If any priority, status, label, or component name cannot be resolved, the cycle is still created but a warning is returned. Suggest the closest available value from the set_project_context response and ask the user to confirm before retrying. 3. All cycles are placed in the 'MCP Generated' folder — do not pass folderId. 4. Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
+3. Create a test cycle in a specific folder
+\`\`\`json
+{
+  "summary": "Sprint 42 Smoke",
+  "folderId": 109987
+}
+\`\`\`
+Expected Output: Test cycle created inside folder 109987
+
+**Hints:** 1. PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project. 2. If any priority, status, label, or component name cannot be resolved, the cycle is still created but a warning is returned. Suggest the closest available value from the set_project_context response and ask the user to confirm before retrying. 3. folderId is optional and must be the numeric folder ID — never a folder name. Ask the user for the ID directly (right-click the target folder in QTM4J → 'Copy Folder Id'); never guess it. When omitted, the cycle is created in the 'MCP Generated' folder. 4. Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
     "inputSchema": [
       "assignee",
       "components",
       "description",
+      "folderId",
       "labels",
       "plannedEndDate",
       "plannedStartDate",

--- a/src/qtm4j/config/constants.ts
+++ b/src/qtm4j/config/constants.ts
@@ -417,7 +417,7 @@ export const TOOL_NAMES = {
   CREATE_TEST_CYCLE: {
     TITLE: "Create Test Cycle",
     SUMMARY:
-      "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Always creates in the 'MCP Generated' folder. projectId is injected automatically from the active project context.",
+      "Create a new test cycle in a QTM4J project. Supports auto-resolving human-readable names for priority and status. Creates it in the folder given by the numeric folderId, or in the 'MCP Generated' folder when folderId is omitted. projectId is injected automatically from the active project context.",
   },
 
   /** Update Test Cycle tool */

--- a/src/qtm4j/schema/test-case.schema.ts
+++ b/src/qtm4j/schema/test-case.schema.ts
@@ -35,8 +35,13 @@ export const CreateTestCaseBody = zod.object({
   description: zod.string().optional().describe("Test case description"),
   folderId: zod
     .number()
+    .int()
     .optional()
-    .describe("Folder ID to place the test case in"),
+    .describe(
+      "Numeric ID of the folder to place the test case in — never a folder name. " +
+        "Get it from the user (right-click the folder in QTM4J → 'Copy Folder Id'). " +
+        "Defaults to the 'MCP Generated' folder when omitted.",
+    ),
   priority: zod
     .string()
     .optional()

--- a/src/qtm4j/schema/test-cycle.schema.ts
+++ b/src/qtm4j/schema/test-cycle.schema.ts
@@ -6,7 +6,9 @@
 import * as zod from "zod";
 
 /**
- * projectId and folderId are injected automatically by the tool.
+ * projectId is injected automatically by the tool.
+ * folderId is a numeric folder ID and defaults to the 'MCP Generated' folder
+ * when omitted.
  * priority, status, labels, and components accept human-readable names
  * and are auto-resolved to numeric IDs before the API call.
  */
@@ -23,6 +25,15 @@ export const CreateTestCycleBody = zod.object({
     .max(65535)
     .optional()
     .describe("Detailed description of the test cycle. Max 65 535 characters."),
+  folderId: zod
+    .number()
+    .int()
+    .optional()
+    .describe(
+      "Numeric ID of the folder to place the test cycle in — never a folder name. " +
+        "Get it from the user (right-click the folder in QTM4J → 'Copy Folder Id'). " +
+        "Defaults to the 'MCP Generated' folder when omitted.",
+    ),
   priority: zod
     .string()
     .optional()

--- a/src/qtm4j/tool/test-case/create-test-case.test.ts
+++ b/src/qtm4j/tool/test-case/create-test-case.test.ts
@@ -100,6 +100,51 @@ describe("CreateTestCase", () => {
       );
     });
 
+    it("should default folderId to 'MCP Generated' when none is given", async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: "1",
+        key: "PROJ-TC-1",
+        versionNo: 1,
+        summary: "Test",
+      });
+
+      await instance.handle({ summary: "Test" });
+
+      const resolveCall = mockFieldResolver
+        .getResolver()
+        .resolve.mock.calls.find((call: any[]) => call[0] === "folderId");
+      expect(resolveCall).toBeDefined();
+      expect(resolveCall[1]).toBe("testcase_folder");
+      expect(resolveCall[2]).toMatchObject({ folderId: "MCP Generated" });
+    });
+
+    it("should pass a caller-supplied folderId straight through to the API", async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: "1",
+        key: "PROJ-TC-1",
+        versionNo: 1,
+        summary: "Test",
+      });
+
+      await instance.handle({ summary: "Test", folderId: 109987 });
+
+      const resolveCalls = mockFieldResolver
+        .getResolver()
+        .resolve.mock.calls.filter((call: any[]) => call[0] === "folderId");
+      expect(resolveCalls).toHaveLength(0);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CASE,
+        expect.objectContaining({ folderId: 109987 }),
+      );
+    });
+
+    it("should reject a non-numeric folderId", async () => {
+      await expect(
+        instance.handle({ summary: "Test", folderId: "Regression" }),
+      ).rejects.toThrow();
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
     it("should return warnings when resolve pushes them", async () => {
       const rawArgs = { summary: "Test", priority: "NonExistent" };
       mockFieldResolver.getResolver.mockReturnValue({

--- a/src/qtm4j/tool/test-case/create-test-case.ts
+++ b/src/qtm4j/tool/test-case/create-test-case.ts
@@ -13,9 +13,15 @@ import {
 const FIELD_CONFIG: Record<string, string> = {
   [InputField.PRIORITY]: ResolverKeys.CommonAttribute.PRIORITY,
   [InputField.STATUS]: ResolverKeys.CommonAttribute.TESTCASE_STATUS,
-  [InputField.FOLDER]: ResolverKeys.CommonAttribute.TESTCASE_FOLDER,
   [InputField.COMPONENTS]: ResolverKeys.SearchableField.COMPONENTS,
   [InputField.LABELS]: ResolverKeys.SearchableField.LABEL,
+};
+
+// Folder used when the caller does not pass a folderId. Resolved by name, so it
+// is only added to FIELD_CONFIG on the fallback path.
+const DEFAULT_FOLDER_NAME = "MCP Generated";
+const FOLDER_FIELD_CONFIG: Record<string, string> = {
+  [InputField.FOLDER]: ResolverKeys.CommonAttribute.TESTCASE_FOLDER,
 };
 
 /**
@@ -31,6 +37,9 @@ const FIELD_CONFIG: Record<string, string> = {
  *   - status     → EAGER
  *   - labels     → LAZY
  *   - components → LAZY
+ *
+ * folderId: a caller-supplied numeric folder ID is used as-is. When omitted, the
+ * test case falls back to the 'MCP Generated' folder.
  */
 export class CreateTestCase extends Tool<Qtm4jClient> {
   // ─── Tool Specification ────────────────────────────────────────────────────
@@ -53,7 +62,7 @@ export class CreateTestCase extends Tool<Qtm4jClient> {
       "Create a test case with priority and status using names from set_project_context response",
       "Create a test case with labels and components by exact name",
       "Add detailed test steps with step descriptions, test data, and expected results",
-      "Create a test case in a specific folder using folderId",
+      "Create a test case in a specific folder using its numeric folderId",
       "Set assignee and reporter using Jira account IDs",
       "Create test cases for manual testing with step-by-step instructions",
       "Create test cases with all metadata fields for comprehensive test management",
@@ -108,6 +117,11 @@ export class CreateTestCase extends Tool<Qtm4jClient> {
         expectedOutput:
           "Test case created with resolved labels/components/priority/status and 3 steps",
       },
+      {
+        description: "Create a test case in a specific folder",
+        parameters: { summary: "Login with SSO", folderId: 109987 },
+        expectedOutput: "Test case created inside folder 109987",
+      },
     ],
     hints: [
       "PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project.",
@@ -115,7 +129,10 @@ export class CreateTestCase extends Tool<Qtm4jClient> {
       "If priority or status name is not found, the operation proceeds without that field and a warning is returned.",
       "Labels and components are resolved on demand. If a name is not found, it is skipped with a warning.",
       "Steps: ALWAYS include all three fields — stepDetails, testData, and expectedResult. Generate reasonable values if not provided.",
-      "folderId is optional. assignee and reporter accept Jira account IDs.",
+      "folderId is optional and must be the numeric folder ID — never a folder name. Ask the user for the ID directly " +
+        "(right-click the target folder in QTM4J → 'Copy Folder Id'); never guess it. " +
+        "When omitted, the test case is created in the 'MCP Generated' folder.",
+      "assignee and reporter accept Jira account IDs.",
     ],
     outputDescription:
       "JSON object with test case ID, key, version number, and summary. Warnings included if any fields were skipped.",
@@ -126,15 +143,25 @@ export class CreateTestCase extends Tool<Qtm4jClient> {
   handle = async (rawArgs: any) => {
     const fieldResolver = this.client.getResolverRegistry();
     const context = fieldResolver.requireProjectContext();
+    const parsed = CreateTestCaseBody.parse(rawArgs) as Record<string, unknown>;
+    const usesDefaultFolder = parsed[InputField.FOLDER] === undefined;
     const body = {
-      ...(CreateTestCaseBody.parse(rawArgs) as Record<string, unknown>),
+      ...parsed,
       projectId: String(context.projectId),
-      folderId: "MCP Generated",
+      ...(usesDefaultFolder
+        ? { [InputField.FOLDER]: DEFAULT_FOLDER_NAME }
+        : {}),
     };
     const warnings: string[] = [];
 
+    // A caller-supplied folderId is already an ID — only the default folder name
+    // needs resolving.
+    const fieldConfig = usesDefaultFolder
+      ? { ...FIELD_CONFIG, ...FOLDER_FIELD_CONFIG }
+      : FIELD_CONFIG;
+
     await Promise.all(
-      Object.entries(FIELD_CONFIG).map(([inputField, resolverKey]) =>
+      Object.entries(fieldConfig).map(([inputField, resolverKey]) =>
         fieldResolver
           .getResolver(resolverKey)
           .resolve(inputField, resolverKey, body, context, warnings),

--- a/src/qtm4j/tool/test-cycle/create-test-cycle.test.ts
+++ b/src/qtm4j/tool/test-cycle/create-test-cycle.test.ts
@@ -79,7 +79,7 @@ describe("CreateTestCycle", () => {
       expect(result.content).toEqual([]);
     });
 
-    it("should always set folderId to 'MCP Generated' before resolution", async () => {
+    it("should default folderId to 'MCP Generated' when none is given", async () => {
       mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
 
       await instance.handle(MINIMAL_ARGS);
@@ -89,6 +89,28 @@ describe("CreateTestCycle", () => {
         .resolve.mock.calls.find((call: any[]) => call[0] === "folderId");
       expect(resolveCall).toBeDefined();
       expect(resolveCall[2]).toMatchObject({ folderId: "MCP Generated" });
+    });
+
+    it("should pass a caller-supplied folderId straight through to the API", async () => {
+      mockApiClient.post.mockResolvedValueOnce(MINIMAL_RESPONSE);
+
+      await instance.handle({ ...MINIMAL_ARGS, folderId: 109987 });
+
+      const resolveCalls = mockFieldResolver
+        .getResolver()
+        .resolve.mock.calls.filter((call: any[]) => call[0] === "folderId");
+      expect(resolveCalls).toHaveLength(0);
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        ENDPOINTS.CREATE_TEST_CYCLE,
+        expect.objectContaining({ folderId: 109987 }),
+      );
+    });
+
+    it("should reject a non-numeric folderId", async () => {
+      await expect(
+        instance.handle({ ...MINIMAL_ARGS, folderId: "Sprint 42" }),
+      ).rejects.toThrow();
+      expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it("should call the create endpoint with projectId from context", async () => {

--- a/src/qtm4j/tool/test-cycle/create-test-cycle.ts
+++ b/src/qtm4j/tool/test-cycle/create-test-cycle.ts
@@ -13,23 +13,30 @@ import {
 const FIELD_CONFIG: Record<string, string> = {
   [InputField.PRIORITY]: ResolverKeys.CommonAttribute.PRIORITY,
   [InputField.STATUS]: ResolverKeys.CommonAttribute.TEST_CYCLE_STATUS,
-  [InputField.FOLDER]: ResolverKeys.CommonAttribute.TEST_CYCLE_FOLDER,
   [InputField.LABELS]: ResolverKeys.SearchableField.LABEL,
   [InputField.COMPONENTS]: ResolverKeys.SearchableField.COMPONENTS,
+};
+
+// Folder used when the caller does not pass a folderId. Resolved by name, so it
+// is only added to FIELD_CONFIG on the fallback path.
+const DEFAULT_FOLDER_NAME = "MCP Generated";
+const FOLDER_FIELD_CONFIG: Record<string, string> = {
+  [InputField.FOLDER]: ResolverKeys.CommonAttribute.TEST_CYCLE_FOLDER,
 };
 
 /**
  * CreateTestCycle Tool
  *
- * Creates a new test cycle in QTM4J. All cycles are placed in the
- * 'MCP Generated' folder automatically.
+ * Creates a new test cycle in QTM4J, in the folder given by folderId or — when
+ * that is omitted — in the 'MCP Generated' folder.
  *
  * Resolved fields (driven by FIELD_CONFIG):
  *   - priority → numeric ID via CommonAttribute resolver
  *   - status → numeric ID via TEST_CYCLE_STATUS resolver
- *   - folderId → resolved to 'MCP Generated' folder ID
  *   - labels → numeric IDs via SearchableField resolver
  *   - components → numeric IDs via SearchableField resolver
+ *
+ * folderId is a numeric folder ID and is used as-is.
  *
  * Safety: if any field fails to resolve, the cycle is still created without that
  * field, and a warning is returned alongside the response.
@@ -52,6 +59,7 @@ export class CreateTestCycle extends Tool<Qtm4jClient> {
     useCases: [
       "Create a test cycle with summary, priority, status, labels, or components",
       "Set planned start and end dates on a new test cycle",
+      "Create a test cycle in a specific folder using its numeric folderId",
     ],
     examples: [
       {
@@ -77,11 +85,18 @@ export class CreateTestCycle extends Tool<Qtm4jClient> {
         expectedOutput:
           "Test cycle created with resolved priority, status, labels, and components",
       },
+      {
+        description: "Create a test cycle in a specific folder",
+        parameters: { summary: "Sprint 42 Smoke", folderId: 109987 },
+        expectedOutput: "Test cycle created inside folder 109987",
+      },
     ],
     hints: [
       "PREREQUISITE: set_project_context must be called before this tool. NEVER auto-select a project.",
       "If any priority, status, label, or component name cannot be resolved, the cycle is still created but a warning is returned. Suggest the closest available value from the set_project_context response and ask the user to confirm before retrying.",
-      "All cycles are placed in the 'MCP Generated' folder — do not pass folderId.",
+      "folderId is optional and must be the numeric folder ID — never a folder name. Ask the user for the ID directly " +
+        "(right-click the target folder in QTM4J → 'Copy Folder Id'); never guess it. " +
+        "When omitted, the cycle is created in the 'MCP Generated' folder.",
       "Date format: 'dd/MMM/yyyy HH:mm' e.g. '10/May/2026 00:00'. Month must be capitalised. plannedStartDate must be ≤ plannedEndDate.",
     ],
     outputDescription:
@@ -94,17 +109,30 @@ export class CreateTestCycle extends Tool<Qtm4jClient> {
     const fieldResolver = this.client.getResolverRegistry();
     const context = fieldResolver.requireProjectContext();
 
-    // Inject projectId and default folderId before resolution.
+    // Inject projectId, and fall back to the default folder when none is given.
+    const parsed = CreateTestCycleBody.parse(rawArgs) as Record<
+      string,
+      unknown
+    >;
+    const usesDefaultFolder = parsed[InputField.FOLDER] === undefined;
     const body: Record<string, unknown> = {
-      ...(CreateTestCycleBody.parse(rawArgs) as Record<string, unknown>),
+      ...parsed,
       projectId: context.projectId,
-      folderId: "MCP Generated",
+      ...(usesDefaultFolder
+        ? { [InputField.FOLDER]: DEFAULT_FOLDER_NAME }
+        : {}),
     };
     const warnings: string[] = [];
 
-    // Resolve all configured fields (priority, status, folderId, labels, components).
+    // A caller-supplied folderId is already an ID — only the default folder name
+    // needs resolving.
+    const fieldConfig = usesDefaultFolder
+      ? { ...FIELD_CONFIG, ...FOLDER_FIELD_CONFIG }
+      : FIELD_CONFIG;
+
+    // Resolve all configured fields (priority, status, labels, components, folder).
     await Promise.all(
-      Object.entries(FIELD_CONFIG).map(([inputField, resolverKey]) =>
+      Object.entries(fieldConfig).map(([inputField, resolverKey]) =>
         fieldResolver
           .getResolver(resolverKey)
           .resolve(inputField, resolverKey, body, context, warnings),


### PR DESCRIPTION
…and cycles

Both create tools overwrote folderId with the hardcoded "MCP Generated" folder name after parsing the input, so a caller could not place a test case or cycle in a specific folder — and test cycles had no folderId input at all.

A numeric folderId is now passed straight to the API and the folder resolver is skipped, since it only maps folder names to IDs. When folderId is omitted the previous behaviour is unchanged: the "MCP Generated" name is injected and resolved.

## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? -->
