### PR TITLE
feat(functional-testing): Adjust listing tools to return test/suite definition urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Common] Removed support for the MCP `sampling` capability, which was deprecated in the 2026-07-28 MCP specification revision ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)). The server no longer negotiates the `sampling` client capability or sends `sampling/createMessage` requests. [#685](https://github.com/SmartBear/smartbear-mcp/pull/685)
 - [PactFlow] The `generate`/`review` tools' OpenAPI matcher recommendation flow no longer relies on MCP sampling: when an OpenAPI document is provided without a `matcher`, the tool now always returns a prompt for the host AI to execute directly and resubmit with a single recommended matcher, rather than a list of up to 5 recommendations to choose from via elicitation. [#685](https://github.com/SmartBear/smartbear-mcp/pull/685)
+- [Swagger] Updated the `list_tests` tool to return test definition `url` for each found test. Updated the `list_suites` tool to return the Suite definition `url` for each found Suite.
 
 ## [0.37.0] - 2026-08-20
 - [QMetry]: Added Test Case, Test Suite, Issue module, Create/Update UDF capability Added. [#666](https://github.com/SmartBear/smartbear-mcp/pull/666)

--- a/src/swagger/client/functional-testing-api.ts
+++ b/src/swagger/client/functional-testing-api.ts
@@ -12,6 +12,7 @@ import type {
   ListFunctionalTestingSuiteExecutionsParams,
   ListSuiteExecutionsResponse,
   ListSuitesResponse,
+  ListTestsResponse,
   RunFunctionalTestingSuiteParams,
   RunFunctionalTestingTestParams,
   TestRunHistoryResponse,
@@ -119,7 +120,7 @@ export class FunctionalTestingAPI {
     return response.json();
   }
 
-  async listTests(): Promise<unknown> {
+  async listTests(): Promise<ListTestsResponse> {
     const response = await this.ftFetch(
       `tests`,
       {

--- a/src/swagger/client/functional-testing-types.ts
+++ b/src/swagger/client/functional-testing-types.ts
@@ -183,6 +183,19 @@ export interface ListSuiteExecutionsResponse {
   };
 }
 
+export interface FunctionalTestingTestSummary {
+  id: number;
+  name: string;
+  created: number;
+  tags: string[];
+  folders: string[];
+  url: string;
+}
+
+export interface ListTestsResponse {
+  tests: FunctionalTestingTestSummary[];
+}
+
 export interface Suite {
   id: string;
   accountId: number;
@@ -190,6 +203,7 @@ export interface Suite {
   slug: string;
   created: number;
   numTestInstances: number;
+  url: string;
 }
 
 export interface ListSuitesResponse {

--- a/src/swagger/functional-testing/functional-testing-api.test.ts
+++ b/src/swagger/functional-testing/functional-testing-api.test.ts
@@ -9,10 +9,26 @@ import {
 const fetchMock = createFetchMock(vi);
 fetchMock.enableMocks();
 
-const testsMock = [
-  { id: "test-1", name: "Login Test" },
-  { id: "test-2", name: "Checkout Test" },
-];
+const testsMock = {
+  tests: [
+    {
+      id: 1,
+      name: "Login Test",
+      created: 1719400000000,
+      tags: [],
+      folders: [],
+      url: "https://app.reflect.run/tests/1/definition?accountId=42",
+    },
+    {
+      id: 2,
+      name: "Checkout Test",
+      created: 1719500000000,
+      tags: [],
+      folders: [],
+      url: "https://app.reflect.run/tests/2/definition?accountId=42",
+    },
+  ],
+};
 
 const UNREACHABLE_MESSAGE =
   "Swagger Functional Testing service is currently unreachable. Retry after a moment.";
@@ -29,6 +45,7 @@ const suitesResponseMock = {
       slug: "smoke-suite",
       created: 1719400000000,
       numTestInstances: 3,
+      url: "https://app.reflect.run/suites/smoke-suite?accountId=42",
     },
     {
       id: "suite-2",
@@ -37,6 +54,7 @@ const suitesResponseMock = {
       slug: "regression-suite",
       created: 1719500000000,
       numTestInstances: 12,
+      url: "https://app.reflect.run/suites/regression-suite?accountId=42",
     },
   ],
   stats: {
@@ -362,12 +380,12 @@ describe("FunctionalTestingAPI", () => {
       expect(result).toEqual(testsMock);
     });
 
-    it("should return empty array when no tests exist", async () => {
-      fetchMock.mockResponseOnce(JSON.stringify([]));
+    it("should return empty tests list when no tests exist", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ tests: [] }));
 
       const result = await api.listTests();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ tests: [] });
     });
 
     it("should throw ToolError on HTTP error", async () => {


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Extend SFT test listing tool response to also include, for each test an url to it's definition.
Same for suite listing tool - url for each Suite definition.

Related changes on API layer: [runreflect/aqa/pull/12988](https://github.com/runreflect/aqa/pull/12988) (already merged)

## Testing

- [x] Verified no regression on existing SFT tools
- [x] Verified no regression for Swagger base tools
- [x] Verified that `list_tests` tool returns working url to test definition for each found test
- [x] Verified that `list_suites` tool returns working url to suite definition for each found suite
- [x] Verified both definitions contains `accountId` param and switching works properly
