### PR TITLE
cache issue fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Bugsnag]: Prevent cross-account data leakage in Bugsnag caching by namespacing cache keys with the caller's credential hash. [#677]
+
+### Changed
+
+- [Bugsnag] Use a single process-wide `CacheService` and namespace every cache key with a SHA-256 hash of the authenticated caller's token.
+- [Bugsnag] Prefer the request auth header when resolving cache namespace via `getProjectApiKey()` so per-request auth is honored.
+- [Bugsnag] Ensure unauthenticated callers bypass the shared cache to avoid exposing cached data.
+- [Bugsnag] Updated cache usage in `getOrganization()`, `getProjects()`, `getCurrentProject()`, `getProjectEventFields()`, and `getProjectTraceFields()`.
+
 ## [0.37.0] - 2026-08-20
 - [QMetry]: Added Test Case, Test Suite, Issue module, Create/Update UDF capability Added. [#666](https://github.com/SmartBear/smartbear-mcp/pull/666)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Bugsnag] Use a single process-wide `CacheService` and namespace every cache key with a SHA-256 hash of the authenticated caller's token.
-- [Bugsnag] Prefer the request auth header when resolving cache namespace via `getProjectApiKey()` so per-request auth is honored.
+- [Bugsnag] Prefer the request auth header when resolving the cache namespace via `getAuthToken()` so per-request auth is honored.
 - [Bugsnag] Ensure unauthenticated callers bypass the shared cache to avoid exposing cached data.
 - [Bugsnag] Updated cache usage in `getOrganization()`, `getProjects()`, `getCurrentProject()`, `getProjectEventFields()`, and `getProjectTraceFields()`.
 

--- a/src/bugsnag/client.test.ts
+++ b/src/bugsnag/client.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_AGENT } from "../common/info.js";
 import { withRequestContext } from "../common/request-context";
@@ -13,7 +13,7 @@ import type {
   TraceField,
 } from "./client/api/api.js";
 import type { BaseAPI } from "./client/api/base.js";
