### PR TITLE
sdkv1 to sdkv2 changes applied to zephyr

### DIFF
--- a/src/zephyr/tool/environment/get-environments.ts
+++ b/src/zephyr/tool/environment/get-environments.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -73,7 +71,7 @@ export class GetEnvironments extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getEnvironmentsInput = ListEnvironmentsQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/folder/create-folder.test.ts
+++ b/src/zephyr/tool/folder/create-folder.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateFolderBody,
@@ -14,17 +10,27 @@ describe("CreateFolder", () => {
   let mockClient: any;
   let instance: CreateFolder;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/folder/create-folder.ts
+++ b/src/zephyr/tool/folder/create-folder.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -55,7 +53,7 @@ export class CreateFolder extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateFolderBody.parse(args);
     const response = await this.client.getApiClient().post(`/folders`, body);
     return {

--- a/src/zephyr/tool/issue-link/get-test-cases.ts
+++ b/src/zephyr/tool/issue-link/get-test-cases.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -29,7 +27,7 @@ export class GetTestCases extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestCasesPathParam.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/issue-link/get-test-cycles.ts
+++ b/src/zephyr/tool/issue-link/get-test-cycles.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -30,7 +28,7 @@ export class GetTestCycles extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestCyclesPathParam.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/issue-link/get-test-executions.ts
+++ b/src/zephyr/tool/issue-link/get-test-executions.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -30,7 +28,7 @@ export class GetTestExecutions extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { issueKey } = GetIssueLinkTestExecutionsParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/priority/get-priorities.ts
+++ b/src/zephyr/tool/priority/get-priorities.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -38,7 +36,7 @@ export class GetPriorities extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getPrioritiesInput = ListPrioritiesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/project/get-project.ts
+++ b/src/zephyr/tool/project/get-project.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetProject extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { projectIdOrKey } = GetProjectParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/project/get-projects.ts
+++ b/src/zephyr/tool/project/get-projects.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -45,7 +43,7 @@ export class GetProjects extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListProjectsQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/status/get-statuses.ts
+++ b/src/zephyr/tool/status/get-statuses.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -48,7 +46,7 @@ export class GetStatuses extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const getStatusesInput = ListStatusesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-case/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseIssueLink201Response as createTestCaseIssueLinkResponse } from "../../common/rest-api-schemas";
 import { CreateTestCaseIssueLink } from "./create-issue-link";
@@ -11,17 +7,27 @@ describe("CreateTestCaseIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestCaseIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-issue-link.ts
+++ b/src/zephyr/tool/test-case/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestCaseIssueLink extends Tool<ZephyrClient> {
       "Create a new link between an issue in Jira and a Test Case in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCaseIssueLinkParams.and(
-      CreateTestCaseIssueLinkBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseIssueLinkParams.extend(
+      CreateTestCaseIssueLinkBody.partial().shape,
     ),
     outputSchema: createTestCaseIssueLinkResponse,
     examples: [
@@ -33,7 +33,7 @@ export class CreateTestCaseIssueLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseIssueLinkParams.and(
       CreateTestCaseIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-test-case.test.ts
+++ b/src/zephyr/tool/test-case/create-test-case.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestCaseBody,
@@ -13,17 +9,27 @@ import { CreateTestCase } from "./create-test-case";
 describe("CreateTestCase", () => {
   let mockClient: any;
   let instance: CreateTestCase;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-case.ts
+++ b/src/zephyr/tool/test-case/create-test-case.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -70,7 +68,7 @@ export class CreateTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestCaseBody.parse(args);
     const response = await this.client.getApiClient().post(`/testcases/`, body);
     return {

--- a/src/zephyr/tool/test-case/create-test-script.test.ts
+++ b/src/zephyr/tool/test-case/create-test-script.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseTestScript201Response as createTestCaseScriptResponse } from "../../common/rest-api-schemas";
 import { CreateTestScript } from "./create-test-script";
@@ -11,17 +7,27 @@ describe("CreateTestScript", () => {
   let mockClient: any;
   let instance: CreateTestScript;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-script.ts
+++ b/src/zephyr/tool/test-case/create-test-script.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -17,8 +15,10 @@ export class CreateTestScript extends Tool<ZephyrClient> {
       "Create a new Test Script of the types Plain Text or BDD in a Zephyr Test Case.",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCaseTestScriptParams.and(
-      CreateTestCaseTestScriptBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseTestScriptParams.extend(
+      CreateTestCaseTestScriptBody.partial().shape,
     ),
     outputSchema: createTestCaseScriptResponse,
     examples: [
@@ -58,7 +58,7 @@ export class CreateTestScript extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseTestScriptParams.and(
       CreateTestCaseTestScriptBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-test-steps.test.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseTestSteps201Response as createTestCaseTestStepsResponse } from "../../common/rest-api-schemas";
 import { CreateTestSteps } from "./create-test-steps";
@@ -11,17 +7,27 @@ describe("CreateTestSteps", () => {
   let mockClient: any;
   let instance: CreateTestSteps;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-test-steps.ts
+++ b/src/zephyr/tool/test-case/create-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -17,7 +15,11 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
     readOnly: false,
     destructive: true,
     idempotent: false,
-    inputSchema: CreateTestCaseTestStepsParams.and(CreateTestCaseTestStepsBody),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCaseTestStepsParams.extend(
+      CreateTestCaseTestStepsBody.shape,
+    ),
     outputSchema: createTestCaseTestStepsResponse,
     examples: [
       {
@@ -90,7 +92,7 @@ export class CreateTestSteps extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCaseTestStepsParams.and(
       CreateTestCaseTestStepsBody,
     ).parse(args);

--- a/src/zephyr/tool/test-case/create-web-link.test.ts
+++ b/src/zephyr/tool/test-case/create-web-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCaseWebLink201Response as CreateTestCaseWebLinkResponse } from "../../common/rest-api-schemas";
 import { CreateTestCaseWebLink } from "./create-web-link";
@@ -11,17 +7,27 @@ describe("CreateTestCaseWebLink", () => {
   let mockClient: any;
   let instance: CreateTestCaseWebLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/create-web-link.ts
+++ b/src/zephyr/tool/test-case/create-web-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -42,7 +40,7 @@ export class CreateTestCaseWebLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const fullInputSchema = CreateTestCaseWebLinkBody.extend({
       testCaseKey: CreateTestCaseWebLinkParams.shape.testCaseKey,
     });

--- a/src/zephyr/tool/test-case/get-links.test.ts
+++ b/src/zephyr/tool/test-case/get-links.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GetTestCaseLinksParams,
@@ -14,17 +10,27 @@ describe("GetTestCaseLinks", () => {
   let mockClient: any;
   let instance: GetTestCaseLinks;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 
@@ -216,14 +222,14 @@ describe("GetTestCaseLinks", () => {
       "/testcases/SA-T10/links",
     );
     expect(result.structuredContent).toBe(responseMock);
-    expect(result.structuredContent?.webLinks).toHaveLength(3);
-    expect((result.structuredContent?.webLinks as any)[0].url).toBe(
+    expect((result.structuredContent as any)?.webLinks).toHaveLength(3);
+    expect((result.structuredContent as any)?.webLinks[0].url).toBe(
       "not-a-valid-url",
     );
-    expect((result.structuredContent?.webLinks as any)[1].url).toBe(
+    expect((result.structuredContent as any)?.webLinks[1].url).toBe(
       "//incomplete",
     );
-    expect((result.structuredContent?.webLinks as any)[2].url).toBe(
+    expect((result.structuredContent as any)?.webLinks[2].url).toBe(
       "http://example.com/path with spaces",
     );
   });

--- a/src/zephyr/tool/test-case/get-links.ts
+++ b/src/zephyr/tool/test-case/get-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -31,7 +29,7 @@ export class GetTestCaseLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-case.ts
+++ b/src/zephyr/tool/test-case/get-test-case.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-cases.ts
+++ b/src/zephyr/tool/test-case/get-test-cases.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -62,7 +60,7 @@ export class GetTestCases extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestCasesCursorPaginatedQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-script.test.ts
+++ b/src/zephyr/tool/test-case/get-test-script.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GetTestCaseTestScript200Response as GetTestScriptResponse } from "../../common/rest-api-schemas";
 import { GetTestScript } from "./get-test-script";
@@ -11,17 +7,27 @@ describe("GetTestScript", () => {
   let mockClient: any;
   let instance: GetTestScript;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/get-test-script.ts
+++ b/src/zephyr/tool/test-case/get-test-script.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -48,7 +46,7 @@ export class GetTestScript extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCaseKey } = GetTestCaseTestScriptParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-case/get-test-steps.ts
+++ b/src/zephyr/tool/test-case/get-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class GetTestCaseSteps extends Tool<ZephyrClient> {
     summary: "Get details of test case steps in Zephyr",
     readOnly: true,
     idempotent: true,
-    inputSchema: GetTestCaseTestStepsParams.and(
-      GetTestCaseTestStepsQueryParams.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: GetTestCaseTestStepsParams.extend(
+      GetTestCaseTestStepsQueryParams.partial().shape,
     ),
     outputSchema: getTestCaseStepsResponse,
     examples: [
@@ -53,7 +53,7 @@ export class GetTestCaseSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = GetTestCaseTestStepsParams.and(
       GetTestCaseTestStepsQueryParams,
     ).parse(args);

--- a/src/zephyr/tool/test-case/update-test-case.test.ts
+++ b/src/zephyr/tool/test-case/update-test-case.test.ts
@@ -1,25 +1,31 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestCase } from "./update-test-case";
 
 describe("UpdateTestCase", () => {
   let mockClient: any;
   let instance: UpdateTestCase;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-case/update-test-case.ts
+++ b/src/zephyr/tool/test-case/update-test-case.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z as zod } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -42,7 +40,9 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
       'Update an existing Test Case in Zephyr. This operation fetches the current test case and merges your updates with it to prevent accidental property deletion. Properties which are not included in the tool call will be left unchanged. To remove a property, set it to null explicitly. For fields that accept multiple values, such as `labels`, if the field is provided, it will override the previous values. For example, if `labels` is provided with the values `["label1", "label2"]`, the Test Case will now only have those two labels, and any previous labels will be removed. If you want to add a label, you would need to specify in the prompt the intention to add a label.',
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestCaseParams.extend(UpdateTestCaseBodyToolInput.shape),
     examples: [
       {
         description:
@@ -114,7 +114,7 @@ export class UpdateTestCase extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = UpdateTestCaseParams.and(UpdateTestCaseBodyToolInput).parse(
       args,
     );

--- a/src/zephyr/tool/test-cycle/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-cycle/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCycleIssueLink } from "./create-issue-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestCycleIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestCycleIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-issue-link.ts
+++ b/src/zephyr/tool/test-cycle/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestCycleIssueLink extends Tool<ZephyrClient> {
       "Create a new link between an issue in Jira and a Test Cycle in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCycleIssueLinkParams.and(
-      CreateTestCycleIssueLinkBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCycleIssueLinkParams.extend(
+      CreateTestCycleIssueLinkBody.shape,
     ),
     examples: [
       {
@@ -42,7 +42,7 @@ export class CreateTestCycleIssueLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCycleIssueLinkParams.and(
       CreateTestCycleIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-cycle/create-test-cycle.test.ts
+++ b/src/zephyr/tool/test-cycle/create-test-cycle.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestCycleBody,
@@ -13,17 +9,27 @@ import { CreateTestCycle } from "./create-test-cycle";
 describe("CreateTestCyCle", () => {
   let mockClient: any;
   let instance: CreateTestCycle;
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/create-test-cycle.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -72,7 +70,7 @@ export class CreateTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestCycleBody.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/create-web-link.test.ts
+++ b/src/zephyr/tool/test-cycle/create-web-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestCycleWebLink } from "./create-web-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestCycleWebLink", () => {
   let mockClient: any;
   let instance: CreateTestCycleWebLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/create-web-link.ts
+++ b/src/zephyr/tool/test-cycle/create-web-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -14,8 +12,10 @@ export class CreateTestCycleWebLink extends Tool<ZephyrClient> {
     summary: "Create a new Web Link for a Test Cycle in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestCycleWebLinkParams.and(
-      CreateTestCycleWebLinkBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestCycleWebLinkParams.extend(
+      CreateTestCycleWebLinkBody.partial().shape,
     ),
     examples: [
       {
@@ -50,7 +50,7 @@ export class CreateTestCycleWebLink extends Tool<ZephyrClient> {
       },
     ],
   };
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestCycleWebLinkParams.and(
       CreateTestCycleWebLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-cycle/get-links.test.ts
+++ b/src/zephyr/tool/test-cycle/get-links.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GetTestCycleLinksParams,
@@ -14,17 +10,27 @@ describe("GetTestCycleLinks", () => {
   let mockClient: any;
   let instance: GetTestCycleLinks;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/get-links.ts
+++ b/src/zephyr/tool/test-cycle/get-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -38,7 +36,7 @@ export class GetTestCycleLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCycleIdOrKey } = GetTestCycleLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/get-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/get-test-cycle.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testCycleIdOrKey } = GetTestCycleParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/get-test-cycles.ts
+++ b/src/zephyr/tool/test-cycle/get-test-cycles.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -70,7 +68,7 @@ export class GetTestCycles extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestCyclesQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestCycle } from "./update-test-cycle";
 
@@ -10,17 +6,27 @@ describe("UpdateTestCycle", () => {
   let mockClient: any;
   let instance: UpdateTestCycle;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-cycle/update-test-cycle.ts
+++ b/src/zephyr/tool/test-cycle/update-test-cycle.ts
@@ -1,7 +1,5 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
 import { z as zod } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -43,7 +41,11 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
       "Update an existing Test Cycle in Zephyr. This operation fetches the current test cycle and merges your updates with it to prevent accidental property deletion. To remove a property, set it to null explicitly. The plannedStartDate and plannedEndDate fields cannot be cleared",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestCycleParams.and(UpdateTestCycleBodyToolInput),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestCycleParams.extend(
+      UpdateTestCycleBodyToolInput.shape,
+    ),
     examples: [
       {
         description:
@@ -116,7 +118,7 @@ export class UpdateTestCycle extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = UpdateTestCycleParams.and(
       UpdateTestCycleBodyToolInput,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/create-issue-link.test.ts
+++ b/src/zephyr/tool/test-execution/create-issue-link.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTestExecutionIssueLink } from "./create-issue-link";
 
@@ -10,17 +6,27 @@ describe("CreateTestExecutionIssueLink", () => {
   let mockClient: any;
   let instance: CreateTestExecutionIssueLink;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/create-issue-link.ts
+++ b/src/zephyr/tool/test-execution/create-issue-link.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class CreateTestExecutionIssueLink extends Tool<ZephyrClient> {
       "Create a new link between a Jira issue and a Test Execution in Zephyr",
     readOnly: false,
     idempotent: false,
-    inputSchema: CreateTestExecutionIssueLinkParams.and(
-      CreateTestExecutionIssueLinkBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: CreateTestExecutionIssueLinkParams.extend(
+      CreateTestExecutionIssueLinkBody.shape,
     ),
     examples: [
       {
@@ -43,7 +43,7 @@ export class CreateTestExecutionIssueLink extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = CreateTestExecutionIssueLinkParams.and(
       CreateTestExecutionIssueLinkBody,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/create-test-execution.test.ts
+++ b/src/zephyr/tool/test-execution/create-test-execution.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CreateTestExecutionBody,
@@ -14,17 +10,27 @@ describe("CreateTestExecution", () => {
   let mockClient: any;
   let instance: CreateTestExecution;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: (_notification) => {
-      throw new Error("Function not implemented.");
-    },
-    sendRequest: (_request, _resultSchema, _options?) => {
-      throw new Error("Function not implemented.");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Function not implemented.");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Function not implemented.");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Function not implemented.");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Function not implemented.");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/create-test-execution.ts
+++ b/src/zephyr/tool/test-execution/create-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -68,7 +66,7 @@ export class CreateTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const body = CreateTestExecutionBody.parse(args);
 
     const response = await this.client

--- a/src/zephyr/tool/test-execution/get-test-execution-links.ts
+++ b/src/zephyr/tool/test-execution/get-test-execution-links.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestExecutionLinks extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testExecutionIdOrKey } = ListTestExecutionLinksParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-execution.ts
+++ b/src/zephyr/tool/test-execution/get-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -35,7 +33,7 @@ export class GetTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const { testExecutionIdOrKey } = GetTestExecutionParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-executions.ts
+++ b/src/zephyr/tool/test-execution/get-test-executions.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -41,7 +39,7 @@ export class GetTestExecutions extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestExecutionsNextgenQueryParams.parse(args);
     const response = await this.client
       .getApiClient()

--- a/src/zephyr/tool/test-execution/get-test-steps.ts
+++ b/src/zephyr/tool/test-execution/get-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class GetTestExecutionSteps extends Tool<ZephyrClient> {
     summary: "Get details of test execution steps in Zephyr",
     readOnly: true,
     idempotent: true,
-    inputSchema: GetTestExecutionTestStepsParams.and(
-      GetTestExecutionTestStepsQueryParams.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: GetTestExecutionTestStepsParams.extend(
+      GetTestExecutionTestStepsQueryParams.partial().shape,
     ),
     outputSchema: getTestExecutionStepsResponse,
     examples: [
@@ -75,7 +75,7 @@ export class GetTestExecutionSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = GetTestExecutionTestStepsParams.and(
       GetTestExecutionTestStepsQueryParams,
     ).parse(args);

--- a/src/zephyr/tool/test-execution/update-test-execution.test.ts
+++ b/src/zephyr/tool/test-execution/update-test-execution.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestExecution } from "./update-test-execution";
 
@@ -10,17 +6,27 @@ describe("UpdateTestExecution", () => {
   let mockClient: any;
   let instance: UpdateTestExecution;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: () => {
-      throw new Error("Not implemented");
-    },
-    sendRequest: () => {
-      throw new Error("Not implemented");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Not implemented");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Not implemented");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Not implemented");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/update-test-execution.ts
+++ b/src/zephyr/tool/test-execution/update-test-execution.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class UpdateTestExecution extends Tool<ZephyrClient> {
       "Update an existing Test Execution in Zephyr. This operation only updates specified fields in the payload and ignores `null` or `undefined` values.",
     readOnly: false,
     idempotent: true,
-    inputSchema: UpdateTestExecutionParams.and(
-      UpdateTestExecutionBody.partial(),
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: UpdateTestExecutionParams.extend(
+      UpdateTestExecutionBody.partial().shape,
     ),
     examples: [
       {
@@ -75,7 +75,7 @@ export class UpdateTestExecution extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const fullInputSchema = UpdateTestExecutionParams.and(
       UpdateTestExecutionBody.partial(),
     );

--- a/src/zephyr/tool/test-execution/update-test-steps.test.ts
+++ b/src/zephyr/tool/test-execution/update-test-steps.test.ts
@@ -1,8 +1,4 @@
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { ServerContext } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateTestExecutionSteps } from "./update-test-steps";
 
@@ -10,17 +6,27 @@ describe("UpdateTestExecutionSteps", () => {
   let mockClient: any;
   let instance: UpdateTestExecutionSteps;
 
-  const EXTRA_REQUEST_HANDLER: RequestHandlerExtra<
-    ServerRequest,
-    ServerNotification
-  > = {
-    signal: AbortSignal.timeout(5000),
-    requestId: "",
-    sendNotification: () => {
-      throw new Error("Not implemented");
-    },
-    sendRequest: () => {
-      throw new Error("Not implemented");
+  const EXTRA_REQUEST_HANDLER: ServerContext = {
+    mcpReq: {
+      id: "",
+      method: "tools/call",
+      signal: AbortSignal.timeout(5000),
+      requestState: () => undefined,
+      notify: (_notification) => {
+        throw new Error("Not implemented");
+      },
+      send: (_request: any, _resultSchemaOrOptions?: any, _options?: any) => {
+        throw new Error("Not implemented");
+      },
+      log: (_level, _data, _logger) => {
+        throw new Error("Not implemented");
+      },
+      elicitInput: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
+      requestSampling: (_params, _options) => {
+        throw new Error("Not implemented");
+      },
     },
   };
 

--- a/src/zephyr/tool/test-execution/update-test-steps.ts
+++ b/src/zephyr/tool/test-execution/update-test-steps.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -16,8 +14,10 @@ export class UpdateTestExecutionSteps extends Tool<ZephyrClient> {
       "Update test steps for a given Test Execution in Zephyr. This operation updates the provided steps with their execution status and actual results. Only the fields included in the request will be modified.",
     readOnly: false,
     idempotent: true,
-    inputSchema: PutTestExecutionTestStepsParams.and(
-      PutTestExecutionTestStepsBody,
+    // Flattened via .extend() (not .and()) so the advertised JSON Schema stays
+    // a plain object instead of `allOf`, which older MCP clients don't understand.
+    inputSchema: PutTestExecutionTestStepsParams.extend(
+      PutTestExecutionTestStepsBody.shape,
     ),
     examples: [
       {
@@ -75,7 +75,7 @@ export class UpdateTestExecutionSteps extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsed = PutTestExecutionTestStepsParams.and(
       PutTestExecutionTestStepsBody.required(),
     ).parse(args);

--- a/src/zephyr/tool/test-plan/get-test-plans.ts
+++ b/src/zephyr/tool/test-plan/get-test-plans.ts
@@ -1,6 +1,4 @@
-import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ZodRawShape } from "zod";
-import { Tool } from "../../../common/tools";
+import { Tool, type ToolHandler } from "../../../common/tools";
 import type { ToolParams } from "../../../common/types";
 import type { ZephyrClient } from "../../client";
 import {
@@ -62,7 +60,7 @@ export class GetTestPlans extends Tool<ZephyrClient> {
     ],
   };
 
-  handle: ToolCallback<ZodRawShape> = async (args) => {
+  handle: ToolHandler = async (args) => {
     const parsedArgs = ListTestPlansCursorPaginatedQueryParams.parse(args);
     const response = await this.client
       .getApiClient()


### PR DESCRIPTION
Applied codemod(sdkv2) modelcontextprotocol changes to src/zephyr.