### PR TITLE
feat(pactflow): add asyncapi to publish contract tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [PactFlow] `publish_provider_contract` tool: added support for AsyncAPI provider contracts (`specification: "asyncapi"`), alongside the existing OpenAPI (`"oas"`) support.
+
 ## [0.35.0] - 2026-08-11
 
 ### Added

--- a/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
+++ b/docs/products/SmartBear MCP Server/contract-testing-with-pactflow.md
@@ -489,21 +489,21 @@ Read more on PactFlow [Docs](https://docs.pactflow.io/).
 
 #### Publish Provider Contract
 
-- Purpose: Publish a provider OpenAPI contract and self-verification results to PactFlow for Bi-Directional Contract Testing.
+- Purpose: Publish a provider OpenAPI or AsyncAPI contract and self-verification results to PactFlow for Bi-Directional Contract Testing.
 - Parameters:
   - **`providerName`** (required): Name of the provider application
   - **`pacticipantVersionNumber`** (required): Version number of the provider
   - **`contract`** (required): Object containing:
-    - **`content`**: Base64-encoded OpenAPI specification
+    - **`content`**: Base64-encoded OpenAPI or AsyncAPI specification
     - **`contentType`**: `application/json`, `application/yaml`, or `application/yml`
-    - **`specification`**: Must be `oas`
+    - **`specification`**: `oas` for OpenAPI or `asyncapi` for AsyncAPI
     - **`selfVerificationResults`**: Results of verifying the provider against its own spec, including `success` (boolean), `verifier` (tool name, e.g. `dredd`), and optional content/format fields
   - **`branch`** (optional): Branch name of the provider
   - **`tags`** (optional): Version tags
   - **`buildUrl`** (optional): URL of the CI build
 - Availability: Cloud
 - **Use Cases:**
-  - Upload an OpenAPI spec as the provider contract along with tool-based verification results.
+  - Upload an OpenAPI or AsyncAPI spec as the provider contract along with tool-based verification results.
   - Enable PactFlow to perform automated cross-contract verification without running consumer pact tests directly on the provider.
 
 #### Get Pacts for Verification

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -3533,14 +3533,14 @@ None",
       "readOnlyHint": false,
       "title": "Contract Testing: Publish Provider Contract",
     },
-    "description": "Publish a provider OpenAPI contract and self-verification results to PactFlow (Bi-Directional Contract Testing).
+    "description": "Publish a provider OpenAPI or AsyncAPI contract and self-verification results to PactFlow (Bi-Directional Contract Testing).
 
 **Toolset:** Contracts
 
 **Parameters:**
 - providerName (string) *required*: Name of the provider application
 - pacticipantVersionNumber (string) *required*: Version number of the provider
-- contract (object) *required*: Provider contract (OpenAPI spec) and verification details
+- contract (object) *required*: Provider contract (OpenAPI or AsyncAPI spec) and verification details
 - tags (array): Version tags
 - branch (string): Branch name of the provider
 - buildUrl (string): URL of the CI build",

--- a/src/pactflow/client.test.ts
+++ b/src/pactflow/client.test.ts
@@ -1841,6 +1841,29 @@ describe("PactFlowClient", () => {
           expect.objectContaining({ method: "POST" }),
         );
       });