-import type { CurrentUserAPI, ErrorAPI } from "./client/api/index.js";
+import type { CurrentUserAPI, ErrorAPI, Project } from "./client/api/index.js";
 import type { ProjectAPI } from "./client/api/Project.js";
 import { BugsnagClient } from "./client.js";
 import {
@@ -79,7 +79,6 @@ const cacheKeyNames = {
   PROJECTS: "bugsnag_projects",
   PROJECT_EVENT_FIELDS: "bugsnag_project_event_fields",
   PROJECT_TRACE_FIELDS: "bugsnag_project_trace_fields",
-  CURRENT_PROJECT: "bugsnag_current_project",
 };
 
 // Resolves a logical cache key to the namespaced key the client actually uses.
@@ -87,6 +86,10 @@ const cacheKeyNames = {
 // is credential-scoped — see the "cache isolation" tests below for that.
 function nsKey(client: BugsnagClient, key: string): string {
   return (client as any).cacheKey(key);
+}
+
+function configuredProjects(project: Project): Project[] {
+  return [{ ...project, api_key: "test-project-key" }];
 }
 
 vi.mock("./client/api/CurrentUser.ts", () => ({
@@ -788,23 +791,64 @@ describe("BugsnagClient", () => {
       );
     });
 
-    it("does not let a caller-supplied project key reach another account's entry", async () => {
-      // Attacker holds their own valid token but sends the victim's project
-      // key as a header, hoping to land on the victim's cached entries.
-      const victim = new BugsnagClient();
-      await victim.configure({} as any, {
-        auth_token: "victim-token",
-        project_api_key: "victim-project-key",
+    it("gives the same token different cache keys on different API authorities", async () => {
+      const defaultClient = new BugsnagClient();
+      await defaultClient.configure({} as any, {
+        auth_token: "shared-token",
+        project_api_key: "default-project-key",
       });
-      const attacker = new BugsnagClient();
-      await attacker.configure({} as any, { auth_token: "attacker-token" });
+      const hubClient = new BugsnagClient();
+      await hubClient.configure({} as any, {
+        auth_token: "shared-token",
+        project_api_key: "00000-hub-project-key",
+      });
 
-      const attackerKey = withRequestContext(
-        { headers: { "bugsnag-project-api-key": "victim-project-key" } } as any,
-        () => nsKey(attacker, "bugsnag_projects"),
+      for (const key of Object.values(cacheKeyNames)) {
+        expect(nsKey(defaultClient, key)).not.toEqual(nsKey(hubClient, key));
+      }
+    });
+
+    it("does not accept a project key that changes after configuration", async () => {
+      const client = new BugsnagClient();
+      await client.configure({} as any, {
+        auth_token: "test-token",
+        project_api_key: "configured-project-key",
+      });
+      const configuredProject = getMockProject(
+        "project-1",
+        "Configured project",
+        "configured-project-key",
+      );
+      mockCache.get.mockReturnValueOnce([configuredProject]);
+
+      const result = await withRequestContext(
+        { headers: { "bugsnag-project-api-key": "00000-later-key" } } as any,
+        () => client.getCurrentProject(),
       );
 
-      expect(attackerKey).not.toEqual(nsKey(victim, "bugsnag_projects"));
+      expect(result).toEqual(configuredProject);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        nsKey(client, "bugsnag_projects"),
+      );
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it("keeps explicitly selected projects isolated between sessions", async () => {
+      const projectA = getMockProject("project-a", "Project A");
+      const projectB = getMockProject("project-b", "Project B");
+      const sessionA = new BugsnagClient();
+      const sessionB = new BugsnagClient();
+      await sessionA.configure({} as any, { auth_token: "shared-token" });
+      await sessionB.configure({} as any, { auth_token: "shared-token" });
+      mockCache.get
+        .mockReturnValueOnce([projectA, projectB])
+        .mockReturnValueOnce([projectA, projectB]);
+
+      await sessionA.getInputProject(projectA.id);
+      await sessionB.getInputProject(projectB.id);
+
+      expect(await sessionA.getCurrentProject()).toEqual(projectA);
+      expect(await sessionB.getCurrentProject()).toEqual(projectB);
     });
 
     it("bypasses the cache entirely when there is no credential to namespace by", async () => {
@@ -835,7 +879,9 @@ describe("BugsnagClient", () => {
       await client.configure({} as any, { auth_token: "token-b" });
 
       const orgA = getMockOrganization("org-a", "Account A Org");
-      const namespaceForA = createHash("sha256")
+      const namespaceForA = createHmac("sha256", "bugsnag-cache-ns")
+        .update("https://api.bugsnag.com")
+        .update("\0")
         .update("token token-a")
         .digest("hex")
         .slice(0, 32);
@@ -1074,16 +1120,11 @@ describe("BugsnagClient", () => {
           projectId: "proj-1",
         });
 
-        expect(mockCache.set).toHaveBeenCalledWith(
-          nsKey(clientWithNoApiKey, "bugsnag_current_project"),
-          mockProject,
-        );
+        expect(mockCache.set).not.toHaveBeenCalled();
 
         // The subsequent call should get a current project and not throw if a project ID is not provided
 
-        mockCache.get
-          .mockReturnValueOnce(mockProject) // current project
-          .mockReturnValueOnce(mockEventFields);
+        mockCache.get.mockReturnValueOnce(mockEventFields);
         mockErrorAPI.listProjectErrors.mockResolvedValue({
           body: mockErrors,
           totalCount: 1,
@@ -1185,7 +1226,7 @@ describe("BugsnagClient", () => {
         ];
 
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(configuredProjects(mockProject))
           .mockReturnValueOnce(mockOrg);
         mockProjectAPI.listProjectEventFields.mockResolvedValue({
           body: [
@@ -1228,7 +1269,7 @@ describe("BugsnagClient", () => {
 
       it("should get error details without any latest events or pivots", async () => {
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(configuredProjects(mockProject))
           .mockReturnValueOnce(mockOrg);
         mockProjectAPI.listProjectEventFields.mockResolvedValue({
           body: [
@@ -1271,7 +1312,7 @@ describe("BugsnagClient", () => {
 
       it("should throw when error ID does not exist", async () => {
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(configuredProjects(mockProject))
           .mockReturnValueOnce(mockOrg);
         mockErrorAPI.viewErrorOnProject.mockResolvedValue({ body: null });
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -1412,7 +1453,7 @@ describe("BugsnagClient", () => {
         };
 
         mockCache.get
-          .mockReturnValueOnce(mockProject) // current project
+          .mockReturnValueOnce(configuredProjects(mockProject)) // projects
           .mockReturnValueOnce(mockEventFields); // event fields
         mockErrorAPI.listProjectErrors.mockResolvedValue({
           body: mockErrors,
@@ -1465,7 +1506,7 @@ describe("BugsnagClient", () => {
         };
 
         mockCache.get
-          .mockReturnValueOnce(mockProject) // current project
+          .mockReturnValueOnce(configuredProjects(mockProject)) // projects
           .mockReturnValueOnce(mockEventFields); // event fields
         mockErrorAPI.listProjectErrors.mockResolvedValue({
           body: mockErrors,
@@ -1514,7 +1555,7 @@ describe("BugsnagClient", () => {
         };
 
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(configuredProjects(mockProject))
           .mockReturnValueOnce(mockEventFields);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -1553,7 +1594,7 @@ describe("BugsnagClient", () => {
           "event.since": [{ type: "eq" as const, value: "7d" }],
         };
 
-        mockCache.get.mockReturnValueOnce(mockProject); // current project
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject)); // projects
         mockErrorAPI.listErrorEvents.mockResolvedValue({
           body: mockEvents,
           totalCount: 2,
@@ -1601,7 +1642,7 @@ describe("BugsnagClient", () => {
           ],
         };
         mockCache.get
-          .mockReturnValueOnce(mockProject)
+          .mockReturnValueOnce(configuredProjects(mockProject))
           .mockReturnValueOnce(mockEventFields);
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -1624,7 +1665,7 @@ describe("BugsnagClient", () => {
           "Project 1",
           "test-project-key",
         );
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
         const toolHandler = registerToolsSpy.mock.calls.find(
           (call: any) => call[0].title === "Get Current Project",
@@ -1677,7 +1718,7 @@ describe("BugsnagClient", () => {
 
         // First get for the project, second for cached build (return null to call API)
         mockCache.get
-          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce(configuredProjects(mockProjects[0]))
           .mockReturnValueOnce([mockProjects[0]]);
         mockProjectAPI.getProjectReleaseById.mockResolvedValue({
           body: basicBuild,
@@ -1715,7 +1756,7 @@ describe("BugsnagClient", () => {
 
         // First get for the project, second for cached build (return null to call API)
         mockCache.get
-          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce(configuredProjects(mockProjects[0]))
           .mockReturnValueOnce([mockProjects[0]]);
         mockProjectAPI.getProjectReleaseById.mockResolvedValue({
           body: basicBuild,
@@ -1762,7 +1803,7 @@ describe("BugsnagClient", () => {
 
         // First get for the project, second for cached build (return null to call API)
         mockCache.get
-          .mockReturnValueOnce(mockProjectSessionStability)
+          .mockReturnValueOnce(configuredProjects(mockProjectSessionStability))
           .mockReturnValueOnce([mockProjectSessionStability]);
         mockProjectAPI.getProjectReleaseById.mockResolvedValue({
           body: basicBuild,
@@ -1838,7 +1879,7 @@ describe("BugsnagClient", () => {
 
       it("should throw error when build not found", async () => {
         mockCache.get
-          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce(configuredProjects(mockProjects[0]))
           .mockReturnValueOnce([mockProjects[0]]);
         mockProjectAPI.getProjectReleaseById.mockResolvedValue({ body: null });
 
@@ -1892,7 +1933,7 @@ describe("BugsnagClient", () => {
 
         // Mock project cache to return the project
         mockCache.get
-          .mockReturnValueOnce(mockProjects[1])
+          .mockReturnValueOnce(configuredProjects(mockProjects[1]))
           .mockReturnValueOnce([mockProjects[1]]);
         mockProjectAPI.listProjectReleaseGroups.mockResolvedValue({
           body: mockReleases,
@@ -1994,7 +2035,7 @@ describe("BugsnagClient", () => {
 
       it("should handle empty releases list", async () => {
         // Mock project cache to return the project
-        mockCache.get.mockReturnValueOnce(mockProjects[0]);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProjects[0]));
         mockProjectAPI.listProjectReleaseGroups.mockResolvedValue({ body: [] });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2122,7 +2163,7 @@ describe("BugsnagClient", () => {
 
       it("should throw error when release not found", async () => {
         mockCache.get
-          .mockReturnValueOnce(mockProjects[0])
+          .mockReturnValueOnce(configuredProjects(mockProjects[0]))
           .mockReturnValueOnce(null);
         mockProjectAPI.getReleaseGroup.mockResolvedValue({ body: null });
 
@@ -2141,7 +2182,7 @@ describe("BugsnagClient", () => {
       const mockProject = getMockProject("proj-1", "Project 1");
 
       it("should link a Jira issue to an error (link_issue)", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2168,7 +2209,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should unlink a Jira issue from an error (unlink_issue)", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2192,7 +2233,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should update error status to snooze for 1 hour with project from cache", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2224,7 +2265,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should update error status to snooze until 10 additional users affected", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2256,7 +2297,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should update error status to snooze until 10 additional occurrences", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2288,7 +2329,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should update error status to snooze until 10 occurrences in 2 hours", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2322,7 +2363,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should update error successfully with project from cache", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2374,7 +2415,7 @@ describe("BugsnagClient", () => {
         // Test all operations except override_severity which requires special elicitInput handling
         const operations = ["open", "fix", "ignore", "discard", "undiscard"];
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2406,7 +2447,7 @@ describe("BugsnagClient", () => {
           content: { severity: "warning" },
         });
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2448,7 +2489,7 @@ describe("BugsnagClient", () => {
           action: "reject",
         });
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 200 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2470,7 +2511,7 @@ describe("BugsnagClient", () => {
       });
 
       it("should return false when API returns non-success status", async () => {
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockErrorAPI.updateErrorOnProject.mockResolvedValue({ status: 400 });
 
         client.registerTools(registerToolsSpy, getInputFunctionSpy);
@@ -2533,7 +2574,7 @@ describe("BugsnagClient", () => {
           getMockSpanGroup(2, "POST /api/login", "http_request"),
         ];
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockProjectAPI.listProjectSpanGroups.mockResolvedValue({
           body: mockSpanGroups,
           nextUrl: null,
@@ -2586,7 +2627,7 @@ describe("BugsnagClient", () => {
           "span_group.category": [{ type: "eq", value: "http_request" }],
         };
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockProjectAPI.listProjectSpanGroups.mockResolvedValue({
           body: mockSpanGroups,
           nextUrl: "/next",
@@ -2645,7 +2686,7 @@ describe("BugsnagClient", () => {
         };
         const mockDistribution = { buckets: [{ range: "0-100ms", count: 50 }] };
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockProjectAPI.getProjectSpanGroup.mockResolvedValue({
           body: mockSpanGroup,
         });
@@ -2724,7 +2765,7 @@ describe("BugsnagClient", () => {
           getMockSpan("trace-def", 2, "POST /api/login", "http_request"),
         ];
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockProjectAPI.listSpansBySpanGroupId.mockResolvedValue({
           body: mockSpans,
           nextUrl: null,
@@ -2783,7 +2824,7 @@ describe("BugsnagClient", () => {
           getMockSpan("trace-abc", 2, "POST /api/login", "http_request"),
         ];
 
-        mockCache.get.mockReturnValue(mockProject);
+        mockCache.get.mockReturnValue(configuredProjects(mockProject));
         mockProjectAPI.listSpansByTraceId.mockResolvedValue({
           body: mockSpans,
           nextUrl: null,
@@ -2838,8 +2879,8 @@ describe("BugsnagClient", () => {
         ];
 
         mockCache.get.mockImplementation((key: string) => {
-          if (key === nsKey(client, "bugsnag_current_project")) {
-            return mockProject;
+          if (key === nsKey(client, "bugsnag_projects")) {
+            return configuredProjects(mockProject);
           }
           return undefined;
         });
@@ -2884,8 +2925,8 @@ describe("BugsnagClient", () => {
           if (key === nsKey(client, "bugsnag_project_trace_fields")) {
             return mockCachedFilters;
           }
-          if (key === nsKey(client, "bugsnag_current_project")) {
-            return mockProject;
+          if (key === nsKey(client, "bugsnag_projects")) {
+            return configuredProjects(mockProject);
           }
           return undefined;
         });
@@ -2976,7 +3017,7 @@ describe("BugsnagClient", () => {
           ],
         };
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.getProjectNetworkGroupingRuleset.mockResolvedValue({
           body: mockRuleset,
         });
@@ -3036,7 +3077,7 @@ describe("BugsnagClient", () => {
           endpoints: [],
         };
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.getProjectNetworkGroupingRuleset.mockResolvedValue({
           body: mockRuleset,
         });
@@ -3078,7 +3119,7 @@ describe("BugsnagClient", () => {
           endpoints: endpoints,
         };
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.updateProjectNetworkGroupingRuleset.mockResolvedValue({
           status: 200,
           body: mockRuleset,
@@ -3142,7 +3183,7 @@ describe("BugsnagClient", () => {
         const mockProject = { id: "proj-1", name: "Project 1" };
         const endpoints = ["/api/{version}/items/{itemId}"];
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.updateProjectNetworkGroupingRuleset.mockResolvedValue({
           status: 204,
           body: { projectId: "proj-1", endpoints },
@@ -3163,7 +3204,7 @@ describe("BugsnagClient", () => {
         const mockProject = { id: "proj-1", name: "Project 1" };
         const endpoints: string[] = [];
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.updateProjectNetworkGroupingRuleset.mockResolvedValue({
           status: 200,
           body: { projectId: "proj-1", endpoints },
@@ -3193,7 +3234,7 @@ describe("BugsnagClient", () => {
           "/graphql",
         ];
 
-        mockCache.get.mockReturnValueOnce(mockProject);
+        mockCache.get.mockReturnValueOnce(configuredProjects(mockProject));
         mockProjectAPI.updateProjectNetworkGroupingRuleset.mockResolvedValue({
           status: 200,
           body: { projectId: "proj-1", endpoints },

--- a/src/bugsnag/client.test.ts
+++ b/src/bugsnag/client.test.ts
@@ -808,7 +808,39 @@ describe("BugsnagClient", () => {
       }
     });
 
-    it("does not accept a project key that changes after configuration", async () => {
+    it("uses the request project key before the configured project key", async () => {
+      const client = new BugsnagClient();
+      await client.configure({} as any, {
+        auth_token: "test-token",
+        project_api_key: "configured-project-key",
+      });
+      const configuredProject = getMockProject(
+        "project-1",
+        "Configured project",
+        "configured-project-key",
+      );
+      const requestProject = getMockProject(
+        "project-2",
+        "Request project",
+        "request-project-key",
+      );
+      mockCache.get.mockReturnValueOnce([configuredProject, requestProject]);
+
+      const result = await withRequestContext(
+        {
+          headers: { "bugsnag-project-api-key": "request-project-key" },
+        } as any,
+        () => client.getCurrentProject(),
+      );
+
+      expect(result).toEqual(requestProject);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        nsKey(client, "bugsnag_projects"),
+      );
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the configured project key when the request has no project key", async () => {
       const client = new BugsnagClient();
       await client.configure({} as any, {
         auth_token: "test-token",
@@ -821,16 +853,29 @@ describe("BugsnagClient", () => {
       );
       mockCache.get.mockReturnValueOnce([configuredProject]);
 
-      const result = await withRequestContext(
-        { headers: { "bugsnag-project-api-key": "00000-later-key" } } as any,
-        () => client.getCurrentProject(),
+      const result = await withRequestContext({ headers: {} } as any, () =>
+        client.getCurrentProject(),
       );
 
       expect(result).toEqual(configuredProject);
-      expect(mockCache.get).toHaveBeenCalledWith(
-        nsKey(client, "bugsnag_projects"),
+    });
+
+    it("rejects a request project key that switches API authority", async () => {
+      const client = new BugsnagClient();
+      await client.configure({} as any, {
+        auth_token: "test-token",
+        project_api_key: "configured-project-key",
+      });
+
+      await expect(
+        withRequestContext(
+          { headers: { "bugsnag-project-api-key": "00000-hub-key" } } as any,
+          () => client.getCurrentProject(),
+        ),
+      ).rejects.toThrow(
+        "Bugsnag-Project-Api-Key cannot switch the API authority",
       );
-      expect(mockCache.set).not.toHaveBeenCalled();
+      expect(mockCache.get).not.toHaveBeenCalled();
     });
 
     it("keeps explicitly selected projects isolated between sessions", async () => {

--- a/src/bugsnag/client.test.ts
+++ b/src/bugsnag/client.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { USER_AGENT } from "../common/info.js";
+import { withRequestContext } from "../common/request-context";
 import { ToolError } from "../common/tools.js";
 import type {
   ErrorApiView,
@@ -64,6 +66,28 @@ const mockCache = {
   get: vi.fn(),
   del: vi.fn(),
 };
+
+// BugsnagClient now holds a single module-level shared CacheService (see
+// client.ts) instead of one per session, so this mock stands in for that one
+// shared instance across every test.
+vi.mock("../common/cache", () => ({
+  CacheService: vi.fn().mockImplementation(() => mockCache),
+}));
+
+const cacheKeyNames = {
+  ORG: "bugsnag_org",
+  PROJECTS: "bugsnag_projects",
+  PROJECT_EVENT_FIELDS: "bugsnag_project_event_fields",
+  PROJECT_TRACE_FIELDS: "bugsnag_project_trace_fields",
+  CURRENT_PROJECT: "bugsnag_current_project",
+};
+
+// Resolves a logical cache key to the namespaced key the client actually uses.
+// Note this delegates to the implementation, so it cannot prove the namespace
+// is credential-scoped — see the "cache isolation" tests below for that.
+function nsKey(client: BugsnagClient, key: string): string {
+  return (client as any).cacheKey(key);
+}
 
 vi.mock("./client/api/CurrentUser.ts", () => ({
   CurrentUserAPI: vi.fn().mockImplementation(() => mockCurrentUserAPI),
@@ -705,13 +729,10 @@ describe("BugsnagClient", () => {
       expect(MockedProjectAPI).toHaveBeenCalledOnce();
     });
 
-    it("should use cache from server.getCache()", async () => {
+    it("uses the shared cache, namespaced by the caller's identity", async () => {
       const client = new BugsnagClient();
-      const mockServer = {
-        getCache: vi.fn().mockReturnValue(mockCache),
-      } as any;
 
-      await client.configure(mockServer, {
+      await client.configure({} as any, {
         auth_token: "test-token",
       });
 
@@ -730,11 +751,104 @@ describe("BugsnagClient", () => {
 
       await client.getProjects();
 
-      expect(mockServer.getCache).toHaveBeenCalled();
-      expect(mockCache.set).toHaveBeenCalledWith("bugsnag_org", mockOrg);
       expect(mockCache.set).toHaveBeenCalledWith(
-        "bugsnag_projects",
+        nsKey(client, "bugsnag_org"),
+        mockOrg,
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        nsKey(client, "bugsnag_projects"),
         mockProjects,
+      );
+    });
+
+    // Namespacing is the ONLY thing separating accounts in the shared cache
+    // (see the comment above getSharedCache in client.ts), so these cover the
+    // ways two accounts could end up on one key.
+    it("gives two accounts different cache keys even when they share a project API key", async () => {
+      // A BugSnag project API key arrives in a caller-supplied request header
+      // and ships inside customer apps, so it identifies nothing. If it were
+      // the namespace, anyone who knows a project key could read that
+      // project's org and full project list — every project's api_key with it.
+      const accountA = new BugsnagClient();
+      await accountA.configure({} as any, {
+        auth_token: "token-a",
+        project_api_key: "shared-project-key",
+      });
+      const accountB = new BugsnagClient();
+      await accountB.configure({} as any, {
+        auth_token: "token-b",
+        project_api_key: "shared-project-key",
+      });
+
+      for (const key of Object.values(cacheKeyNames)) {
+        expect(nsKey(accountA, key)).not.toEqual(nsKey(accountB, key));
+      }
+      expect(nsKey(accountA, "bugsnag_org")).not.toContain(
+        "shared-project-key",
+      );
+    });
+
+    it("does not let a caller-supplied project key reach another account's entry", async () => {
+      // Attacker holds their own valid token but sends the victim's project
+      // key as a header, hoping to land on the victim's cached entries.
+      const victim = new BugsnagClient();
+      await victim.configure({} as any, {
+        auth_token: "victim-token",
+        project_api_key: "victim-project-key",
+      });
+      const attacker = new BugsnagClient();
+      await attacker.configure({} as any, { auth_token: "attacker-token" });
+
+      const attackerKey = withRequestContext(
+        { headers: { "bugsnag-project-api-key": "victim-project-key" } } as any,
+        () => nsKey(attacker, "bugsnag_projects"),
+      );
+
+      expect(attackerKey).not.toEqual(nsKey(victim, "bugsnag_projects"));
+    });
+
+    it("bypasses the cache entirely when there is no credential to namespace by", async () => {
+      // Without a credential there is no identity, so an unauthenticated
+      // caller must not read from — or populate — a shared bucket.
+      const client = new BugsnagClient();
+      await client.configure({} as any, {} as any);
+
+      expect(nsKey(client, "bugsnag_org")).toBeNull();
+
+      mockCache.get.mockClear();
+      mockCache.set.mockClear();
+      mockCurrentUserAPI.listUserOrganizations.mockResolvedValueOnce({
+        body: [getMockOrganization("org-a", "Account A Org")],
+      });
+      await client.getOrganization();
+
+      expect(mockCache.get).not.toHaveBeenCalled();
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it("resolves each request to its own namespace from that request's auth header", async () => {
+      // Every session gets its own client (ClientRegistry.cloneClient), but in
+      // HTTP mode the auth header is resent per request and wins over the
+      // configured token — so the namespace must follow the header, not the
+      // instance field.
+      const client = new BugsnagClient();
+      await client.configure({} as any, { auth_token: "token-b" });
+
+      const orgA = getMockOrganization("org-a", "Account A Org");
+      const namespaceForA = createHash("sha256")
+        .update("token token-a")
+        .digest("hex")
+        .slice(0, 32);
+
+      mockCache.get.mockReturnValueOnce(orgA);
+      const resultForAccountA = await withRequestContext(
+        { headers: { "bugsnag-auth-token": "token-a" } } as any,
+        () => client.getOrganization(),
+      );
+
+      expect(resultForAccountA).toEqual(orgA);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        `tok:${namespaceForA}:bugsnag_org`,
       );
     });
   });
@@ -775,7 +889,9 @@ describe("BugsnagClient", () => {
 
         const result = await client.getProjects();
 
-        expect(mockCache.get).toHaveBeenCalledWith("bugsnag_projects");
+        expect(mockCache.get).toHaveBeenCalledWith(
+          nsKey(client, "bugsnag_projects"),
+        );
         expect(result).toEqual(mockProjects);
       });
 
@@ -793,7 +909,7 @@ describe("BugsnagClient", () => {
           "org-1",
         );
         expect(mockCache.set).toHaveBeenCalledWith(
-          "bugsnag_projects",
+          nsKey(client, "bugsnag_projects"),
           mockProjects,
         );
         expect(result).toEqual(mockProjects);
@@ -959,7 +1075,7 @@ describe("BugsnagClient", () => {
         });
 
         expect(mockCache.set).toHaveBeenCalledWith(
-          "bugsnag_current_project",
+          nsKey(clientWithNoApiKey, "bugsnag_current_project"),
           mockProject,
         );
 
@@ -2722,7 +2838,7 @@ describe("BugsnagClient", () => {
         ];
 
         mockCache.get.mockImplementation((key: string) => {
-          if (key === "bugsnag_current_project") {
+          if (key === nsKey(client, "bugsnag_current_project")) {
             return mockProject;
           }
           return undefined;
@@ -2743,7 +2859,7 @@ describe("BugsnagClient", () => {
           "proj-1",
         );
         expect(mockCache.set).toHaveBeenCalledWith(
-          "bugsnag_project_trace_fields",
+          nsKey(client, "bugsnag_project_trace_fields"),
           { "proj-1": mockTraceFields },
         );
         expect(result).toEqual({
@@ -2765,10 +2881,10 @@ describe("BugsnagClient", () => {
         const mockCachedFilters = { "proj-1": mockPerformanceFilters };
 
         mockCache.get.mockImplementation((key: string) => {
-          if (key === "bugsnag_project_trace_fields") {
+          if (key === nsKey(client, "bugsnag_project_trace_fields")) {
             return mockCachedFilters;
           }
-          if (key === "bugsnag_current_project") {
+          if (key === nsKey(client, "bugsnag_current_project")) {
             return mockProject;
           }
           return undefined;
@@ -2804,7 +2920,7 @@ describe("BugsnagClient", () => {
         ];
 
         mockCache.get.mockImplementation((key: string) => {
-          if (key === "bugsnag_projects") {
+          if (key === nsKey(clientWithNoApiKey, "bugsnag_projects")) {
             return mockProjects;
           }
           return undefined;
@@ -2827,7 +2943,7 @@ describe("BugsnagClient", () => {
           "proj-2",
         );
         expect(mockCache.set).toHaveBeenCalledWith(
-          "bugsnag_project_trace_fields",
+          nsKey(clientWithNoApiKey, "bugsnag_project_trace_fields"),
           {
             "proj-2": mockTraceFields,
           },

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { z } from "zod";
 import { CacheService } from "../common/cache";
 import { getUserAgent } from "../common/info";
@@ -53,16 +53,11 @@ const cacheKeys = {
   PROJECTS: "bugsnag_projects",
   PROJECT_EVENT_FIELDS: "bugsnag_project_event_fields",
   PROJECT_TRACE_FIELDS: "bugsnag_project_trace_fields",
-  CURRENT_PROJECT: "bugsnag_current_project",
 };
 
-// One cache store for the whole process, deliberately not one per session.
-// ClientRegistry.configure() hands every session its own BugsnagClient (see
-// cloneClient), so a per-session CacheService would be built on every connect
-// and never released: NodeCache schedules a self-rescheduling checkperiod
-// timer that keeps the instance reachable for the life of the process, and
-// CacheService exposes no close(). A single store also lets the same account
-// reconnect into a warm cache instead of starting cold every time.
+// Keep one Bugsnag cache for the process so reconnecting sessions from the
+// same account can reuse account-level data. Session state is kept on each
+// BugsnagClient instance instead of in this shared store.
 //
 // Isolation therefore comes entirely from the key, not from the store — see
 // cacheKey(), which namespaces every entry by a hash of the caller's
@@ -70,8 +65,7 @@ const cacheKeys = {
 // caller-controlled (a project API key arrives in a request header and is not
 // secret) may ever be used as the namespace on its own.
 //
-// Built lazily (not at module load) so it always picks up test doubles for
-// CacheService instead of racing module-evaluation order.
+// Built lazily so it picks up test doubles for CacheService.
 let sharedCacheInstance: CacheService | undefined;
 function getSharedCache(): CacheService {
   if (!sharedCacheInstance) {
@@ -108,7 +102,9 @@ export class BugsnagClient implements Client {
   private _errorsApi: ErrorAPI | undefined;
   private _projectApi: ProjectAPI | undefined;
   private _appEndpoint: string | undefined;
+  private _cacheAuthority: string | undefined;
   private _authToken?: string;
+  private _selectedProjects = new Map<string, Project>();
 
   get currentUserApi(): CurrentUserAPI {
     if (!this._currentUserApi) throw new Error("Client not configured");
@@ -130,32 +126,23 @@ export class BugsnagClient implements Client {
     return this._appEndpoint;
   }
 
-  // Resolves the project API key for the current call: the request's own
-  // header first, so a session that sends the key per request is honoured
-  // even after configure() ran without one, falling back to whatever was
-  // configured at session-start for stdio/single-session mode.
-  private getProjectApiKey(): string | null {
-    const contextHeader = getRequestHeader("Bugsnag-Project-Api-Key");
-    if (contextHeader) {
-      return Array.isArray(contextHeader) ? contextHeader[0] : contextHeader;
-    }
-    return this._projectApiKey ?? null;
-  }
-
-  // Namespaces the shared cache by the caller's credential, hashed so the raw
-  // token is never used as (or recoverable from) a cache key. The credential
-  // is the only value here that actually identifies an account: the project
-  // API key arrives in a caller-supplied request header and ships inside
-  // customer apps, so namespacing on it would let anyone who knows a project
-  // key read another account's cached org and project list.
+  // Namespaces the shared cache by API authority and caller credential, hashed
+  // so neither value is exposed in a cache key. Tokens are meaningful only
+  // within their issuing authority, so both values are required for isolation.
   // Returns null when there is no credential at all — callers then bypass the
   // cache rather than sharing a single anonymous bucket.
   private cacheNamespace(): string | null {
     const authToken = this.getAuthToken();
-    if (!authToken) {
+    if (!authToken || !this._cacheAuthority) {
       return null;
     }
-    return `tok:${createHash("sha256").update(authToken).digest("hex").slice(0, 32)}`;
+    const namespace = createHmac("sha256", "bugsnag-cache-ns")
+      .update(this._cacheAuthority)
+      .update("\0")
+      .update(authToken)
+      .digest("hex")
+      .slice(0, 32);
+    return `tok:${namespace}`;
   }
 
   private cacheKey(key: string): string | null {
@@ -163,26 +150,17 @@ export class BugsnagClient implements Client {
     if (!namespace) {
       return null;
     }
-    // CURRENT_PROJECT is the only project-scoped entry, so only it is keyed by
-    // project as well; keying the rest by project would fragment token-scoped
-    // data (org, project list, field definitions) for no benefit.
-    return key === cacheKeys.CURRENT_PROJECT
-      ? `${namespace}:${key}:${this.getProjectApiKey() ?? "-"}`
-      : `${namespace}:${key}`;
+    return `${namespace}:${key}`;
   }
 
   // Namespaced cache read. Returns undefined when there is no credential to
   // namespace by, so the caller falls through to the API.
-  // `caller` is the BugsnagClient method name — manual-testing aid only, so
-  // HIT/MISS lines show which method triggered them; remove along with
-  // logCache() once verification is done.
   private cacheGet<T>(key: string): T | undefined {
     const namespacedKey = this.cacheKey(key);
     if (!namespacedKey) {
       return undefined;
     }
-    const value = getSharedCache().get<T>(namespacedKey);
-    return value;
+    return getSharedCache().get<T>(namespacedKey);
   }
 
   // Namespaced cache write. No-ops when there is no credential to namespace
@@ -207,6 +185,11 @@ export class BugsnagClient implements Client {
   ): Promise<void> {
     this._appEndpoint = this.getEndpoint(
       "app",
+      config.project_api_key,
+      config.endpoint,
+    );
+    this._cacheAuthority = this.getEndpoint(
+      "api",
       config.project_api_key,
       config.endpoint,
     );
@@ -239,7 +222,10 @@ export class BugsnagClient implements Client {
     }
 
     // Fall back to configured token (needs prefix for Authorization header)
-    return this._authToken ? `token ${this._authToken}` : null;
+    if (this._authToken) {
+      return `token ${this._authToken}`;
+    }
+    return null;
   }
 
   getBearerToken(): string | null {
@@ -377,15 +363,16 @@ export class BugsnagClient implements Client {
   }
 
   async getCurrentProject(): Promise<Project | null> {
-    const projectApiKey = this.getProjectApiKey();
-    let project = this.cacheGet<Project>(cacheKeys.CURRENT_PROJECT) ?? null;
-    if (!project && projectApiKey) {
-      const projects = await this.getProjects();
-      project =
-        projects.find((p: Project) => p.api_key === projectApiKey) ?? null;
-      this.cacheSet(cacheKeys.CURRENT_PROJECT, project);
+    const projectApiKey = this._projectApiKey;
+    if (!projectApiKey) {
+      const namespace = this.cacheNamespace();
+      return namespace ? (this._selectedProjects.get(namespace) ?? null) : null;
     }
-    return project;
+
+    const projects = await this.getProjects();
+    return (
+      projects.find((project) => project.api_key === projectApiKey) ?? null
+    );
   }
 
   async getProjectEventFields(project: Project): Promise<EventField[]> {
@@ -453,8 +440,11 @@ export class BugsnagClient implements Client {
         throw new ToolError(`Project with ID ${projectId} not found.`);
       }
       // If this hasn't been configured at startup, set this to the current project for future tool calls
-      if (!this.getProjectApiKey()) {
-        this.cacheSet(cacheKeys.CURRENT_PROJECT, maybeProject);
+      if (!this._projectApiKey) {
+        const namespace = this.cacheNamespace();
+        if (namespace) {
+          this._selectedProjects.set(namespace, maybeProject);
+        }
       }
       return maybeProject;
     } else {

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -103,6 +103,7 @@ export class BugsnagClient implements Client {
   private _projectApi: ProjectAPI | undefined;
   private _appEndpoint: string | undefined;
   private _cacheAuthority: string | undefined;
+  private _endpoint: string | undefined;
   private _authToken?: string;
   private _selectedProjects = new Map<string, Project>();
 
@@ -133,11 +134,12 @@ export class BugsnagClient implements Client {
   // cache rather than sharing a single anonymous bucket.
   private cacheNamespace(): string | null {
     const authToken = this.getAuthToken();
-    if (!authToken || !this._cacheAuthority) {
+    if (!authToken) {
       return null;
     }
+    const cacheAuthority = this.getRequestApiAuthority();
     const namespace = createHmac("sha256", "bugsnag-cache-ns")
-      .update(this._cacheAuthority)
+      .update(cacheAuthority)
       .update("\0")
       .update(authToken)
       .digest("hex")
@@ -183,6 +185,7 @@ export class BugsnagClient implements Client {
     _server: SmartBearMcpServer,
     config: z.infer<typeof ConfigurationSchema>,
   ): Promise<void> {
+    this._endpoint = config.endpoint;
     this._appEndpoint = this.getEndpoint(
       "app",
       config.project_api_key,
@@ -198,6 +201,29 @@ export class BugsnagClient implements Client {
 
     // Initialize APIs even if auth_token is missing, to allow request-level auth
     await this.initializeApis(config);
+  }
+
+  getProjectApiKey(): string | undefined {
+    const contextHeader = getRequestHeader("Bugsnag-Project-Api-Key");
+    const requestProjectApiKey = Array.isArray(contextHeader)
+      ? contextHeader[0]
+      : contextHeader;
+
+    return requestProjectApiKey || this._projectApiKey;
+  }
+
+  private getRequestApiAuthority(): string {
+    const authority = this.getEndpoint(
+      "api",
+      this.getProjectApiKey(),
+      this._endpoint,
+    );
+    if (this._cacheAuthority && authority !== this._cacheAuthority) {
+      throw new ToolError(
+        `Bugsnag-Project-Api-Key cannot switch the API authority from ${this._cacheAuthority} to ${authority} within an active MCP session. Reconnect with the project key during session initialization.`,
+      );
+    }
+    return authority;
   }
 
   getAuthToken(): string | null {
@@ -363,7 +389,7 @@ export class BugsnagClient implements Client {
   }
 
   async getCurrentProject(): Promise<Project | null> {
-    const projectApiKey = this._projectApiKey;
+    const projectApiKey = this.getProjectApiKey();
     if (!projectApiKey) {
       const namespace = this.cacheNamespace();
       return namespace ? (this._selectedProjects.get(namespace) ?? null) : null;
@@ -439,8 +465,8 @@ export class BugsnagClient implements Client {
       if (!maybeProject) {
         throw new ToolError(`Project with ID ${projectId} not found.`);
       }
-      // If this hasn't been configured at startup, set this to the current project for future tool calls
-      if (!this._projectApiKey) {
+      // Without an effective project key, remember this selection for future calls.
+      if (!this.getProjectApiKey()) {
         const namespace = this.cacheNamespace();
         if (namespace) {
           this._selectedProjects.set(namespace, maybeProject);

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
-import  { CacheService } from "../common/cache";
+import { CacheService } from "../common/cache";
 import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
@@ -378,9 +378,7 @@ export class BugsnagClient implements Client {
 
   async getCurrentProject(): Promise<Project | null> {
     const projectApiKey = this.getProjectApiKey();
-    let project =
-      this.cacheGet<Project>(cacheKeys.CURRENT_PROJECT) ??
-      null;
+    let project = this.cacheGet<Project>(cacheKeys.CURRENT_PROJECT) ?? null;
     if (!project && projectApiKey) {
       const projects = await this.getProjects();
       project =
@@ -404,10 +402,7 @@ export class BugsnagClient implements Client {
           field.display_id && !EXCLUDED_EVENT_FIELDS.has(field.display_id),
       );
       projectFiltersCache[project.id] = filtersResponse;
-      this.cacheSet(
-        cacheKeys.PROJECT_EVENT_FIELDS,
-        projectFiltersCache,
-      );
+      this.cacheSet(cacheKeys.PROJECT_EVENT_FIELDS, projectFiltersCache);
     }
     return projectFiltersCache[project.id];
   }
@@ -422,10 +417,7 @@ export class BugsnagClient implements Client {
         await this.projectApi.listProjectTraceFields(project.id)
       ).body;
       projectFiltersCache[project.id] = filtersResponse;
-      this.cacheSet(
-        cacheKeys.PROJECT_TRACE_FIELDS,
-        projectFiltersCache,
-      );
+      this.cacheSet(cacheKeys.PROJECT_TRACE_FIELDS, projectFiltersCache);
     }
     return projectFiltersCache[project.id];
   }
@@ -462,10 +454,7 @@ export class BugsnagClient implements Client {
       }
       // If this hasn't been configured at startup, set this to the current project for future tool calls
       if (!this.getProjectApiKey()) {
-        this.cacheSet(
-          cacheKeys.CURRENT_PROJECT,
-          maybeProject,
-        );
+        this.cacheSet(cacheKeys.CURRENT_PROJECT, maybeProject);
       }
       return maybeProject;
     } else {

--- a/src/bugsnag/client.ts
+++ b/src/bugsnag/client.ts
@@ -1,5 +1,6 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
-import type { CacheService } from "../common/cache";
+import  { CacheService } from "../common/cache";
 import { getUserAgent } from "../common/info";
 import { getRequestHeader } from "../common/request-context";
 import type { SmartBearMcpServer } from "../common/server";
@@ -55,6 +56,30 @@ const cacheKeys = {
   CURRENT_PROJECT: "bugsnag_current_project",
 };
 
+// One cache store for the whole process, deliberately not one per session.
+// ClientRegistry.configure() hands every session its own BugsnagClient (see
+// cloneClient), so a per-session CacheService would be built on every connect
+// and never released: NodeCache schedules a self-rescheduling checkperiod
+// timer that keeps the instance reachable for the life of the process, and
+// CacheService exposes no close(). A single store also lets the same account
+// reconnect into a warm cache instead of starting cold every time.
+//
+// Isolation therefore comes entirely from the key, not from the store — see
+// cacheKey(), which namespaces every entry by a hash of the caller's
+// credential. That is the ONLY boundary between accounts here, so nothing
+// caller-controlled (a project API key arrives in a request header and is not
+// secret) may ever be used as the namespace on its own.
+//
+// Built lazily (not at module load) so it always picks up test doubles for
+// CacheService instead of racing module-evaluation order.
+let sharedCacheInstance: CacheService | undefined;
+function getSharedCache(): CacheService {
+  if (!sharedCacheInstance) {
+    sharedCacheInstance = new CacheService();
+  }
+  return sharedCacheInstance;
+}
+
 // Exclude certain event fields from the project event filters to improve agent usage
 const EXCLUDED_EVENT_FIELDS = new Set([
   "search", // This is searches multiple fields and is more a convenience for humans, we're removing to avoid over-matching
@@ -77,7 +102,6 @@ const ConfigurationSchema = z.object({
 });
 
 export class BugsnagClient implements Client {
-  private cache?: CacheService;
   private _projectApiKey?: string;
   private _isConfigured: boolean = false;
   private _currentUserApi: CurrentUserAPI | undefined;
@@ -106,6 +130,71 @@ export class BugsnagClient implements Client {
     return this._appEndpoint;
   }
 
+  // Resolves the project API key for the current call: the request's own
+  // header first, so a session that sends the key per request is honoured
+  // even after configure() ran without one, falling back to whatever was
+  // configured at session-start for stdio/single-session mode.
+  private getProjectApiKey(): string | null {
+    const contextHeader = getRequestHeader("Bugsnag-Project-Api-Key");
+    if (contextHeader) {
+      return Array.isArray(contextHeader) ? contextHeader[0] : contextHeader;
+    }
+    return this._projectApiKey ?? null;
+  }
+
+  // Namespaces the shared cache by the caller's credential, hashed so the raw
+  // token is never used as (or recoverable from) a cache key. The credential
+  // is the only value here that actually identifies an account: the project
+  // API key arrives in a caller-supplied request header and ships inside
+  // customer apps, so namespacing on it would let anyone who knows a project
+  // key read another account's cached org and project list.
+  // Returns null when there is no credential at all — callers then bypass the
+  // cache rather than sharing a single anonymous bucket.
+  private cacheNamespace(): string | null {
+    const authToken = this.getAuthToken();
+    if (!authToken) {
+      return null;
+    }
+    return `tok:${createHash("sha256").update(authToken).digest("hex").slice(0, 32)}`;
+  }
+
+  private cacheKey(key: string): string | null {
+    const namespace = this.cacheNamespace();
+    if (!namespace) {
+      return null;
+    }
+    // CURRENT_PROJECT is the only project-scoped entry, so only it is keyed by
+    // project as well; keying the rest by project would fragment token-scoped
+    // data (org, project list, field definitions) for no benefit.
+    return key === cacheKeys.CURRENT_PROJECT
+      ? `${namespace}:${key}:${this.getProjectApiKey() ?? "-"}`
+      : `${namespace}:${key}`;
+  }
+
+  // Namespaced cache read. Returns undefined when there is no credential to
+  // namespace by, so the caller falls through to the API.
+  // `caller` is the BugsnagClient method name — manual-testing aid only, so
+  // HIT/MISS lines show which method triggered them; remove along with
+  // logCache() once verification is done.
+  private cacheGet<T>(key: string): T | undefined {
+    const namespacedKey = this.cacheKey(key);
+    if (!namespacedKey) {
+      return undefined;
+    }
+    const value = getSharedCache().get<T>(namespacedKey);
+    return value;
+  }
+
+  // Namespaced cache write. No-ops when there is no credential to namespace
+  // by, so an unauthenticated caller can never populate a shared entry.
+  private cacheSet<T>(key: string, value: T): void {
+    const namespacedKey = this.cacheKey(key);
+    if (!namespacedKey) {
+      return;
+    }
+    getSharedCache().set(namespacedKey, value);
+  }
+
   name = "BugSnag";
   capabilityPrefix = "bugsnag";
   configPrefix = "Bugsnag";
@@ -113,11 +202,9 @@ export class BugsnagClient implements Client {
   defaultToolsets = ["Projects"];
 
   async configure(
-    server: SmartBearMcpServer,
+    _server: SmartBearMcpServer,
     config: z.infer<typeof ConfigurationSchema>,
   ): Promise<void> {
-    this.cache = server.getCache();
-
     this._appEndpoint = this.getEndpoint(
       "app",
       config.project_api_key,
@@ -254,7 +341,7 @@ export class BugsnagClient implements Client {
   }
 
   async getOrganization(): Promise<Organization> {
-    let org = this.cache?.get<Organization>(cacheKeys.ORG);
+    let org = this.cacheGet<Organization>(cacheKeys.ORG);
     if (!org) {
       const response = await this.currentUserApi.listUserOrganizations();
       const orgs = response.body;
@@ -262,7 +349,7 @@ export class BugsnagClient implements Client {
         throw new Error("No organizations found for the current user.");
       }
       org = orgs[0];
-      this.cache?.set(cacheKeys.ORG, org);
+      this.cacheSet(cacheKeys.ORG, org);
     }
     return org;
   }
@@ -272,14 +359,14 @@ export class BugsnagClient implements Client {
   // stores them in the cache for future use.
   // It throws an error if no organizations are found in the cache.
   async getProjects(): Promise<Project[]> {
-    let projects = this.cache?.get<Project[]>(cacheKeys.PROJECTS);
+    let projects = this.cacheGet<Project[]>(cacheKeys.PROJECTS);
     if (!projects) {
       const org = await this.getOrganization();
       const response = await this.currentUserApi.getOrganizationProjects(
         org.id,
       );
       projects = response.body;
-      this.cache?.set(cacheKeys.PROJECTS, projects);
+      this.cacheSet(cacheKeys.PROJECTS, projects);
     }
     return projects;
   }
@@ -290,20 +377,22 @@ export class BugsnagClient implements Client {
   }
 
   async getCurrentProject(): Promise<Project | null> {
-    let project = this.cache?.get<Project>(cacheKeys.CURRENT_PROJECT) ?? null;
-    if (!project && this._projectApiKey) {
+    const projectApiKey = this.getProjectApiKey();
+    let project =
+      this.cacheGet<Project>(cacheKeys.CURRENT_PROJECT) ??
+      null;
+    if (!project && projectApiKey) {
       const projects = await this.getProjects();
       project =
-        projects.find((p: Project) => p.api_key === this._projectApiKey) ??
-        null;
-      this.cache?.set(cacheKeys.CURRENT_PROJECT, project);
+        projects.find((p: Project) => p.api_key === projectApiKey) ?? null;
+      this.cacheSet(cacheKeys.CURRENT_PROJECT, project);
     }
     return project;
   }
 
   async getProjectEventFields(project: Project): Promise<EventField[]> {
     const projectFiltersCache =
-      this.cache?.get<Record<string, EventField[]>>(
+      this.cacheGet<Record<string, EventField[]>>(
         cacheKeys.PROJECT_EVENT_FIELDS,
       ) || {};
     if (!projectFiltersCache[project.id]) {
@@ -315,14 +404,17 @@ export class BugsnagClient implements Client {
           field.display_id && !EXCLUDED_EVENT_FIELDS.has(field.display_id),
       );
       projectFiltersCache[project.id] = filtersResponse;
-      this.cache?.set(cacheKeys.PROJECT_EVENT_FIELDS, projectFiltersCache);
+      this.cacheSet(
+        cacheKeys.PROJECT_EVENT_FIELDS,
+        projectFiltersCache,
+      );
     }
     return projectFiltersCache[project.id];
   }
 
   async getProjectTraceFields(project: Project): Promise<TraceField[]> {
     const projectFiltersCache =
-      this.cache?.get<Record<string, TraceField[]>>(
+      this.cacheGet<Record<string, TraceField[]>>(
         cacheKeys.PROJECT_TRACE_FIELDS,
       ) || {};
     if (!projectFiltersCache[project.id]) {
@@ -330,7 +422,10 @@ export class BugsnagClient implements Client {
         await this.projectApi.listProjectTraceFields(project.id)
       ).body;
       projectFiltersCache[project.id] = filtersResponse;
-      this.cache?.set(cacheKeys.PROJECT_TRACE_FIELDS, projectFiltersCache);
+      this.cacheSet(
+        cacheKeys.PROJECT_TRACE_FIELDS,
+        projectFiltersCache,
+      );
     }
     return projectFiltersCache[project.id];
   }
@@ -366,8 +461,11 @@ export class BugsnagClient implements Client {
         throw new ToolError(`Project with ID ${projectId} not found.`);
       }
       // If this hasn't been configured at startup, set this to the current project for future tool calls
-      if (!this._projectApiKey) {
-        this.cache?.set(cacheKeys.CURRENT_PROJECT, maybeProject);
+      if (!this.getProjectApiKey()) {
+        this.cacheSet(
+          cacheKeys.CURRENT_PROJECT,
+          maybeProject,
+        );
       }
       return maybeProject;
     } else {


### PR DESCRIPTION
## Goal

Prevent cross-account data leakage in Bugsnag caching by removing per-session cache reliance and ensuring cache entries are isolated by caller identity.

## Design

Use a single process-wide cache for the Bugsnag client, but namespace every cache key with a hash of the authenticated caller’s token. This keeps cache reuse efficient while preventing one account from reading another account’s cached org, project, or field data. The implementation also prefers the current request’s auth header when present, so HTTP requests resolve the correct namespace per call.

## Changeset

- Replaced `server.getCache()` usage with a shared module-level `CacheService`.
- Added lazy initialization for the shared cache instance.
- Added `getProjectApiKey()`, which resolves the Bugsnag project API key from the request header first, then falls back to the configured value.
- Added credential-based cache namespacing using a SHA-256 hash of the auth token.
- Updated cache reads/writes in:
  - `getOrganization()`
  - `getProjects()`
  - `getCurrentProject()`
  - `getProjectEventFields()`
  - `getProjectTraceFields()`
  - project lookup/write paths
- Added safeguards so unauthenticated callers bypass the shared cache entirely.
- Expanded tests to cover:
  - shared cache behavior
  - cache key namespacing per account
  - request-header-driven namespace resolution
  - no-cache behavior without credentials
  - prevention of cross-account key collision

## Testing

- I have tested with : unit testcases
- Verified cache keys are namespaced instead of using raw logical keys.
- Added isolation tests for multiple accounts and request-scoped auth headers.
- Added coverage for unauthenticated requests bypassing cache access.