### PR TITLE
chore: skip contract testing on dependabot prs

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -19,6 +19,7 @@ jobs:
   consumer-tests:
     name: Generate & publish pact contracts
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Goal

Skip contract testing on dependabot prs as they don't get secrets