### PR TITLE
fix(swagger): preserve API visibility on create_or_update_api update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [Swagger] `create_or_update_api` tool: no longer forces private visibility when updating an existing API. Visibility is now set to private only on creation; updates preserve the API's current visibility.
+
 ### Changed
 
 - [Swagger] `create_api_from_prompt` tool: now create-only - fails with a conflict error instead of overwriting when the generated API version already exists. Marked as non-destructive.

--- a/docs/products/SmartBear MCP Server/swagger-studio-integration.md
+++ b/docs/products/SmartBear MCP Server/swagger-studio-integration.md
@@ -52,7 +52,7 @@ The Swagger Studio client provides comprehensive API and Domain management capab
 | --- | --- | --- | --- |
 | `owner` | Organization name (owner of the API) | string | Yes |
 | `apiName` | API name. If an API with this name already exists under the specified owner, it will be updated. | string | Yes |
-| `definition` | API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. API is created with fixed values: version 1.0.0, private visibility, automock disabled, and no project assignment. | string | Yes |
+| `definition` | API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. On create, fixed values are used: version 1.0.0, private visibility, automock disabled, and no project assignment. On update, the API's existing visibility is preserved. | string | Yes |
 
 #### `scan_api_standardization`
 

--- a/src/common/__snapshots__/server-definitions.test.ts.snap
+++ b/src/common/__snapshots__/server-definitions.test.ts.snap
@@ -11936,7 +11936,7 @@ None",
 **Parameters:**
 - owner (string) *required*: Organization name (owner of the API)
 - apiName (string) *required*: API name
-- definition (string) *required*: API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. API is created with fixed values: version 1.0.0, private visibility, automock disabled, and no project assignment.",
+- definition (string) *required*: API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. On create, fixed values are used: version 1.0.0, private visibility, automock disabled, and no project assignment. On update, the API's existing visibility is preserved.",
     "inputSchema": [
       "apiName",
       "definition",

--- a/src/swagger/api.test.ts
+++ b/src/swagger/api.test.ts
@@ -1634,6 +1634,7 @@ describe("SwaggerAPI", () => {
         `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore?isPrivate=true`,
         expect.objectContaining({ method: "POST" }),
       );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(result.operation).toBe("create");
     });
 
@@ -1661,6 +1662,7 @@ describe("SwaggerAPI", () => {
         `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore`,
         expect.objectContaining({ method: "POST" }),
       );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(result.operation).toBe("update");
     });
   });

--- a/src/swagger/api.test.ts
+++ b/src/swagger/api.test.ts
@@ -1600,6 +1600,71 @@ describe("SwaggerAPI", () => {
     });
   });
 
+  describe("createOrUpdateApi", () => {
+    const owner = "orgname";
+    const apiName = "petstore";
+    const definition = [
+      "openapi: 3.0.0",
+      "info:",
+      "  title: Pets",
+      "  version: 1.0.0",
+      "paths: {}",
+      "",
+    ].join("\n");
+
+    it("sends isPrivate=true when creating a new API", async () => {
+      fetchMock.mockResponseOnce("", { status: 404 }).mockResponseOnce("", {
+        status: 201,
+        headers: { "X-Version": "1.0.0" },
+      });
+
+      const result = await api.createOrUpdateApi({
+        owner,
+        apiName,
+        definition,
+      });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore`,
+        expect.objectContaining({ method: "GET" }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore?isPrivate=true`,
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(result.operation).toBe("create");
+    });
+
+    it("omits isPrivate when updating an existing API, preserving visibility", async () => {
+      fetchMock.mockResponseOnce("", { status: 200 }).mockResponseOnce("", {
+        status: 200,
+        headers: { "X-Version": "1.0.0" },
+      });
+
+      const result = await api.createOrUpdateApi({
+        owner,
+        apiName,
+        definition,
+      });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore`,
+        expect.objectContaining({ method: "GET" }),
+      );
+      // Visibility must not be sent on update, otherwise an existing public
+      // API would silently be flipped to private.
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        `${DUMMY_REGISTRY_BASE_PATH}/apis/orgname/petstore`,
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(result.operation).toBe("update");
+    });
+  });
+
   describe("patchApi", () => {
     const owner = "orgname";
     const apiName = "petstore";

--- a/src/swagger/client/api.ts
+++ b/src/swagger/client/api.ts
@@ -1271,8 +1271,38 @@ export class SwaggerAPI {
    * @returns Created or updated API metadata with URL. HTTP 201 indicates creation, HTTP 200 indicates update
    */
   async createOrUpdateApi(params: CreateApiParams): Promise<CreateApiResponse> {
-    // Fixed values: visibility=private, automock=false, version=1.0.0
-    return this.saveApiDefinition(params, { isPrivate: true });
+    // New API: fixed values - visibility=private, automock=false, version=1.0.0
+    // Existing API: isPrivate is omitted so the registry preserves current visibility
+    const exists = await this.apiExists({
+      owner: params.owner,
+      apiName: params.apiName,
+    });
+    return this.saveApiDefinition(params, exists ? {} : { isPrivate: true });
+  }
+
+  /**
+   * Check whether an API (any version) already exists for the given owner/name.
+   */
+  private async apiExists({
+    owner,
+    apiName,
+  }: {
+    owner: string;
+    apiName: string;
+  }): Promise<boolean> {
+    const url = `${this.config.registryBasePath}/apis/${encodeURIComponent(owner)}/${encodeURIComponent(apiName)}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.headers,
+    });
+    if (response.status === 404) return false;
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new ToolError(
+        `SwaggerHub Registry API apiExists failed - status: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}. owner=${owner}, apiName=${apiName}`,
+      );
+    }
+    return true;
   }
 
   /**

--- a/src/swagger/client/registry-types.ts
+++ b/src/swagger/client/registry-types.ts
@@ -76,7 +76,7 @@ export const CreateApiParamsSchema = z.object({
   definition: z
     .string()
     .describe(
-      "API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. API is created with fixed values: version 1.0.0, private visibility, automock disabled, and no project assignment.",
+      "API definition content (OpenAPI/AsyncAPI specification in JSON or YAML format). Format is automatically detected. On create, fixed values are used: version 1.0.0, private visibility, automock disabled, and no project assignment. On update, the API's existing visibility is preserved.",
     ),
 });
 


### PR DESCRIPTION
This pull request updates the behavior of the Swagger `create_or_update_api` tool to ensure that API visibility is only set to private when creating a new API, and that the existing visibility is preserved during updates. The changes include code updates, improved documentation, and new tests to verify the correct behavior.