### PR TITLE
refactor(functional-testing): tool annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Swagger] Corrected tool annotation hints for the Functional Testing tools so they no longer fall back to registration defaults: `run_test` and `run_suite` are now declared open-world (`openWorldHint: true`), `cancel_suite_execution` is declared destructive (`destructiveHint: true`), and all tools use the shared `READ_ONLY`/`WRITE`/`WRITE_DESTRUCTIVE` presets to set `readOnlyHint`/`destructiveHint`/`openWorldHint` explicitly.
+
 ## [0.35.0] - 2026-08-11
 
 ### Added

--- a/src/swagger/client/functional-testing-tools.ts
+++ b/src/swagger/client/functional-testing-tools.ts
@@ -11,6 +11,7 @@ import {
   RunFunctionalTestingSuiteParamsSchema,
   RunFunctionalTestingTestParamsSchema,
 } from "./functional-testing-types";
+import { READ_ONLY, WRITE, WRITE_DESTRUCTIVE } from "./tool-constants";
 import type { SwaggerToolParams } from "./tools";
 
 export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
@@ -23,7 +24,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to retrieve test execution results or history.",
     handler: "listFunctionalTestingTests",
     idempotent: true,
-    readOnly: true,
+    ...READ_ONLY,
   },
   {
     title: "Create Test",
@@ -38,8 +39,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: CreateFunctionalTestingTestParamsSchema,
     outputSchema: CreateFunctionalTestingTestResponseSchema,
     handler: "createFunctionalTestingTest",
+    ...WRITE,
     idempotent: false,
-    readOnly: false,
   },
   {
     title: "Run Test",
@@ -50,8 +51,9 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Use `swagger_get_test_status` with that executionId to track progress and retrieve the final result.",
     inputSchema: RunFunctionalTestingTestParamsSchema,
     handler: "runFunctionalTestingTest",
+    ...WRITE,
+    openWorld: true,
     idempotent: false,
-    readOnly: false,
   },
   {
     title: "Get Test Status",
@@ -63,7 +65,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: GetFunctionalTestingExecutionTestSchema,
     handler: "getFunctionalTestingExecution",
     idempotent: true,
-    readOnly: true,
+    ...READ_ONLY,
   },
   {
     title: "List Suite Executions",
@@ -74,8 +76,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to retrieve the status of a single execution or individual test results.",
     inputSchema: ListFunctionalTestingSuiteExecutionsSchema,
     handler: "listFunctionalTestingSuiteExecutions",
-    readOnly: true,
     idempotent: true,
+    ...READ_ONLY,
   },
   {
     title: "Cancel Suite Execution",
@@ -86,7 +88,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to cancel individual test runs.",
     inputSchema: CancelFunctionalTestingSuiteExecutionSchema,
     handler: "cancelFunctionalTestingSuiteExecution",
-    readOnly: false,
+    ...WRITE_DESTRUCTIVE,
     idempotent: false,
   },
   {
@@ -103,8 +105,8 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: CreateFunctionalTestingSuiteParamsSchema,
     outputSchema: CreateFunctionalTestingSuiteResponseSchema,
     handler: "createFunctionalTestingSuite",
+    ...WRITE,
     idempotent: false,
-    readOnly: false,
   },
   {
     title: "List Suites",
@@ -115,7 +117,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to retrieve individual tests or test suite execution results.",
     handler: "listFunctionalTestingSuites",
     idempotent: true,
-    readOnly: true,
+    ...READ_ONLY,
   },
   {
     title: "Run Suite",
@@ -128,8 +130,9 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
       "Do not use this tool to run a single test — use `swagger_run_test` instead.",
     inputSchema: RunFunctionalTestingSuiteParamsSchema,
     handler: "runFunctionalTestingSuite",
+    ...WRITE,
+    openWorld: true,
     idempotent: false,
-    readOnly: false,
   },
   {
     title: "Get Suite Status",
@@ -142,7 +145,7 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: GetFunctionalTestingSuiteExecutionSchema,
     handler: "getFunctionalTestingSuiteExecution",
     idempotent: true,
-    readOnly: true,
+    ...READ_ONLY,
   },
   {
     title: "Get Test Execution History",
@@ -156,6 +159,6 @@ export const FUNCTIONAL_TESTING_TOOLS: SwaggerToolParams[] = [
     inputSchema: GetFunctionalTestHistoryParamsSchema,
     handler: "getFunctionalTestingTestHistory",
     idempotent: true,
-    readOnly: true,
+    ...READ_ONLY,
   },
 ];


### PR DESCRIPTION
## Goal

Functional Testing tools (`src/swagger/client/functional-testing-tools.ts`) only set readOnly + idempotent inline; destructive and openWorld were omitted and silently fell back to the registration defaults in src/common/server.ts (destructiveHint: false, openWorldHint: false) regardless of what the tool actually does. MCP clients (Claude Desktop, Claude Code, etc.) rely on these annotation hints to gate confirmation prompts, sandboxing, and tool visibility, so a mutating/destructive tool that reports no destructive or open-world behavior is misleading and unsafe. This change brings the Functional Testing tools in line with the annotation pattern already used by the rest of the Swagger tools.

## Design

Reused the shared `READ_ONLY` / `WRITE` / `WRITE_DESTRUCTIVE` presets from `tool-constants.ts` instead of repeating inline flags, matching the established pattern in `tools.ts`. Each preset fixes `readOnly` / `destructive` / `openWorld` together, so a tool can't set one hint and silently default the rest. Hints were reviewed per tool rather than mechanically swapped:

- Read tools (List Tests, Get Test Status, List Suite Executions, List Suites, Get Suite Status, Get Test Execution History) → `READ_ONLY`
- Create tools (Create Test, Create Suite) → `WRITE`
- Run Test / Run Suite → `WRITE` plus openWorld: true, since they execute test steps against arbitrary user-defined external endpoints — genuinely open-world side effects beyond the SmartBear backend.
- Cancel Suite Execution → `WRITE_DESTRUCTIVE`, since it irreversibly stops an in-progress run and should trigger a client confirmation prompt.

`idempotent: false` is kept explicit on all mutating tools (create/run/cancel), because the presets don't carry idempotency and the server default is true — without it, non-idempotent mutations would be mislabeled.

Changeset

src/swagger/client/functional-testing-tools.ts:

- Import `READ_ONLY`, `WRITE`, `WRITE_DESTRUCTIVE` from `./tool-constants`.
- Replace inline readOnly / idempotent flags on all 11 Functional Testing tools with the appropriate shared preset spread.
- Add openWorld: true to Run Test and Run Suite.
- Mark Cancel Suite Execution as destructive via WRITE_DESTRUCTIVE.

Testing
- tsc --noEmit passes with no errors
- smoke tested SFT tools
