### PR TITLE
release: v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.38.0] - 2026-08-27
+
 - [Bugsnag] Use a single process-wide `CacheService` and namespace every cache key with a SHA-256 hash of the authenticated caller's token. [#679](https://github.com/SmartBear/smartbear-mcp/pull/679)
 - [Bugsnag] Prefer the request auth header when resolving the cache namespace via `getAuthToken()` so per-request auth is honored.
 - [Bugsnag] Ensure unauthenticated callers bypass the shared cache to avoid exposing cached data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartbear/mcp",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartbear/mcp",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
## Goal
Prepare the SmartBear MCP repository for the v0.38.0 release by updating the package version and finalizing the unreleased changelog entries.
## Design
Used the repository's existing npm run bump release process to keep the package metadata, lockfile, and changelog version synchronized.
## Changeset
- Updated the package version from 0.37.0 to 0.38.0 in package.json.
- Updated the corresponding version metadata in package-lock.json.
- Added the 0.38.0 release heading and release date to CHANGELOG.md.
- Moved the existing unreleased changes under the 0.38.0 release.
## Testing
No application behavior was changed. Verified that the generated release commit updates only package.json, package-lock.json, and CHANGELOG.md.