+
+      it("should publish an AsyncAPI provider contract", async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+
+        const asyncApiInput = {
+          ...mockInput,
+          contract: {
+            ...mockInput.contract,
+            specification: "asyncapi" as const,
+          },
+        };
+        const { providerName, ...bodyWithoutProvider } = asyncApiInput;
+        await client.publishProviderContract(asyncApiInput);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          "https://example.com/provider-contracts/provider/ProviderAPI/publish",
+          {
+            method: "POST",
+            headers: client.requestHeaders,
+            body: JSON.stringify(bodyWithoutProvider),
+          },
+        );
+      });
     });
 
     describe("getPactsForVerification", () => {

--- a/src/pactflow/client.ts
+++ b/src/pactflow/client.ts
@@ -877,10 +877,10 @@ export class PactflowClient implements Client {
   }
 
   /**
-   * Publishes a provider OpenAPI contract and its self-verification results to PactFlow
-   * for use in Bi-Directional Contract Testing.
+   * Publishes a provider OpenAPI or AsyncAPI contract and its self-verification results
+   * to PactFlow for use in Bi-Directional Contract Testing.
    *
-   * @param params - `providerName`, version number, base64-encoded OpenAPI spec,
+   * @param params - `providerName`, version number, base64-encoded OpenAPI/AsyncAPI spec,
    *   content type, and self-verification results.
    * @returns Publication result.
    * @throws ToolError if the request fails.

--- a/src/pactflow/client/base.ts
+++ b/src/pactflow/client/base.ts
@@ -250,13 +250,17 @@ export const PublishProviderContractSchema = z.object({
     .object({
       content: z
         .string()
-        .describe("Base64-encoded OpenAPI specification content"),
+        .describe(
+          "Base64-encoded OpenAPI or AsyncAPI specification content",
+        ),
       contentType: z
         .enum(["application/json", "application/yaml", "application/yml"])
-        .describe("Content type of the OpenAPI spec"),
+        .describe("Content type of the spec"),
       specification: z
-        .literal("oas")
-        .describe("Specification type (must be 'oas')"),
+        .enum(["oas", "asyncapi"])
+        .describe(
+          "Specification type: 'oas' for OpenAPI or 'asyncapi' for AsyncAPI",
+        ),
       selfVerificationResults: z
         .object({
           success: z.boolean().describe("Whether self-verification passed"),
@@ -286,7 +290,9 @@ export const PublishProviderContractSchema = z.object({
           "Results of self-verifying the provider against its own contract",
         ),
     })
-    .describe("Provider contract (OpenAPI spec) and verification details"),
+    .describe(
+      "Provider contract (OpenAPI or AsyncAPI spec) and verification details",
+    ),
   tags: z.array(z.string()).optional().describe("Version tags"),
   branch: z.string().optional().describe("Branch name of the provider"),
   buildUrl: z.string().optional().describe("URL of the CI build"),

--- a/src/pactflow/client/base.ts
+++ b/src/pactflow/client/base.ts
@@ -250,9 +250,7 @@ export const PublishProviderContractSchema = z.object({
     .object({
       content: z
         .string()
-        .describe(
-          "Base64-encoded OpenAPI or AsyncAPI specification content",
-        ),
+        .describe("Base64-encoded OpenAPI or AsyncAPI specification content"),
       contentType: z
         .enum(["application/json", "application/yaml", "application/yml"])
         .describe("Content type of the spec"),

--- a/src/pactflow/client/tools.ts
+++ b/src/pactflow/client/tools.ts
@@ -434,9 +434,9 @@ export const TOOLS: PactflowToolParams[] = [
     title: "Publish Provider Contract",
     toolset: "Contracts",
     summary:
-      "Publish a provider OpenAPI contract and self-verification results to PactFlow (Bi-Directional Contract Testing).",
+      "Publish a provider OpenAPI or AsyncAPI contract and self-verification results to PactFlow (Bi-Directional Contract Testing).",
     purpose:
-      "Upload an OpenAPI specification as a provider contract along with the results of running a tool (e.g. Dredd, Schemathesis) that verifies the provider implementation against the spec. This enables PactFlow to perform automated cross-contract verification without requiring the provider to run the consumer Pact tests.",
+      "Upload an OpenAPI or AsyncAPI specification as a provider contract along with the results of running a tool (e.g. Dredd, Schemathesis) that verifies the provider implementation against the spec. This enables PactFlow to perform automated cross-contract verification without requiring the provider to run the consumer Pact tests.",
     inputSchema: PublishProviderContractSchema,
     handler: "publishProviderContract",
     readOnly: false,


### PR DESCRIPTION
## Goal

Publish provider contract tool also takes async api as input, this pr adds that

## Testing
Tested manually from vscode

