### PR TITLE
feat(common): extract per-request client metadata for modern-era clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Common] Rewrote the transport bootstrap to serve both the 2025-11-25 and 2026-07-28 (RC) MCP protocol revisions from a single deployment, on stdio (`serveStdio`, `legacy: "serve"`) and HTTP (per-request routing between the existing sessionful wiring and a new stateless `createMcpHandler` leg). Existing 2025-11-25 clients are unaffected. [#687](https://github.com/SmartBear/smartbear-mcp/pull/687)
+- [Common] Modern-era (2026-07-28) requests now carry client identity: the protocol version, client info and capabilities are extracted from each request's `_meta` envelope into the request context, so error reports and downstream `User-Agent` headers are attributed for clients that no longer send an `initialize` handshake. Legacy per-connection capture is unchanged.
 - [PactFlow] Refactored the internal PactFlow client from a monolithic 2,400-line class into six domain API classes (`PacticipantApi`, `EnvironmentApi`, `ContractApi`, `WebhookApi`, `AdminApi`, `AIApi`) backed by a shared `HttpClient`. This is an internal implementation change; all tool behaviour and the external `PactflowClient` interface are unchanged. [#686](https://github.com/SmartBear/smartbear-mcp/pull/686)
 
 ## [0.38.0] - 2026-08-27

--- a/src/common/initialize.test.ts
+++ b/src/common/initialize.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleInitializeMessage } from "./initialize";
+import {
+  extractModernClientMeta,
+  handleInitializeMessage,
+} from "./initialize";
 import type { SmartBearMcpServer } from "./server";
+
+const PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion";
+const CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo";
+const CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities";
+
+/** A modern-era request envelope as sent by a 2026-07-28 client. */
+function modernMessage(
+  meta: Record<string, unknown> = {
+    [PROTOCOL_VERSION_KEY]: "2026-07-28",
+    [CLIENT_INFO_KEY]: { name: "Modern Client", version: "2.0.0" },
+    [CLIENT_CAPABILITIES_KEY]: {},
+  },
+) {
+  return { method: "tools/list", params: { _meta: meta } };
+}
 
 function fakeServer() {
   return {
@@ -115,5 +133,69 @@ describe("handleInitializeMessage", () => {
       version: "1.2.3",
     });
     expect(server.setElicitationSupported).not.toHaveBeenCalled();
+  });
+
+  it("ignores a message carrying a modern protocol claim", () => {
+    const server = fakeServer();
+
+    handleInitializeMessage(server, {
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        clientInfo: { name: "Confused Client", version: "1.0.0" },
+        _meta: { [PROTOCOL_VERSION_KEY]: "2026-07-28" },
+      },
+    });
+
+    expect(server.setClientInfo).not.toHaveBeenCalled();
+    expect(server.setMcpClientIdentity).not.toHaveBeenCalled();
+  });
+});
+
+describe("extractModernClientMeta", () => {
+  it("lifts protocolVersion, clientInfo and capabilities from _meta", () => {
+    expect(extractModernClientMeta(modernMessage())).toEqual({
+      protocolVersion: "2026-07-28",
+      clientInfo: { name: "Modern Client", version: "2.0.0" },
+      clientCapabilities: {},
+    });
+  });
+
+  it("returns undefined for legacy messages carrying no _meta", () => {
+    expect(
+      extractModernClientMeta({
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          clientInfo: { name: "Claude Code", version: "1.0.0" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-object messages", () => {
+    expect(extractModernClientMeta(null)).toBeUndefined();
+    expect(extractModernClientMeta("tools/list")).toBeUndefined();
+    expect(extractModernClientMeta(42)).toBeUndefined();
+  });
+
+  it("returns undefined when _meta carries no protocol claim", () => {
+    expect(
+      extractModernClientMeta(
+        modernMessage({ [CLIENT_INFO_KEY]: { name: "x", version: "1" } }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("tolerates a protocol claim with no clientInfo or capabilities", () => {
+    expect(
+      extractModernClientMeta(
+        modernMessage({ [PROTOCOL_VERSION_KEY]: "2026-07-28" }),
+      ),
+    ).toEqual({
+      protocolVersion: "2026-07-28",
+      clientInfo: undefined,
+      clientCapabilities: undefined,
+    });
   });
 });

--- a/src/common/initialize.ts
+++ b/src/common/initialize.ts
@@ -1,10 +1,59 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+} from "@modelcontextprotocol/server";
 import { setProcessClientIdentity, toClientIdentity } from "./client-identity";
+import type { ModernClientMeta } from "./request-context";
 import type { SmartBearMcpServer } from "./server";
 import type { ClientInfo } from "./types";
 
 /**
+ * Lift the modern-era (2026-07-28) client metadata out of a request's `_meta`
+ * envelope.
+ *
+ * The modern era has no `initialize` handshake and no session, so a client
+ * restates who it is and what it supports on every request (SEP-2575). This is
+ * the modern counterpart of {@link handleInitializeMessage}: same information,
+ * scoped to one request instead of one connection.
+ *
+ * Returns `undefined` for anything without a modern protocol claim — which is
+ * how legacy messages are told apart from modern ones.
+ */
+export function extractModernClientMeta(
+  message: unknown,
+): ModernClientMeta | undefined {
+  if (typeof message !== "object" || message === null) {
+    return undefined;
+  }
+
+  const params = (message as { params?: Record<string, unknown> }).params;
+  const meta = params?._meta as Record<string, unknown> | undefined;
+
+  const protocolVersion = meta?.[PROTOCOL_VERSION_META_KEY];
+  if (typeof protocolVersion !== "string") {
+    // No protocol claim: legacy traffic, or a message the modern era rejects
+    // in its own validation. Either way there is nothing to lift here.
+    return undefined;
+  }
+
+  return {
+    protocolVersion,
+    clientInfo: meta?.[CLIENT_INFO_META_KEY] as ClientInfo | undefined,
+    clientCapabilities: meta?.[CLIENT_CAPABILITIES_META_KEY] as
+      | Record<string, unknown>
+      | undefined,
+  };
+}
+
+/**
  * Applies the client info and capability flags carried by an MCP `initialize`
  * request onto the given server instance. No-ops for any other message.
+ *
+ * Legacy (2025-era) path only: `initialize` exists solely in that era, and the
+ * per-connection state it captures is meaningful only there. Modern requests
+ * carry the same information per request instead — see
+ * {@link extractModernClientMeta}.
  *
  * clientInfo has been a required field of `initialize` params since the
  * original 2024-11-05 MCP spec version, so it is captured unconditionally.
@@ -24,6 +73,12 @@ export function handleInitializeMessage(
     !("method" in message) ||
     (message as { method: unknown }).method !== "initialize"
   ) {
+    return;
+  }
+
+  // Belt-and-braces era gate: a message carrying a modern protocol claim is
+  // never legacy, even if it somehow also names `initialize`.
+  if (extractModernClientMeta(message)) {
     return;
   }
 

--- a/src/common/request-context.test.ts
+++ b/src/common/request-context.test.ts
@@ -1,10 +1,14 @@
 import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
 import {
+  getRequestClientMeta,
   getRequestContext,
+  getRequestEra,
   getRequestHeader,
   requestContextStorage,
+  setModernRequestClient,
   withRequestContext,
+  withRequestHeaders,
 } from "./request-context";
 
 function fakeRequest(
@@ -80,6 +84,68 @@ describe("request-context", () => {
         getRequestHeader("Non-Existent"),
       );
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("setModernRequestClient", () => {
+    it("records era and client metadata for the current request", () => {
+      withRequestHeaders({}, () => {
+        setModernRequestClient({
+          protocolVersion: "2026-07-28",
+          clientInfo: { name: "Modern Client", version: "2.0.0" },
+          clientCapabilities: { elicitation: {} },
+        });
+
+        expect(getRequestEra()).toBe("modern");
+        expect(getRequestClientMeta()).toEqual({
+          protocolVersion: "2026-07-28",
+          clientInfo: { name: "Modern Client", version: "2.0.0" },
+          clientCapabilities: { elicitation: {} },
+        });
+      });
+    });
+
+    it("derives the client identity used for downstream attribution", () => {
+      withRequestHeaders({}, () => {
+        setModernRequestClient({
+          protocolVersion: "2026-07-28",
+          clientInfo: { name: "Modern Client", version: "2.0.0" },
+        });
+
+        expect(getRequestContext()?.mcpClient).toEqual({
+          name: "Modern Client",
+          version: "2.0.0",
+          protocolVersion: "2026-07-28",
+        });
+      });
+    });
+
+    it("does not leak between requests", () => {
+      withRequestHeaders({}, () => {
+        setModernRequestClient({ protocolVersion: "2026-07-28" });
+        expect(getRequestEra()).toBe("modern");
+      });
+
+      withRequestHeaders({}, () => {
+        expect(getRequestEra()).toBe("legacy");
+        expect(getRequestClientMeta()).toBeUndefined();
+      });
+    });
+
+    it("is a no-op outside a request context", () => {
+      expect(() =>
+        setModernRequestClient({ protocolVersion: "2026-07-28" }),
+      ).not.toThrow();
+      expect(getRequestClientMeta()).toBeUndefined();
+    });
+  });
+
+  describe("getRequestEra", () => {
+    it("defaults to legacy so untagged paths keep 2025-era behavior", () => {
+      expect(getRequestEra()).toBe("legacy");
+      withRequestHeaders({ authorization: "Bearer abc" }, () => {
+        expect(getRequestEra()).toBe("legacy");
+      });
     });
   });
 

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -1,6 +1,32 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { IncomingMessage } from "node:http";
 import type { McpClientIdentity } from "./client-identity";
+import type { ClientInfo } from "./types";
+
+/**
+ * The protocol era serving the current request.
+ *
+ * - `legacy` — 2025-era: the client introduced itself once via `initialize`
+ *   and per-connection state lives on the server instance.
+ * - `modern` — 2026-07-28: no handshake and no session; the client restates
+ *   its identity and capabilities in the `_meta` envelope of every request,
+ *   so that state lives here, for the duration of one request only.
+ */
+export type ProtocolEra = "legacy" | "modern";
+
+/**
+ * Client metadata carried by the `_meta` envelope of a single modern-era
+ * request (SEP-2575). The legacy equivalents are captured once per connection
+ * from `initialize` and held on the server instance instead.
+ */
+export interface ModernClientMeta {
+  /** Protocol revision claimed by this request, e.g. `2026-07-28`. */
+  protocolVersion?: string;
+  /** Self-reported client name/version, as `initialize` used to carry. */
+  clientInfo?: ClientInfo;
+  /** Capabilities this client declares for this request. */
+  clientCapabilities?: Record<string, unknown>;
+}
 
 // Storage for pre-request data that can be retrieved from a tool to prevent caching as part of the server instance in a session.
 // For example, the auth token.
@@ -9,6 +35,11 @@ export interface RequestContext {
   // Identity of the MCP client for this session, captured at `initialize`.
   // Used to forward client attribution to downstream APIs (User-Agent).
   mcpClient?: McpClientIdentity;
+  // Which protocol era is serving this request. Unset on paths that predate
+  // era routing (and for legacy traffic, which is the safe default).
+  era?: ProtocolEra;
+  // Modern-era only: per-request client metadata lifted from `_meta`.
+  clientMeta?: ModernClientMeta;
 }
 
 // Create the storage instance
@@ -53,6 +84,40 @@ export function setRequestMcpClient(identity: McpClientIdentity): void {
   if (context) {
     context.mcpClient = identity;
   }
+}
+
+/**
+ * Mark the current request as served by the modern (2026-07-28) era and record
+ * the client metadata lifted from its `_meta` envelope. The derived
+ * {@link McpClientIdentity} is set too, so existing attribution consumers
+ * (Bugsnag metadata, downstream User-Agent) work for modern clients without
+ * knowing where the identity came from. No-op outside a request context.
+ */
+export function setModernRequestClient(meta: ModernClientMeta): void {
+  const context = getRequestContext();
+  if (!context) {
+    return;
+  }
+  context.era = "modern";
+  context.clientMeta = meta;
+  context.mcpClient = {
+    name: meta.clientInfo?.name,
+    version: meta.clientInfo?.version,
+    protocolVersion: meta.protocolVersion,
+  };
+}
+
+/** The protocol era serving the current request; `legacy` when unset. */
+export function getRequestEra(): ProtocolEra {
+  return getRequestContext()?.era ?? "legacy";
+}
+
+/**
+ * Modern-era client metadata for the current request, or `undefined` on the
+ * legacy path (where the equivalents live on the server instance).
+ */
+export function getRequestClientMeta(): ModernClientMeta | undefined {
+  return getRequestContext()?.clientMeta;
 }
 
 /**

--- a/src/common/server.test.ts
+++ b/src/common/server.test.ts
@@ -2,6 +2,10 @@ import { ResourceTemplate } from "@modelcontextprotocol/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import z from "zod";
 import Bugsnag from "./bugsnag";
+import {
+  setModernRequestClient,
+  withRequestHeaders,
+} from "./request-context";
 import { SmartBearMcpServer } from "./server";
 import { ToolError } from "./tools";
 
@@ -62,6 +66,91 @@ describe("SmartBearMcpServer", () => {
         name: "Cursor",
         version: "0.9.0",
       });
+    });
+  });
+
+  describe("modern-era client state (per request)", () => {
+    /** Run `fn` as if serving one modern-era request from `clientInfo`. */
+    function inModernRequest<T>(
+      meta: {
+        protocolVersion?: string;
+        clientInfo?: { name: string; version: string };
+        clientCapabilities?: Record<string, unknown>;
+      },
+      fn: () => T,
+    ): T {
+      return withRequestHeaders({}, () => {
+        setModernRequestClient(meta);
+        return fn();
+      });
+    }
+
+    it("prefers the request's _meta clientInfo over the connection's", () => {
+      server.setClientInfo({ name: "Legacy Client", version: "1.0.0" });
+
+      const info = inModernRequest(
+        {
+          protocolVersion: "2026-07-28",
+          clientInfo: { name: "Modern Client", version: "2.0.0" },
+        },
+        () => server.getClientInfo(),
+      );
+
+      expect(info).toEqual({ name: "Modern Client", version: "2.0.0" });
+      // The legacy value is untouched and still serves legacy callers.
+      expect(server.getClientInfo()).toEqual({
+        name: "Legacy Client",
+        version: "1.0.0",
+      });
+    });
+
+    it("attributes the identity used for Bugsnag and User-Agent", () => {
+      const identity = inModernRequest(
+        {
+          protocolVersion: "2026-07-28",
+          clientInfo: { name: "Modern Client", version: "2.0.0" },
+        },
+        () => server.getMcpClientIdentity(),
+      );
+
+      expect(identity).toEqual({
+        name: "Modern Client",
+        version: "2.0.0",
+        protocolVersion: "2026-07-28",
+      });
+    });
+
+    it("reads elicitation support from the request's declared capabilities", () => {
+      // Modern clients do not declare `elicitation` (MRTR replaces it), so the
+      // polyfill path stays in effect until MRTR lands.
+      expect(
+        inModernRequest({ protocolVersion: "2026-07-28" }, () =>
+          server.isElicitationSupported(),
+        ),
+      ).toBe(false);
+
+      expect(
+        inModernRequest(
+          {
+            protocolVersion: "2026-07-28",
+            clientCapabilities: { elicitation: {} },
+          },
+          () => server.isElicitationSupported(),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not let a modern request's state leak into legacy serving", () => {
+      server.setElicitationSupported(true);
+
+      expect(
+        inModernRequest({ protocolVersion: "2026-07-28" }, () =>
+          server.isElicitationSupported(),
+        ),
+      ).toBe(false);
+
+      // Outside the modern request the legacy connection flag still applies.
+      expect(server.isElicitationSupported()).toBe(true);
     });
   });
 

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -6,12 +6,17 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
 import { ZodObject, z } from "zod";
 import Bugsnag, { type BugsnagEvent } from "../common/bugsnag";
 import { CacheService } from "./cache";
-import { type McpClientIdentity, toClientIdentity } from "./client-identity";
+import {
+  getCurrentClientIdentity,
+  type McpClientIdentity,
+  toClientIdentity,
+} from "./client-identity";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./info";
 import {
   executeElicitationOrPolyfill,
   isElicitationPolyfillResult,
 } from "./pollyfills";
+import { getRequestClientMeta, getRequestEra } from "./request-context";
 import { ToolError } from "./tools";
 import type { Client, ClientInfo, ToolParams } from "./types";
 import {
@@ -59,7 +64,20 @@ export class SmartBearMcpServer extends McpServer {
     this.elicitationSupported = supported;
   }
 
+  /**
+   * Whether the current caller supports server-initiated elicitation.
+   *
+   * Modern era: read from the capabilities this request declared in `_meta`.
+   * In practice modern clients do not declare `elicitation` — the 2026-07-28
+   * revision replaces server-initiated elicitation with MRTR — so this
+   * resolves false and callers fall back to the polyfill until MRTR lands.
+   * Legacy era: the per-connection flag captured at `initialize`.
+   */
   isElicitationSupported(): boolean {
+    if (getRequestEra() === "modern") {
+      const capabilities = getRequestClientMeta()?.clientCapabilities;
+      return !!capabilities && Object.hasOwn(capabilities, "elicitation");
+    }
     return this.elicitationSupported;
   }
 
@@ -67,8 +85,13 @@ export class SmartBearMcpServer extends McpServer {
     this.clientInfo = info;
   }
 
+  /**
+   * Client info for the current caller: from this request's `_meta` envelope in
+   * the modern era, falling back to the value captured at `initialize` for
+   * legacy connections.
+   */
   getClientInfo(): ClientInfo | undefined {
-    return this.clientInfo;
+    return getRequestClientMeta()?.clientInfo ?? this.clientInfo;
   }
 
   getClients(): Client[] {
@@ -84,13 +107,24 @@ export class SmartBearMcpServer extends McpServer {
   }
 
   /**
-   * Return the MCP client identity for this session. Prefers the value captured
-   * at `initialize`; falls back to the SDK's `getClientVersion()` so callers
-   * still get an answer if the explicit capture was skipped.
+   * Return the MCP client identity for the current caller.
+   *
+   * Resolution order: the metadata this request carried in `_meta` (modern
+   * era over HTTP, per request), then the value captured at `initialize`
+   * (legacy era, per connection), then the process-wide identity (which is how
+   * modern-era stdio records its single client), then the SDK's
+   * `getClientVersion()` so callers still get an answer if every capture was
+   * skipped.
    */
   getMcpClientIdentity(): McpClientIdentity {
+    const modernMeta = getRequestClientMeta();
+    if (modernMeta) {
+      return toClientIdentity(modernMeta.clientInfo, modernMeta.protocolVersion);
+    }
     return (
-      this.mcpClientIdentity ?? toClientIdentity(this.server.getClientVersion())
+      this.mcpClientIdentity ??
+      getCurrentClientIdentity() ??
+      toClientIdentity(this.server.getClientVersion())
     );
   }
 

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -15,8 +15,13 @@ import {
 } from "@modelcontextprotocol/server";
 import { SSEServerTransport } from "@modelcontextprotocol/server-legacy/sse";
 import { clientRegistry } from "./client-registry";
-import { handleInitializeMessage } from "./initialize";
 import {
+  extractModernClientMeta,
+  handleInitializeMessage,
+} from "./initialize";
+import {
+  type ModernClientMeta,
+  setModernRequestClient,
   setRequestMcpClient,
   withRequestContext,
   withRequestHeaders,
@@ -497,10 +502,43 @@ async function handleMcpEndpoint(
     return;
   }
 
+  // Modern requests carry no session, so the client's identity and
+  // capabilities arrive in each request's `_meta` envelope (SEP-2575). Lift
+  // them into the request context now: this is the modern counterpart of the
+  // legacy `initialize` capture, and it is what makes client attribution
+  // (Bugsnag metadata, downstream User-Agent) work for modern callers.
   const headers = webHeadersToRecord(probe.headers);
+  const clientMeta = extractModernClientMetaFromBody(parsedBody);
   await modernServerStorage.run(server, () =>
-    withRequestHeaders(headers, () => modern(req, res, parsedBody)),
+    withRequestHeaders(headers, () => {
+      if (clientMeta) {
+        setModernRequestClient(clientMeta);
+      }
+      return modern(req, res, parsedBody);
+    }),
   );
+}
+
+/**
+ * Lift modern-era client metadata from a parsed request body.
+ *
+ * JSON-RPC batches were removed by the 2025-06-18 revision, so a modern body
+ * is a single message in practice; arrays are still scanned defensively so a
+ * batched client is attributed rather than silently anonymous.
+ */
+function extractModernClientMetaFromBody(
+  parsedBody: unknown,
+): ModernClientMeta | undefined {
+  if (Array.isArray(parsedBody)) {
+    for (const message of parsedBody) {
+      const meta = extractModernClientMeta(message);
+      if (meta) {
+        return meta;
+      }
+    }
+    return undefined;
+  }
+  return extractModernClientMeta(parsedBody);
 }
 
 /**

--- a/src/common/transport-stdio.test.ts
+++ b/src/common/transport-stdio.test.ts
@@ -1,5 +1,9 @@
 import type { JSONRPCMessage } from "@modelcontextprotocol/server";
 import { describe, expect, it, vi } from "vitest";
+import {
+  getCurrentClientIdentity,
+  setProcessClientIdentity,
+} from "./client-identity";
 import type { SmartBearMcpServer } from "./server";
 import { createInitializeCaptureTap, getEnvVarName } from "./transport-stdio";
 
@@ -88,6 +92,35 @@ describe("createInitializeCaptureTap", () => {
     tap.observe(initialized);
 
     expect(server.setClientInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("records modern-era identity without needing a server instance", () => {
+    setProcessClientIdentity(undefined);
+    const tap = createInitializeCaptureTap();
+
+    // No handshake and no server yet: a modern request still attributes.
+    tap.observe({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientInfo": {
+            name: "Modern Client",
+            version: "2.0.0",
+          },
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    } as unknown as JSONRPCMessage);
+
+    expect(getCurrentClientIdentity()).toEqual({
+      name: "Modern Client",
+      version: "2.0.0",
+      protocolVersion: "2026-07-28",
+    });
+    setProcessClientIdentity(undefined);
   });
 
   it("ignores non-initialize traffic", () => {

--- a/src/common/transport-stdio.ts
+++ b/src/common/transport-stdio.ts
@@ -4,9 +4,16 @@ import {
   StdioServerTransport,
   serveStdio,
 } from "@modelcontextprotocol/server/stdio";
+import {
+  setProcessClientIdentity,
+  toClientIdentity,
+} from "./client-identity";
 import { clientRegistry } from "./client-registry";
 import { USER_AGENT } from "./info";
-import { handleInitializeMessage } from "./initialize";
+import {
+  extractModernClientMeta,
+  handleInitializeMessage,
+} from "./initialize";
 import { SmartBearMcpServer } from "./server";
 import { registerShutdownHandler } from "./shutdown";
 import { getTypeDescription, isOptionalType } from "./zod-utils";
@@ -88,6 +95,18 @@ export function createInitializeCaptureTap(): {
 
   return {
     observe(message: JSONRPCMessage): void {
+      // Modern era: no handshake, so identity arrives on every request in
+      // `_meta` and needs no server instance to record. Stdio serves exactly
+      // one client per process, so the process-wide slot — the same one the
+      // legacy capture writes — is the right home for it, and nothing needs
+      // buffering.
+      const modernMeta = extractModernClientMeta(message);
+      if (modernMeta) {
+        setProcessClientIdentity(
+          toClientIdentity(modernMeta.clientInfo, modernMeta.protocolVersion),
+        );
+        return;
+      }
       if (activeServer) {
         handleInitializeMessage(activeServer, message);
         return;


### PR DESCRIPTION
##Goal 

The 2026-07-28 revision removes the initialize handshake and protocol sessions, so a modern client restates its identity and capabilities in the _meta envelope of every request (SEP-2575). Nothing read that — leaving modern callers anonymous in error reports and downstream User-Agent headers, and leaving the codebase with no way to tell which era it was serving.

##Testing 
Verified both old and new clients still work on stdio and HTTP, and a new-era client's identity now shows up in the User-Agent where previously only old-era clients did.