### PR TITLE
fix(http): stop deriving OAuth discovery URLs from untrusted request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Swagger] Updated and fixed Functional Testing tool descriptions for clarity and LLM usability: added explicit async/polling guidance to `run_test` and `run_suite`, enumerated status values with descriptions for `get_test_status` and `get_suite_status`, added `limit`/`offset` pagination hints and total run count to `get_test_history`, standardized status terminology to `canceled` across all tool descriptions, and restructured the public doc into `Tests` and `Suites` sections with bold field labels and cross-tool references.
 
+- [Common] Security: `WWW-Authenticate` OAuth discovery URLs are no longer derived from the client-supplied `Host` header over a hardcoded `http://`. The header is now built via `getBaseUrl()`, honouring the `BASE_URL` env var and deriving the scheme from `X-Forwarded-Proto`. `X-Forwarded-Host` is now only trusted when the new `TRUST_PROXY` env var is enabled, since it can be forged by clients on deployments without a proxy stripping it. Both variables are documented in the README.
+
 ## [0.40.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,6 +315,13 @@ Add the following configuration to your `claude_desktop_config.json` to launch t
 }
 ```
 
+## Server Configuration (HTTP mode)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BASE_URL` | *(derived from request)* | The server's own public URL, e.g. `https://mcp.example.com`. Set this on any deployment behind a proxy or load balancer — otherwise the address advertised for OAuth discovery is derived from the client-supplied `Host` header. |
+| `TRUST_PROXY` | `false` | Set to `true` only when a proxy in front of the server sets `X-Forwarded-Host` and strips any client-supplied value. |
+
 ## Documentation
 
 For detailed introduction, examples, and advanced configuration visit our 📖 [Full Documentation](https://developer.smartbear.com/smartbear-mcp)

--- a/src/common/transport-http.test.ts
+++ b/src/common/transport-http.test.ts
@@ -10,6 +10,7 @@ import {
   handleReadyRequest,
   handleStreamableHttpRequest,
   newServer,
+  newServerFromWebRequest,
 } from "./transport-http";
 import type { Client } from "./types";
 
@@ -123,6 +124,7 @@ describe("transport-http helpers", () => {
   describe("getBaseUrl", () => {
     afterEach(() => {
       delete process.env.BASE_URL;
+      delete process.env.TRUST_PROXY;
     });
 
     it("should return BASE_URL env var when set", () => {
@@ -131,13 +133,39 @@ describe("transport-http helpers", () => {
       expect(getBaseUrl(req)).toBe("https://override.example.com");
     });
 
-    it("should use x-forwarded-proto and x-forwarded-host when present", () => {
+    it("should use x-forwarded-proto and x-forwarded-host when TRUST_PROXY is enabled", () => {
+      process.env.TRUST_PROXY = "true";
       const req = fakeRequest({
         "x-forwarded-proto": "https",
         "x-forwarded-host": "proxy.example.com",
         host: "localhost:3000",
       });
       expect(getBaseUrl(req)).toBe("https://proxy.example.com");
+    });
+
+    it("should ignore x-forwarded-host when TRUST_PROXY is not enabled", () => {
+      const req = fakeRequest({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.example.com",
+        host: "realhost.example.com",
+      });
+      expect(getBaseUrl(req)).toBe("https://realhost.example.com");
+    });
+
+    it("should normalise an unrecognised x-forwarded-proto to http", () => {
+      const req = fakeRequest({
+        "x-forwarded-proto": "gopher",
+        host: "myhost:8080",
+      });
+      expect(getBaseUrl(req)).toBe("http://myhost:8080");
+    });
+
+    it("should use the client-facing entry of an x-forwarded-proto chain", () => {
+      const req = fakeRequest({
+        "x-forwarded-proto": "https, http",
+        host: "myhost:8080",
+      });
+      expect(getBaseUrl(req)).toBe("https://myhost:8080");
     });
 
     it("should default protocol to http when x-forwarded-proto is absent", () => {
@@ -217,6 +245,8 @@ describe("newServer (OAuth flow)", () => {
   afterEach(() => {
     // Restore clientRegistry.getAll
     clientRegistry.getAll = originalGetAll;
+    delete process.env.BASE_URL;
+    delete process.env.TRUST_PROXY;
   });
 
   it("should return 401 with WWW-Authenticate header when no clients are configured", async () => {
@@ -232,6 +262,91 @@ describe("newServer (OAuth flow)", () => {
     expect(res._status).toBe(401);
     expect(res._headers["WWW-Authenticate"]).toBe(
       'OAuth resource_metadata="http://myserver.example.com:3000/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("should build WWW-Authenticate from BASE_URL, ignoring a forged Host", async () => {
+    clientRegistry.getAll = () => [];
+    process.env.BASE_URL = "https://real.example.com";
+
+    const req = fakeRequest({ host: "evil.attacker.com" });
+    const res = fakeResponse();
+
+    await newServer(req, res);
+
+    expect(res._headers["WWW-Authenticate"]).toBe(
+      'OAuth resource_metadata="https://real.example.com/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("should not reflect x-forwarded-host into WWW-Authenticate by default", async () => {
+    clientRegistry.getAll = () => [];
+
+    const req = fakeRequest({
+      "x-forwarded-host": "evil.attacker.com",
+      host: "myserver.example.com:3000",
+    });
+    const res = fakeResponse();
+
+    await newServer(req, res);
+
+    expect(res._headers["WWW-Authenticate"]).toBe(
+      'OAuth resource_metadata="http://myserver.example.com:3000/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("should use https in WWW-Authenticate when terminating TLS at a proxy", async () => {
+    clientRegistry.getAll = () => [];
+
+    const req = fakeRequest({
+      "x-forwarded-proto": "https",
+      host: "myserver.example.com",
+    });
+    const res = fakeResponse();
+
+    await newServer(req, res);
+
+    expect(res._headers["WWW-Authenticate"]).toBe(
+      'OAuth resource_metadata="https://myserver.example.com/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("should build WWW-Authenticate from BASE_URL on the modern (web Request) leg too", async () => {
+    clientRegistry.getAll = () => [];
+    process.env.BASE_URL = "https://real.example.com";
+
+    const request = new Request("http://evil.attacker.com/mcp", {
+      method: "POST",
+      headers: { host: "evil.attacker.com" },
+    });
+    const res = fakeResponse();
+
+    await newServerFromWebRequest(request, res);
+
+    expect(res._status).toBe(401);
+    expect(res._headers["WWW-Authenticate"]).toBe(
+      'OAuth resource_metadata="https://real.example.com/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("should derive the scheme from x-forwarded-proto on the modern (web Request) leg", async () => {
+    clientRegistry.getAll = () => [];
+
+    const request = new Request("http://myserver.example.com/mcp", {
+      method: "POST",
+      headers: {
+        host: "myserver.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "evil.attacker.com",
+      },
+    });
+    const res = fakeResponse();
+
+    await newServerFromWebRequest(request, res);
+
+    expect(res._status).toBe(401);
+    expect(res._headers["WWW-Authenticate"]).toBe(
+      'OAuth resource_metadata="https://myserver.example.com/.well-known/oauth-protected-resource"',
     );
   });
 

--- a/src/common/transport-http.ts
+++ b/src/common/transport-http.ts
@@ -78,18 +78,52 @@ export function handleReadyRequest(
 }
 
 /**
- * Helper to construct the base URL from the request, respecting proxy headers.
- * This is critical for cloud deployments where SSL termination happens at the load balancer.
- * If BASE_URL env var is set, it takes precedence over request headers.
+ * Lower-cased request headers, as exposed by both Node's `IncomingMessage`
+ * and the web `Headers` API. Lets the base-URL helpers serve both HTTP eras.
  */
-export function getBaseUrl(req: IncomingMessage): string {
+type HeaderRecord = Record<string, string | string[] | undefined>;
+
+/**
+ * Resolve the request scheme, normalised to http or https.
+ * Proxy chains send a comma-separated list, where the first entry faces the client.
+ */
+function getForwardedProtocol(headers: HeaderRecord): string {
+  const forwarded = (headers["x-forwarded-proto"] as string) || "";
+  const protocol = forwarded.split(",")[0]?.trim().toLowerCase();
+  return protocol === "https" ? "https" : "http";
+}
+
+/**
+ * Construct the server's public base URL from request headers, respecting
+ * proxy headers. This is critical for cloud deployments where SSL termination
+ * happens at the load balancer.
+ *
+ * Resolution order:
+ * 1. BASE_URL env var - always preferred, and the only source not derived from
+ *    client input. Set this on any deployment that terminates TLS elsewhere.
+ * 2. x-forwarded-host - only when TRUST_PROXY is enabled. Without a proxy in front
+ *    to overwrite it, any client can forge this header.
+ * 3. Host header.
+ */
+export function getBaseUrlFromHeaders(headers: HeaderRecord): string {
   const baseUrlOverride = process.env.BASE_URL;
   if (baseUrlOverride) {
     return baseUrlOverride;
   }
-  const protocol = (req.headers["x-forwarded-proto"] as string) || "http";
-  const host = (req.headers["x-forwarded-host"] as string) || req.headers.host;
+  const protocol = getForwardedProtocol(headers);
+  const hostHeader = headers.host as string | undefined;
+  const host =
+    process.env.TRUST_PROXY === "true"
+      ? (headers["x-forwarded-host"] as string) || hostHeader
+      : hostHeader;
   return `${protocol}://${host}`;
+}
+
+/**
+ * {@link getBaseUrlFromHeaders} for a Node `IncomingMessage`.
+ */
+export function getBaseUrl(req: IncomingMessage): string {
+  return getBaseUrlFromHeaders(req.headers);
 }
 
 /**
@@ -918,10 +952,13 @@ async function buildConfiguredServer(
     };
 
     // Add WWW-Authenticate header to support OAuth discovery flow
-    // This points the client to the Protected Resource Metadata endpoint
-    if (host) {
+    // This points the client to the Protected Resource Metadata endpoint.
+    // Built via getBaseUrlFromHeaders so it honours BASE_URL and matches the
+    // deployment's scheme, rather than echoing the Host header over a hardcoded
+    // http://. Shared by both HTTP eras, so the modern leg is covered too.
+    if (process.env.BASE_URL || host) {
       responseHeaders["WWW-Authenticate"] =
-        `OAuth resource_metadata="http://${host}/.well-known/oauth-protected-resource"`;
+        `OAuth resource_metadata="${getBaseUrlFromHeaders(headers)}/.well-known/oauth-protected-resource"`;
     }
 
     res.writeHead(401, responseHeaders);


### PR DESCRIPTION
## Goal

Stop deriving OAuth discovery URLs from untrusted request headers. The 401 `WWW-Authenticate` header echoed the client-supplied `Host` over a hardcoded `http://`. It is now built via `getBaseUrl()` — honouring `BASE_URL` and deriving the scheme from `X-Forwarded-Proto` — and `X-Forwarded-Host` is only trusted when the new `TRUST_PROXY` env var is enabled.

## Testing

- 7 new unit tests: forged `Host` ignored when `BASE_URL` is set, `X-Forwarded-Host` ignored by default, scheme derivation/normalisation, proxy chains
- Verified 5 of them fail against the pre-fix code
